### PR TITLE
Google drive

### DIFF
--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -63,7 +63,7 @@ function main(){
   let folderUrlList = "";
   const fileNum = json.files.length;
   if (fileNum == 0){
-    throw"Such folder doesn't exist.";
+    throw "Folder " + folderName + " doesn't exist.";
   }
   for(let i = 0; i < fileNum; i++){
     if (i > 0){

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-06-28</last-modified>
+<last-modified>2019-07-01</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <label>Google Drive: Search Folder</label>
@@ -54,11 +54,7 @@ function main(){
 
   // get OAuth token
   let token;
-  try{
-    token = httpClient.getOAuth2Token( oauth );
-  }catch(e){
-    throw "not have a token";
-  }
+  token = httpClient.getOAuth2Token( oauth );
   const folderNameRep = folderName.replace(/['\\]/g,"\\$&");
   const q = "mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '" + folderNameRep + "' and '" + parentFolderId + "' in parents";
   const json = searchFolder(token,q);


### PR DESCRIPTION
>エラーをするとき、"Such folder" ではなく、"Folder ○○" と ○○にフォルダ名を入れるようにしてください。

に対応。同時にトークン周りを変更。