### PR TITLE
Update box-folder-delete.xml

### DIFF
--- a/box-folder-delete.xml
+++ b/box-folder-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-07-28</last-modified>
+<last-modified>2020-08-27</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Box: Delete Folder</label>
@@ -25,10 +25,16 @@
 main();
 function main(){
   const folderIds = engine.findDataByNumber(configs.get("FolderIdsItem"));
-  if (folderIds == null) {
+  if (folderIds === "" ||folderIds === null){
     throw "Folder IDs aren't set.";
   }
-  const linesArray = folderIds.split("\n");
+
+  let linesArray = folderIds.split("\n");
+  linesArray = linesArray.filter(lines => lines !== ""); // 空文字列を削除
+  if (linesArray.length === 0) {
+    throw "Folder IDs aren't set.";
+  }
+
   const numOfLines = linesArray.length;
   if (numOfLines > httpClient.getRequestingLimit()){
   	throw "Number of Folder IDs is over the limit."
@@ -38,6 +44,7 @@ function main(){
     deleteFolder(token, linesArray[i])
   }
 }
+
 function deleteFolder(token, folderId) {
   const url = `https://api.box.com/2.0/folders/${folderId}`;
 


### PR DESCRIPTION
@hatanaka-akihiro  さん
ソースコードを修正しました。追加した処理のテスト、正常系のテストは確認済です。
よろしくお願いします。

OneDrive for Business: ファイル / フォルダ削除 に合わせて、フォルダIDの列数カウントで、改行を削除する処理を加えました。

