### PR TITLE
Google スプレッドシート: 行追加 (テーブル型データ項目) 

### DIFF
--- a/google-sheets-row-append-by-table.xml
+++ b/google-sheets-row-append-by-table.xml
@@ -5,7 +5,7 @@
 <label locale="ja">Google スプレッドシート: 行追加 (テーブル型データ)</label>
 <summary>Appends values of table data item after the last row in a sheet. Inserts new rows if necessary.</summary>
 <summary locale="ja">シート末尾にテーブル型データの値を入力します。必要あれば行領域を拡大します。</summary>
-<last-modified>2020-04-03</last-modified>
+<last-modified>2020-04-14</last-modified>
 <help-page-url>https://support.questetra.com/addons/googlesheets-appendtable/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googlesheets-appendtable/</help-page-url>
 
@@ -215,6 +215,8 @@ function makingDataLoop(tableData,tableDataList,dataidArray,obj){
       if(flag && cellValueEmptyCheck(cellValue)) {
         //put null if all latter cells are empty
         obj.requests[0].appendCells.rows[i].values[j] = null;
+      }else if(cellValueEmptyCheck(cellValue)){
+        obj.requests[0].appendCells.rows[i].values[j] = {"userEnteredValue": {"stringValue": "" }};
       }else{
         obj.requests[0].appendCells.rows[i].values[j] = cellValue;
         flag = false;


### PR DESCRIPTION
数値型で空白だとエラーが出るのを修正
空白の場合は設定に関係なく文字型の空文字を追加するように(nullを入れない場合は)した。
テスト : https://docs.google.com/spreadsheets/d/122G8ylw8ql-Io9B3_ZEjalReAddPHNScm6CVaNXMmiE/edit#gid=0
