### PR TITLE
T7428: kintone: 選択肢データの一括取得　再帰呼び出し部分の修正

### DIFF
--- a/kintone-choice-download.xml
+++ b/kintone-choice-download.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>kintone: Download Choice Data</label>
 <label locale="ja">kintone: 選択肢データの一括取得</label>
-<last-modified>2020-09-29</last-modified>
+<last-modified>2020-10-09</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Download Choice Data in specified two fields from a Kintone App.</summary>
@@ -272,9 +272,9 @@ function getRecords( apiUri, apiToken, { app, fields, query, lastRecordId }, rec
   // 再帰呼び出し
   if ( json.records.length === LIMIT ) {
     // 取得レコードの件数が LIMIT と同じ場合は、未取得のレコードが残っている場合があるので、
-    // params.lastRecordId を更新し、getRecords を再帰呼び出しする
-    params.lastRecordId = json.records[json.records.length - 1].$id.value;
-    getRecords( apiUri, apiToken, params, records, requestNum );
+    // lastRecordId を更新し、getRecords を再帰呼び出しする
+    lastRecordId = json.records[json.records.length - 1].$id.value;
+    getRecords( apiUri, apiToken, { app, fields, query, lastRecordId }, records, requestNum );
   }
 }
 


### PR DESCRIPTION
@hatanaka-akihiro さん

指摘箇所の修正の際、再帰呼び出しの引数の修正が抜けていました。
このままだと500件以上のデータが取得できないため、修正のプルリクエストをさせていただきます。