### PR TITLE
Microsoft 365 OneDrive for Business: ファイルコピー　フォルダコピー対応　summaryとコメントを修正

### DIFF
--- a/onedrive-file-copy.xml
+++ b/onedrive-file-copy.xml
@@ -4,7 +4,7 @@
 <label>Microsoft 365 OneDrive for Business: Copy File / Folder</label>
 <label locale="ja">Microsoft 365 OneDrive for Business: ファイル / フォルダコピー</label>
 <last-modified>2020-07-27</last-modified>
-<summary>Creates a copy of a file into the specified folder on OneDrive.</summary>
+<summary>Creates a copy of a file/folder into the specified folder on OneDrive.</summary>
 <summary locale="ja">OneDrive 上のファイル / フォルダを複製し、指定フォルダに新規保存します。</summary>
 <help-page-url>https://support.questetra.com/addons/onedrive-file-copy/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/onedrive-file-copy/</help-page-url>
@@ -197,7 +197,7 @@
     * copyリクエストをPOSTし、レスポンスを返す
     * @param {String} sourceInfo  コピー元アイテム情報 {driveId, id}
     * @param {String} destInfo  コピー先フォルダ情報 {driveId, id}
-    * @param {String} newName  新しいファイルの名前
+    * @param {String} newName  新しいファイル / フォルダの名前
     * @param {String} token  OAuth2 トークン
     * @return {HttpResponseWrapper} response  レスポンス
     */
@@ -227,7 +227,7 @@
   /**
     * copyリクエストのBODYを生成し、JSON文字列で返す
     * @param {Object} destInfo  コピー先フォルダ情報 {driveId, id}
-    * @param {String} newName  新しいファイルの名前
+    * @param {String} newName  新しいファイル / フォルダの名前
     * @return {JSON String} requestBody  リクエストBODY
     */
   function generateCopyRequestBody( destInfo, newName ) {
@@ -293,7 +293,7 @@
   }
 
   /**
-    * 新しいファイルのURLを返す
+    * 新しいファイル / フォルダのURLを返す
     * @param {String} driveIdOfSource  コピー元アイテムのドライブのID（フォルダのドライブIDが空文字列の場合に使用）
     * @param {String} driveIdOfDest  コピー先フォルダのドライブID
     * @param {String} newItemId  新しいファイル/ フォルダのID

--- a/onedrive-file-copy.xml
+++ b/onedrive-file-copy.xml
@@ -3,7 +3,7 @@
 <engine-type>2</engine-type>
 <label>Microsoft 365 OneDrive for Business: Copy File / Folder</label>
 <label locale="ja">Microsoft 365 OneDrive for Business: ファイル / フォルダコピー</label>
-<last-modified>2020-07-27</last-modified>
+<last-modified>2020-07-28</last-modified>
 <summary>Creates a copy of a file/folder into the specified folder on OneDrive.</summary>
 <summary locale="ja">OneDrive 上のファイル / フォルダを複製し、指定フォルダに新規保存します。</summary>
 <help-page-url>https://support.questetra.com/addons/onedrive-file-copy/</help-page-url>


### PR DESCRIPTION
@hatanaka-akihiro さん
ヘルプページ更新作業中に、英語版の summary の更新が抜けていたことに気づきました。
　更新前）Creates a copy of a file into the specified folder on OneDrive.
　更新後）Creates a copy of a file/folder into the specified folder on OneDrive.
お手数ですが、再度マージ頂けますと幸いです。