### PR TITLE
Update box-folder-link-create.xml

### DIFF
--- a/box-folder-link-create.xml
+++ b/box-folder-link-create.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-08-23</last-modified>
+<last-modified>2020-08-20</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>1</engine-type>
+<engine-type>2</engine-type>
 <label>Box: Create Shared Link to Folder</label>
 <label locale="ja">Box: フォルダ共有リンク作成</label>
 <summary>Create a URL to download the specified folder on Box</summary>
@@ -22,13 +22,13 @@
     <label>C3: Date Time type data Item with Expiration of the Link</label>
     <label locale="ja">C3: リンクの有効期限が格納されている日時型データ項目</label>
   </config>
-  <config name="DownloadPass" form-type="SELECT" select-data-type="STRING">
+  <config name="DownloadPass" form-type="SELECT" select-data-type="STRING" editable="true">
     <label>C4: String type data Item with Password of the Link</label>
     <label locale="ja">C4: リンクのパスワードが格納されている文字型データ項目</label>
   </config>
   <config name="DownloadUrlItem" form-type="SELECT" select-data-type="STRING" required="true">
     <label>C5: String type data Item that will save web the Shared Link</label>
-    <label locale="ja">5: 共有リンクを保存する文字型データ項目</label>
+    <label locale="ja">C5: 共有リンクを保存する文字型データ項目</label>
   </config>
 </configs>
 
@@ -44,15 +44,27 @@ function main(){
     throw "Folder ID is blank";
   }
   const dateItem = configs.get("unsharedAt");
-  const passwordItem = configs.get("DownloadPass");
+  const password = decidePassword();
   let unsharedDate = null;
   if (dateItem !== "" && dateItem !== null){
     unsharedDate = engine.findDataByNumber(dateItem);
   }
+  
+  /**
+  * ファイルのpasswordをconfigから読み出して出力する。
+  * @return {String}  password
+  */
+function decidePassword(){
   let password = "";
-  if (passwordItem !== "" && passwordItem !== null){
-    password = engine.findDataByNumber(passwordItem);
+  const passwordDef = configs.getObject("DownloadPass");
+  if(passwordDef === null){
+    password = configs.get( "DownloadPass");
+  }else{
+    password = engine.findData(passwordDef);
   }
+  return password;
+}
+
   // get OAuth token
   let token;
   token = httpClient.getOAuth2Token(configs.get("OAuth2"));
@@ -77,18 +89,18 @@ function main(){
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
   if (status >= 300) {
-    const error = "Failed to create \n status:" + status + "\n" + responseTxt
+    const error = `Failed to create \n status: ${status}\n ${responseTxt}`;
     throw error;
   }
-  engine.log("status:" + status);
+  engine.log(`status: ${status}`);
   engine.log(responseTxt);
   
   
   const jsonRes = JSON.parse(responseTxt);
 
-  const UrlData = configs.get("DownloadUrlItem");
-  if (UrlData !== null || UrlData !== "") {
-      engine.setDataByNumber(UrlData,jsonRes["shared_link"]["url"] );
+  const UrlData = configs.getObject( "DownloadUrlItem" );
+  if (UrlData !== null) {
+      engine.setData(UrlData,jsonRes["shared_link"]["url"] );
   }
 }
 ]]></script>

--- a/box-folder-link-create.xml
+++ b/box-folder-link-create.xml
@@ -22,7 +22,7 @@
     <label>C3: Date Time type data Item with Expiration of the Link</label>
     <label locale="ja">C3: リンクの有効期限が格納されている日時型データ項目</label>
   </config>
-  <config name="DownloadPass" form-type="SELECT" select-data-type="STRING" editable="true">
+  <config name="DownloadPass" form-type="SELECT" select-data-type="STRING">
     <label>C4: String type data Item with Password of the Link</label>
     <label locale="ja">C4: リンクのパスワードが格納されている文字型データ項目</label>
   </config>
@@ -44,27 +44,18 @@ function main(){
     throw "Folder ID is blank";
   }
   const dateItem = configs.get("unsharedAt");
-  const password = decidePassword();
+  const passwordItem = configs.get("DownloadPass");//  const password = decidePassword();
+  
   let unsharedDate = null;
   if (dateItem !== "" && dateItem !== null){
     unsharedDate = engine.findDataByNumber(dateItem);
   }
-  
-  /**
-  * ファイルのpasswordをconfigから読み出して出力する。
-  * @return {String}  password
-  */
-function decidePassword(){
-  let password = "";
-  const passwordDef = configs.getObject("DownloadPass");
-  if(passwordDef === null){
-    password = configs.get( "DownloadPass");
-  }else{
-    password = engine.findData(passwordDef);
-  }
-  return password;
-}
 
+  let password = "";
+  if (passwordItem !== "" && passwordItem !== null){
+    password = engine.findDataByNumber(passwordItem);
+  }
+  
   // get OAuth token
   let token;
   token = httpClient.getOAuth2Token(configs.get("OAuth2"));

--- a/box-folder-link-create.xml
+++ b/box-folder-link-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-08-20</last-modified>
+<last-modified>2020-08-24</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Box: Create Shared Link to Folder</label>
@@ -44,7 +44,7 @@ function main(){
     throw "Folder ID is blank";
   }
   const dateItem = configs.get("unsharedAt");
-  const passwordItem = configs.get("DownloadPass");//  const password = decidePassword();
+  const passwordItem = configs.get("DownloadPass");
   
   let unsharedDate = null;
   if (dateItem !== "" && dateItem !== null){


### PR DESCRIPTION
@hatanaka-akihiro  さん
ソースコードを更新しました。ご確認をお願いいたします。

・engineを「2」に変更
・config nameの、C5 の「C」を追加（日本語のみ）
・C4: リンクのパスワードが格納されている文字型データ項目　固定値でも入力できるよう、「editable="true"」を追加
・ファイルのpasswordをconfigから読み出して出力する「decidePassword」関数を追加
・ステータスログ出力、エラーログ出力をテンプレート文字列に変更