### PR TITLE
Update box-file-copy.xml

### DIFF
--- a/box-file-copy.xml
+++ b/box-file-copy.xml
@@ -4,7 +4,7 @@
 <label>Box: Copy File</label>
 <label locale="ja">Box: ファイルコピー</label>
 
-<last-modified>2020-06-29</last-modified>
+<last-modified>2020-07-02</last-modified>
 
 <summary>Copy the File and save it in the specified Folder</summary>
 <summary locale="ja">既存ファイルを複製し、指定フォルダに新規保存します</summary>
@@ -105,7 +105,7 @@ function checkNewFileName(newFileName){
   }
 
 //ファイル名に「/」や「\」が含まれていないか
- const reg = new RegExp('[/\]');
+ const reg = new RegExp('[/\\\\]');
  if(newFileName.search(reg) !== -1) {
     throw "Invalid File Name";
   }


### PR DESCRIPTION
サポートされないファイル名のチェックで、「\」バックスラッシュのチェックができるよう修正しました。
よろしくお願いします。