### PR TITLE
Update box-folder-search.xml

### DIFF
--- a/box-folder-search.xml
+++ b/box-folder-search.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-08-15</last-modified>
+<last-modified>2020-08-17</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>1</engine-type>
+<engine-type>2</engine-type>
 <label>Box: Search Folder</label>
 <label locale="ja">Box: フォルダ検索</label>
 <summary>Search for the folder in the specified folder on Box</summary>
@@ -44,8 +44,9 @@ function main(){
     throw "Folder Name is blank";
   }
   //get C4&C5
-  const idData = configs.get("FolderIdItem");
-  const urlData = configs.get("WebViewUrlItem");
+  const idData = configs.getObject( "FolderIdItem" );
+  const urlData = configs.getObject( "WebViewUrlItem" );
+
   //If neither C4 nor C5 are set,throw error
   if((idData === null || idData === "") && (urlData === null || urlData === "")){
     throw "Neither of Data Items to save result are set.";
@@ -78,27 +79,18 @@ function main(){
     throw "Folder " + folderName + " doesn't exist.";
   }
   //set ID to Data Item
-  if (idData !== null && idData !== "") {
-    const idDataDef = engine.findDataDefinitionByNumber(idData);
-    //Multiple Judge
-    if(idDataDef.matchDataType("STRING_TEXTFIELD") && folderCount > 1){
-      throw "Multiple folders are found.Can't set data to single-line string Data Item."
-    }
-    engine.setDataByNumber(idData,folderIdList);
-  }
-  //set URL to Data Item
-  if (urlData !== null && urlData !== "") {
-    const urlDataDef = engine.findDataDefinitionByNumber(urlData);
-    //Multiple Judge
-    if(urlDataDef.matchDataType("STRING_TEXTFIELD") && folderCount > 1){
-      throw "Multiple folders are found.Can't set data to single-line string Data Item."
-    }
-    engine.setDataByNumber(urlData,folderUrlList);
+  if (idData !== null) {
+        engine.setData(idData,folderIdList);
+     }
+ 
+  //set URL to Data Item  
+  if (urlData !== null) {
+        engine.setData(urlData, folderUrlList);
   }
 }
 //search folder on box
 function searchFolder(token,parentFolderId){
-  const url = 'https://api.box.com/2.0/folders/' + parentFolderId +  '/items';
+  const url = `https://api.box.com/2.0/folders/${parentFolderId}/items`;
   let marker = "";
   let jsonRes = [];
   let json;
@@ -107,19 +99,19 @@ function searchFolder(token,parentFolderId){
     const response = httpClient.begin()
       .bearer(token)
       .queryParam("fields", "id,type,name")
-      .queryParam("limit", 1000)
-      .queryParam("usemarker",true)
+      .queryParam("limit", "1000")
+      .queryParam("usemarker","true")
       .queryParam("marker",marker)
       .get(url);
     const status = response.getStatusCode();
     const responseTxt = response.getResponseAsString() + "\n";
     if (status >= 300) {
-      const error = "Failed to search \n status:" + status + "\n" + responseTxt;
+      const error = `Failed to search \n status: ${status}\n${responseTxt}`;
       throw error;
     }
     json = JSON.parse(responseTxt)
     jsonRes = jsonRes.concat(json.entries);
-    engine.log("status:" + status + "\n" + responseTxt);
+    engine.log(`status: ${status} \n ${responseTxt}`);
     marker = json['next_marker'];
     if(marker === undefined || marker === '' || marker === null) {
       return jsonRes;


### PR DESCRIPTION
@hatanaka-akihiro  さん
ソースコードを修正しました。ご確認をお願いします。

・engineを「2」に変更
・リクエストAPI、エラーログ、ステータスログをテンプレート文字列に変更
・Boxにはひとつのフォルダ内に同名のファイルが複数存在することはないので、
「フォルダIDを出力するデータ項目が単一行指定で、複数フォルダが検索された場合」と、「フォルダURLを出力するデータ項目が単一行指定で、複数フォルダが検索された場合」の処理を削除
・C4、C5のデータ項目参照処理を「configs.getObject」に変更
・C4、C5のデータ項目代入処理を「engine.setData」に変更