### PR TITLE
Add LINENotify.xml

### DIFF
--- a/LINENotify.xml
+++ b/LINENotify.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service-task-definition>
+	<label>LINE Notify</label>
+	<label locale="ja">LINE Notifyに投稿</label>
+	<summary>Post message to your LINE Group by using LINE Notify.In advance you have to configure OAuth2.</summary>
+	<summary locale="ja">LINE Notifyを通してLINEグループにメッセージを投稿します。事前にOAuth2の設定を行ってください。</summary>
+	<configs>
+	<config name="Message" form-type="SELECT" select-data-type="STRING" required="true">
+		<label>I1.Text Message</label>
+		<label locale="ja">I1.テキスト</label>
+	</config>
+	</configs>
+	<script><![CDATA[
+var token = httpClient.getOAuth2Token('LINE');
+var message = engine.findDataByNumber(configs.get("Message"));
+
+var response = httpClient.begin()
+  .bearer(token)
+  .multipart("message", message)
+  .post('https://notify-api.line.me/api/notify');
+
+]]>
+</script>
+</service-task-definition>


### PR DESCRIPTION
#8 
OAuthの設定が出来ていれば投稿できるはずです。
>Client ID / Secret は、オープン（誰にでも見える）にして良いものではない

LINE Notifyの仕様的に、Client ID / Secret はHelpあたりに書かざるを得ないわけですが、それは大丈夫なのでしょうか(サービスごとにClient ID / Secretが存在する仕様です。本来はアプリ内で(ユーザーに見えない形で)token取得を行うことが想定されているようなので)。