### PR TITLE
Google Calendarアドオンの修正2つ

### DIFF
--- a/google-calendar-insert-event.xml
+++ b/google-calendar-insert-event.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2018-12-05</last-modified>
+<last-modified>2018-12-07</last-modified>
+<license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <label>Google Calendar: Insert Event</label>
 <label locale="ja">Google Calendar: 予定追加</label>
@@ -51,9 +52,6 @@
 
 
 <script><![CDATA[
-// Insert Event to Google Calendar via Calendar API v3 (ver. 20161025)
-// (c) 2016, Questetra, Inc. (the MIT License)
-
 //// == 工程コンフィグの参照 / Config Retrieving ==
 var userId = configs.get( "conf_User" );
 var quser = quserDao.findById(parseInt(userId));

--- a/google-calendar-insert-event.xml
+++ b/google-calendar-insert-event.xml
@@ -3,16 +3,16 @@
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <label>Google Calendar: Insert Event</label>
-<label locale="ja">Google Calendar: 予定追加</label>
+<label locale="ja">Google カレンダー: 予定追加</label>
 <summary>Insert an event to Google Calendar.</summary>
-<summary locale="ja">Google Calendarに予定を追加します。</summary>
+<summary locale="ja">Google カレンダーに予定を追加します。</summary>
 <help-page-url>https://support.questetra.com/addons/services/googlecalendar-insertevent/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/services/googlecalendar-insertevent/</help-page-url>
 
 <configs>
   <config name="conf_User" required="true" form-type="QUSER">
     <label>C1:User Who Connects with Google Calendar</label>
-    <label locale="ja">C1:Google Calendar に接続するユーザ</label>
+    <label locale="ja">C1:Google カレンダー に接続するユーザ</label>
   </config>
   <config name="conf_DataIdB" form-type="TEXTFIELD">
     <label>C2:Calendar ID(When empty,inserted to the primary calendar)</label>


### PR DESCRIPTION
#62 
License表記を変更
Google Calendar → Google カレンダー に