### PR TITLE
Updated　Converter-TableToExcelCsv.xml

### DIFF
--- a/Converter-TableToExcelCsv.xml
+++ b/Converter-TableToExcelCsv.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
 <label>Converter (Table to Excel-CSV FILE)</label>
-<label locale="ja">コンバータ (テーブル型データをエクセル対応のCSVファイルに)</label>  <!--t6846対応　日本語に-->
+<label locale="ja">コンバータ (tableデータ to Excel-CSVファイル)</label>
 <last-modified>2019-09-17</last-modified>
 <help-page-url>https://support.questetra.com/addons/converter-tabletoexcelcsv/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/converter-tabletoexcelcsv/</help-page-url>
 <configs>
-<config name="Table_DataId" select-data-type="LIST" form-type="SELECT" required="true"><!--T6846対応-->
+<config name="Table_DataId" select-data-type="LIST" form-type="SELECT" required="true">
 <label>A: Select TABLE DATA</label>
 <label locale="ja">A: テーブル型データを選択してください</label>
 </config>
-<!--<config name="conf_ColIds" form-type="TEXTFIELD" required="true">//T6846対応　削除
-<label>B: Set COL IDs for Extraction (e.g. "0,1,5,3,6")</label>
-<label locale="ja">B: 抽出データのカラム ID をセットしてください (例 "0,1,5,3,6")</label>
-</config>
--->
-<config name="File_NameId" form-type="TEXTFIELD" required="true" el-enabled="true"><!--//T6846対応　テキストフィールドEL式可に--> 
+<config name="File_Name" form-type="TEXTFIELD" required="true" el-enabled="true">
 <label>B: Set File Name</label>
 <label locale="ja">B: ファイル名を入力してください</label>
 </config>
-<config name="File_DataId" select-data-type="FILE" form-type="SELECT" required="true"><!--T6846対応-->
+<config name="File_DataId" select-data-type="FILE" form-type="SELECT" required="true">
 <label>C: Select FILE DATA (append)</label>
 <label locale="ja">C: ファイル型データを選択してください（追加）</label>
 </config>
@@ -32,29 +27,27 @@
 // (c) 2018, Questetra, Inc. (the MIT License)
 
 //// == Config Retrieving / 工程コンフィグの参照 ==
-const tableId = configs.get( "Table_DataId" ) + "";//T6846
-//const colIds  = configs.get( "conf_ColIds" )  + "";T6846削除
-const fnameId = configs.get( "File_NameId" ) + "";//T6846
-const fileId = configs.get( "File_DataId" ) + "";//T6846
+const tableId = configs.get( "Table_DataId" ) + "";
+const filename = configs.get( "File_Name" ) + "";
+const fileId = configs.get( "File_DataId" ) + "";
 
-if(fnameId === "" ||fnameId === null) {
+if(filename === "" ||filename === null) {
     throw new Error( "File Name is blank" );
-  }//T6846
+  }
 
 //// == Data Retrieving / ワークフローデータの参照 ==
-const myTable = engine.findDataByNumber( tableId );//T6846
+const myTable = engine.findDataByNumber( tableId );
 // com.questetra.bpms.core.model.formdata.ListArray
-//const fileName = engine.findDataByNumber( fnameId ) + "";//T6846
-let   myFiles  = engine.findDataByNumber( fileId );// java.util.ArrayList T6846
+let   myFiles  = engine.findDataByNumber( fileId );// java.util.ArrayList
 if( myFiles === null ){ myFiles = new java.util.ArrayList(); }
 
 if( myTable === null){
-  //throw new Error( "Source Table data is NULL" ); t6846 空のテーブルでも空のファイルを保存するよう変更
 
 let myTsv = "";
+
 myFiles.add(
   new com.questetra.bpms.core.event.scripttask.NewQfile(
-    fnameId,
+    filename,
     "text/tab-separated-values; charset=x-UTF-16LE-BOM",
     myTsv
   )
@@ -65,16 +58,14 @@ myFiles.add(
 else{
 
 //// == Calculating / 演算 ==
-//let colIdArray = colIds.split(","); t6846対応 全カラム対象に　削除
-//let numOfCols = colIdArray.length; t6846対応　全カラム対象に　削除
 let numOfRows = myTable.size() - 0; // 行（Tableの高さ）
-let numOfCols = myTable.getRow(0).size(); // 列（Tableの幅）t6846対応
+let numOfCols = myTable.getRow(0).size(); // 列（Tableの幅）
 
 let myTsv = "";
 
 for( let i = 0; i < numOfRows; i++ ){
   for( let j = 0; j < numOfCols; j++ ){
-    myTsv += myTable.get(i, j ) + ""; //t6846対応
+    myTsv += myTable.get(i, j ) + "";
     if( j != numOfCols - 1 ){
       myTsv += "\t";
     }
@@ -86,7 +77,7 @@ for( let i = 0; i < numOfRows; i++ ){
 
 myFiles.add(
   new com.questetra.bpms.core.event.scripttask.NewQfile(
-    fnameId,
+    filename,
     "text/tab-separated-values; charset=x-UTF-16LE-BOM",
     myTsv
   )


### PR DESCRIPTION
「B: 抽出データのカラム ID をセットしてください (例 "0,1,5,3,6")」を無くし、全カラム対象に。
「C: ファイル名が格納されている文字列型データを選択してください」を「テキストフィールド EL 式可」に
　日本語ラベルの変更　コンバータ (tableデータ to Excel-CSVファイル)

ソースコードのconfig 名や変数名が順番に依存した名前を意味のある名前に変更

テーブルが空の時は空のファイルを保存するように変更