### PR TITLE
Google Sheets 関連アドオン

### DIFF
--- a/GoogleSheets-appendCells.xml
+++ b/GoogleSheets-appendCells.xml
@@ -174,7 +174,7 @@ function cellDataObject( data ){
     return dataObj;
   }else{ // for "STRING" 
     if(data.length > 50000){
-      throw "Can't set text over 50,000 character."
+      throw "Can't set text over 50,000 character.";
     }
     dataObj.userEnteredValue.stringValue = data + "";
     return dataObj;

--- a/GoogleSheets-appendCells.xml
+++ b/GoogleSheets-appendCells.xml
@@ -2,7 +2,7 @@
 
 <label>Google Sheets Append Cells</label>
 <label locale="ja">Google Sheets 行追加</label>
-<last-modified>2019-03-11</last-modified>
+<last-modified>2019-04-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <summary>Adds new cells after the last row with data in a sheet, inserting new rows into the sheet if necessary.</summary>
@@ -173,6 +173,9 @@ function cellDataObject( data ){
     dataObj.userEnteredValue.stringValue = "";
     return dataObj;
   }else{ // for "STRING" 
+    if(data.length > 50000){
+      throw "Can't set text over 50,000 character."
+    }
     dataObj.userEnteredValue.stringValue = data + "";
     return dataObj;
   }

--- a/GoogleSheets-appendCells.xml
+++ b/GoogleSheets-appendCells.xml
@@ -170,7 +170,8 @@ function cellDataObject( data ){
   let dataObj = {};
   dataObj.userEnteredValue = {};
   if( data === "" ){
-    return null;
+    dataObj.userEnteredValue.stringValue = "";
+    return dataObj;
   }else{ // for "STRING" 
     dataObj.userEnteredValue.stringValue = data + "";
     return dataObj;

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-
 <label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
 <last-modified>2019-03-20</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
-<summary></summary>
-<summary locale="ja"></summary>
+<summary>Download Choice Data in specified 2 columns from Google Sheet</summary>
+<summary locale="ja">Google Sheet から指定した2列に入っている選択肢データを取得します。</summary>
 <help-page-url>https://support.questetra.com/addons/googlesheets-getidslabels/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googlesheets-getidslabels/</help-page-url>
 

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -10,7 +10,7 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googlesheets-getidslabels/</help-page-url>
 
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets.readonly">
     <label>C1: Set OAuth2 Config Name</label>
     <label locale="ja">C1: OAuth2通信許可設定名</label>
   </config>
@@ -103,14 +103,21 @@ function main(){
   if(jsonObj.valueRanges[0].values[0].length != jsonObj.valueRanges[1].values[0].length){
     throw "Number of cells in two ranges is different.";
   }
-  //error for an empty cells
+  if(jsonObj.valueRanges[0].values[0].length > 150000){
+    throw"Number of Choice Data is over 150,000."
+  }
+  //error for an empty cells,over 1000 characters and add to list
   for( let i = 0; i < jsonObj.valueRanges[0].values[0].length; i++ ){
     if ( jsonObj.valueRanges[0].values[0][i] == ""){
       throw "Empty Cell is in Choice-IDs range.";
+    }else if ( jsonObj.valueRanges[0].values[0][i].length > 1000){
+      throw "Over 1000-character Choice-ID is in range.";
     }
     choiseIds += jsonObj.valueRanges[0].values[0][i] + "\n";
     if ( jsonObj.valueRanges[1].values[0][i] == ""){
       throw "Empty Cell is in Labels range.";
+    }else if ( jsonObj.valueRanges[1].values[0][i].length > 1000){
+      throw "Over 1000-character Label is in range.";
     }
     choiseLabels += jsonObj.valueRanges[1].values[0][i] + "\n";
   }

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
-<last-modified>2019-04-02</last-modified>
+<last-modified>2019-04-12</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <summary>Download Choice Data in specified 2 columns from Google Sheet.</summary>

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
-<last-modified>2019-04-12</last-modified>
+<last-modified>2019-04-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <summary>Download Choice Data in specified 2 columns from Google Sheet.</summary>
@@ -11,8 +11,8 @@
 
 <configs>
   <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets.readonly">
-    <label>C1: Set OAuth2 Config Name</label>
-    <label locale="ja">C1: OAuth2通信許可設定名</label>
+    <label>C1: Set OAuth2 Setting Name</label>
+    <label locale="ja">C1: OAuth2 設定名</label>
   </config>
   <config name="conf_DataIdB" required="true" form-type="TEXTFIELD">
     <label>C2: Spreadsheet ID</label>

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
-<last-modified>2019-03-25</last-modified>
+<last-modified>2019-04-02</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <summary>Download Choice Data in specified 2 columns from Google Sheet.</summary>

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
-<last-modified>2019-03-20</last-modified>
+<last-modified>2019-03-25</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
-<summary>Download Choice Data in specified 2 columns from Google Sheet</summary>
+<summary>Download Choice Data in specified 2 columns from Google Sheet.</summary>
 <summary locale="ja">Google Sheet から指定した2列に入っている選択肢データを取得します。</summary>
 <help-page-url>https://support.questetra.com/addons/googlesheets-getidslabels/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googlesheets-getidslabels/</help-page-url>

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 
-<label>Batch to Get SELECT Data from Google Sheet</label>
+<label>Download Choice Data from Google Sheet</label>
 <label locale="ja">Google Sheets 選択肢データの一括取得</label>
-<last-modified>2019-03-18</last-modified>
+<last-modified>2019-03-20</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
+<summary></summary>
+<summary locale="ja"></summary>
 <help-page-url>https://support.questetra.com/addons/googlesheets-getidslabels/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googlesheets-getidslabels/</help-page-url>
 


### PR DESCRIPTION
Google Sheets 選択肢データの一括取得
再テスト後、C1のラベルを修正したところまで。

Google Sheets 行追加
途中です。
C4以降が空だった時の挙動をとりあえず「空文字を送る」に戻してあります。