### PR TITLE
フォルダ名重複時エラーにならないように

### DIFF
--- a/box-folder-create.xml
+++ b/box-folder-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-10-11</last-modified>
+<last-modified>2019-10-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <label>Box: Create Folder</label>
@@ -76,18 +76,22 @@ function createFolder(token, parentFolderId, name) {
     .post(url);
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
-  let jsonRes = JSON.parse(responseTxt);;
-  if (status === 409){
-    if(jsonRes["context_info"]["conflicts"][0]["type"] == "folder"){
-      jsonRes = jsonRes["context_info"]["conflicts"][0];
-    }else{
-      const error = "Failed to create \n status:" + status + "\n" + responseTxt
+  let jsonRes = JSON.parse(responseTxt);
+  try{
+    if (status === 409){
+      if(jsonRes["context_info"]["conflicts"][0]["type"] === "folder"){
+        jsonRes = jsonRes["context_info"]["conflicts"][0];
+      }else{
+        throw "";
+      }
+    }else if (status >= 300) {
+      throw "";
+    }
+  }catch(e){
+      const error = "Failed to create \n status:" + status + "\n" + responseTxt;
       throw error;
     }
-  }else if (status >= 300) {
-    const error = "Failed to create \n status:" + status + "\n" + responseTxt
-    throw error;
-  }
+  
   engine.log("status:" + status);
   engine.log(responseTxt);
   

--- a/box-folder-create.xml
+++ b/box-folder-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-07-19</last-modified>
+<last-modified>2019-10-11</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>1</engine-type>
 <label>Box: Create Folder</label>
@@ -60,30 +60,37 @@ function main(){
 }
   //create folder on google drive
 function createFolder(token, parentFolderId, name) {
-  let jsonRes = {};
+  let jsonReq = {};
   //mime type of google drive folder
   if (parentFolderId !== "" && parentFolderId !== null){
-    jsonRes["parent"] = {"id": parentFolderId + '' };
+    jsonReq["parent"] = {"id": parentFolderId + '' };
   }else{
-    jsonRes["parent"]= {"id": 0 + '' }
+    jsonReq["parent"]= {"id": 0 + '' }
   }
-  jsonRes["name"] = name + '';
+  jsonReq["name"] = name + '';
   
   const url = 'https://api.box.com/2.0/folders';
   const response = httpClient.begin()
     .bearer(token)
-    .body(JSON.stringify(jsonRes), "application/json; charset=UTF-8")
+    .body(JSON.stringify(jsonReq), "application/json; charset=UTF-8")
     .post(url);
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
-  if (status >= 300) {
+  let jsonRes = JSON.parse(responseTxt);;
+  if (status === 409){
+    if(jsonRes["context_info"]["conflicts"][0]["type"] == "folder"){
+      jsonRes = jsonRes["context_info"]["conflicts"][0];
+    }else{
+      const error = "Failed to create \n status:" + status + "\n" + responseTxt
+      throw error;
+    }
+  }else if (status >= 300) {
     const error = "Failed to create \n status:" + status + "\n" + responseTxt
     throw error;
   }
   engine.log("status:" + status);
   engine.log(responseTxt);
   
-  jsonRes = JSON.parse(responseTxt);
   return jsonRes;
 }
 


### PR DESCRIPTION
・重複していないとき、作成される
・フォルダと重複しているとき、元あったフォルダのIDが返される
・ファイルと重複しているとき、スクリプトエラーになる
・重複以外のエラーが出たとき、スクリプトエラーになる

以上テスト済み。