### PR TITLE
Update box-file-copy.xml

### DIFF
--- a/box-file-copy.xml
+++ b/box-file-copy.xml
@@ -4,7 +4,7 @@
 <label>Box: Copy File</label>
 <label locale="ja">Box: ファイルコピー</label>
 
-<last-modified>2020-05-21</last-modified>
+<last-modified>2020-05-25</last-modified>
 
 <summary>Copy the File and save it in the specified Folder</summary>
 <summary locale="ja">既存ファイルを複製し、指定フォルダに新規保存します</summary>
@@ -94,14 +94,28 @@ function decideFileId(){
 
 
 /**
-  * 新しいファイルのファイル名をチェックする。（サポートされていない文字が含まれていないか）
+  * 新しいファイルのファイル名をチェックする。（サポートされていない文字が使われていないか）
   */
 function checkNewFileName(newFileName){
-  const reg = new RegExp('[/\]');
-  if(newFileName.length>255){
+
+//ファイル名が255文字を超えていないか
+ if(newFileName.length > 255){
     throw"File Name shoule be less than 256 characters";
-  }else if(newFileName.search(reg) !== -1|| newFileName.slice(0,1) === " " 
-||newFileName.slice(-1) === " " || newFileName === "." || newFileName === ".."){
+  }
+
+//ファイル名に「/」や「\」が含まれていないか
+ const reg = new RegExp('[/\]');
+ if(newFileName.search(reg) !== -1) {
+    throw "Invalid File Name";
+  }
+
+//ファイル名の先頭と末尾に半角スペースが使われていないか
+ if(newFileName.slice(0,1) === " " || newFileName.slice(-1) === " ") {
+    throw "Invalid File Name";
+  }
+
+//ファイル名が「.」や「..」ではないか
+ if(newFileName === "." || newFileName === ".."){
     throw "Invalid File Name";
   }
 }
@@ -167,10 +181,18 @@ function copyFile(token, folderId, fileId, newFileName) {
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
   let jsonRes = JSON.parse(responseTxt);
-  try{
+
+
+  engine.log(`status: ${status}\n`);
+  engine.log(responseTxt);
+
+
+if (status !== 201) {
+try{
     if (status === 409){
-      if(jsonRes["context_info"]["conflicts"][0]["type"] === "file"){
-        jsonRes = jsonRes["context_info"]["conflicts"][0];
+      if(jsonRes["context_info"]["conflicts"]["type"] === "file"
+        ||jsonRes["context_info"]["conflicts"]["type"] === "folder"){
+         throw `Failed to copy \n`;
       }else{
         throw "Handle exceptions";
       }
@@ -178,12 +200,11 @@ function copyFile(token, folderId, fileId, newFileName) {
       throw "Handle exceptions";
     }
   }catch(e){
-    const error = `Failed to copy \n status: ${status}\n${responseTxt}`;
+    const error = `Failed to copy \n`;
       throw error;
     }
-  
-  engine.log(`status: ${status}`);
-  engine.log(responseTxt);
+}
+
 
   return jsonRes.id;
 }


### PR DESCRIPTION
抜けていた処理を追加しました。
文章にすると、以下です。
コピーが成功しなかった場合（ステータスコードが２０１でない時）
　競合エラー（４０９の時）
　　競合先IDがファイルもしくはフォルダであれば（Failed to copy）
　　それ以外は例外処理
　
　ステータスコードが３００以上の時のエラーも例外処理
  ※存在しないフォルダID、ファイルID、権限のないフォルダ、ファイルIDのエラーの時も（Failed to copy）