### PR TITLE
T7407：コンバータ（Date to 和暦テキスト）　エンジンを GraalJS に変更する

### DIFF
--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -8,7 +8,7 @@
   <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   
-  <summary>Converts a DATE / DATETIME data item to Japanese calendar text and stores it in a STRING data item.</summary>
+  <summary>Converts a Date / Datetime type data item will Japanese calendar text and stores it in a String type data item.</summary>
   <summary locale="ja">日付/日時型データ項目を和暦テキストに変換し、文字列型データ項目に格納します。</summary>
   <help-page-url>https://support.questetra.com/addons/converter-datetojpera/</help-page-url>
   <help-page-url locale="ja">https://support.questetra.com/ja/addons/converter-datetojpera/</help-page-url>
@@ -16,12 +16,12 @@
   <configs>
     <config name="conf_DataIdA" required="true" form-type="SELECT"
       select-data-type="DATE_YMD|DATETIME">
-      <label>C1: DATE / DATETIME Data item to be converted</label>
+      <label>C1: Date / Datetime type data item will be converted</label>
       <label locale="ja">C1: 変換対象の日付 / 日時型データ項目</label>
     </config>
     <config name="conf_DataIdB" required="true" form-type="SELECT"
       select-data-type="STRING">
-      <label>C2: String type data item that to save Japanese calendar text</label>
+      <label>C2: String type data item that will save Japanese calendar text</label>
       <label locale="ja">C2: 和暦テキストを保存する文字列型データ項目</label>
     </config>
   </configs>
@@ -50,7 +50,7 @@ function main() {
   // 2019-05-01 = 令和元年5月1日
   const locale = new java.util.Locale("ja", "JP", "JP");
   const formatter = new java.text.SimpleDateFormat("GGGGyyyy年M月d日", locale);
-  let text = formatter.format(dData);
+  const text = formatter.format(dData);
 
   //データ更新
   engine.setDataByNumber(configs.get("conf_DataIdB"), text);

--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -4,7 +4,7 @@
   <label>Converter (Date to Japanese calendar text)</label>
   <label locale="ja">コンバータ (Date to 和暦テキスト)</label>
 
-  <last-modified>2020-11-12</last-modified>
+  <last-modified>2020-11-17</last-modified>
   <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   

--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -4,7 +4,7 @@
   <label>Converter (Date to Japanese calendar text)</label>
   <label locale="ja">コンバータ (Date to 和暦テキスト)</label>
 
-  <last-modified>2020-11-06</last-modified>
+  <last-modified>2020-11-12</last-modified>
   <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   
@@ -21,7 +21,7 @@
     </config>
     <config name="conf_DataIdB" required="true" form-type="SELECT"
       select-data-type="STRING">
-      <label>C2: STRING Data item that will save Japanese calendar text</label>
+      <label>C2: String type data item that to save Japanese calendar text</label>
       <label locale="ja">C2: 和暦テキストを保存する文字列型データ項目</label>
     </config>
   </configs>
@@ -30,9 +30,9 @@
   <script><![CDATA[
 main();
 
-function main(){
+function main() {
   // データの参照
-  const dData = engine.findDataByNumber(configs.get('conf_DataIdA'));
+  const dData = engine.findDataByNumber(configs.get("conf_DataIdA"));
   if (dData === null) {
     // 日付 / 日時型データが空なら、処理失敗に
     throw "DATE/DATETIME Data is empty";
@@ -48,12 +48,12 @@ function main(){
   // 1989-01-08 = 平成元年1月8日
   // 2019-04-30 = 平成31年4月30日
   // 2019-05-01 = 令和元年5月1日
-  const locale = new java.util.Locale( "ja", "JP", "JP" );
-  const formatter = new java.text.SimpleDateFormat( "GGGGyyyy年M月d日", locale );
+  const locale = new java.util.Locale("ja", "JP", "JP");
+  const formatter = new java.text.SimpleDateFormat("GGGGyyyy年M月d日", locale);
   let text = formatter.format(dData);
 
   //データ更新
-  engine.setDataByNumber(configs.get('conf_DataIdB'), text);
+  engine.setDataByNumber(configs.get("conf_DataIdB"), text);
 }
 ]]></script>
 

--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -4,7 +4,7 @@
   <label>Converter (Date to Japanese calendar text)</label>
   <label locale="ja">コンバータ (Date to 和暦テキスト)</label>
 
-  <last-modified>2020-11-05</last-modified>
+  <last-modified>2020-11-06</last-modified>
   <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   
@@ -58,21 +58,21 @@ function main(){
 ]]></script>
 
 
-  <icon>
-    iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACx0lEQVRYR8WXz0sUYRjHP5O0CLX+
-    uHTIQ7sHIby0BdIh0EU6hwmd20Vx9mb9AUvlQQSRVhBq0WW3gxcFKzx4000kBKO2QNgSssgS6uDu
-    oQQJJt4ZZ3ecH+s4O+kLyy7s+z7fz/PM87zPMxKnvKRj6afpBbpRiCDRAkQOzhdQKCEhvvMkeOnW
-    7tEAWVrYZwi4B6qom1UCUgSYII747bhqAzwhxhkeH0PYLCTE48i8cCJwBnhKCkn13I+VQua+nSF7
-    gDQ54K4fyhUbCjkSxM02rQD+en5YT2GChJpLlXUYQHvmWV89txq7bcyJKoCW7Vt1JJxb7hIBwnp1
-    VAHSPAQeuLVSa99U1xTzW/Msflt02vYIWdXDCCBKptkPgI07GzQFmhhcGXSCKCHTWgXQbrjnRvGe
-    iz20nWvzxJO8lqS9uZ3t39u1INRc0CJgk/nCi47WDk8AxkOOEAcVoQGkyat3vGH5BbD3d4/RwijD
-    b4fNzrxCJqoDfAEuGXdMd03TeaHTUwRC50NqDgjx8Q/jJN8k7ewUkLmqAyielBwOieiFg+Fa4tpJ
-    GelIgODZIJnuDDt/dhh67a41rN5aZfnHspPnVWwDgOURiF1CPBvN0hvqJfcxx8DKgH+BUnhPgohj
-    EhrFG6QG1n6usVne9ASw9H2J3CfR3w4tQxLalOHszVn6wn0I8XpXppixRs9UhpaLaPLGJP2X+2ls
-    aKxXH1sAMFxE2l1guYqNEHOf51j4uuAJplgqsv5r3Xi2jKyNd0c2Ix1iZnPGzyS0aUZaOxbVYGlI
-    Y9fH2N3fZeTdiKcImA6VCRCytmOx61QHEh3zf45kUAm9LndyQyk8QyZmfoYnNZZbPK8dAf1fbVAR
-    V5jXSakMxLy9mOgQWnWIUVp83IIIYfFqlqrv1cz8wEREFKJIRFBoQeKKukU0FokSCgUk8rU8dp8D
-    flS8Cxv/AFp57iGwqv7bAAAAAElFTkSuQmCC
-  </icon>
+<icon>
+iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACx0lEQVRYR8WXz0sUYRjHP5O0CLX+
+uHTIQ7sHIby0BdIh0EU6hwmd20Vx9mb9AUvlQQSRVhBq0WW3gxcFKzx4000kBKO2QNgSssgS6uDu
+oQQJJt4ZZ3ecH+s4O+kLyy7s+z7fz/PM87zPMxKnvKRj6afpBbpRiCDRAkQOzhdQKCEhvvMkeOnW
+7tEAWVrYZwi4B6qom1UCUgSYII747bhqAzwhxhkeH0PYLCTE48i8cCJwBnhKCkn13I+VQua+nSF7
+gDQ54K4fyhUbCjkSxM02rQD+en5YT2GChJpLlXUYQHvmWV89txq7bcyJKoCW7Vt1JJxb7hIBwnp1
+VAHSPAQeuLVSa99U1xTzW/Msflt02vYIWdXDCCBKptkPgI07GzQFmhhcGXSCKCHTWgXQbrjnRvGe
+iz20nWvzxJO8lqS9uZ3t39u1INRc0CJgk/nCi47WDk8AxkOOEAcVoQGkyat3vGH5BbD3d4/RwijD
+b4fNzrxCJqoDfAEuGXdMd03TeaHTUwRC50NqDgjx8Q/jJN8k7ewUkLmqAyielBwOieiFg+Fa4tpJ
+GelIgODZIJnuDDt/dhh67a41rN5aZfnHspPnVWwDgOURiF1CPBvN0hvqJfcxx8DKgH+BUnhPgohj
+EhrFG6QG1n6usVne9ASw9H2J3CfR3w4tQxLalOHszVn6wn0I8XpXppixRs9UhpaLaPLGJP2X+2ls
+aKxXH1sAMFxE2l1guYqNEHOf51j4uuAJplgqsv5r3Xi2jKyNd0c2Ix1iZnPGzyS0aUZaOxbVYGlI
+Y9fH2N3fZeTdiKcImA6VCRCytmOx61QHEh3zf45kUAm9LndyQyk8QyZmfoYnNZZbPK8dAf1fbVAR
+V5jXSakMxLy9mOgQWnWIUVp83IIIYfFqlqrv1cz8wEREFKJIRFBoQeKKukU0FokSCgUk8rU8dp8D
+flS8Cxv/AFp57iGwqv7bAAAAAElFTkSuQmCC
+</icon>
 
 </service-task-definition>

--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -4,8 +4,8 @@
   <label>Converter (Date to Japanese calendar text)</label>
   <label locale="ja">コンバータ (Date to 和暦テキスト)</label>
 
-  <last-modified>2019-06-04</last-modified>
-  <engine-type>1</engine-type>
+  <last-modified>2020-11-05</last-modified>
+  <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   
   <summary>Converts a DATE / DATETIME data item to Japanese calendar text and stores it in a STRING data item.</summary>

--- a/converter-dateToJpEra.xml
+++ b/converter-dateToJpEra.xml
@@ -8,7 +8,7 @@
   <engine-type>2</engine-type>
   <license>(C) Questetra, Inc. (MIT License)</license>
   
-  <summary>Converts a Date / Datetime type data item will Japanese calendar text and stores it in a String type data item.</summary>
+  <summary>Converts a Date / Datetime type data item to Japanese calendar text and stores it in a String type data item.</summary>
   <summary locale="ja">日付/日時型データ項目を和暦テキストに変換し、文字列型データ項目に格納します。</summary>
   <help-page-url>https://support.questetra.com/addons/converter-datetojpera/</help-page-url>
   <help-page-url locale="ja">https://support.questetra.com/ja/addons/converter-datetojpera/</help-page-url>
@@ -16,12 +16,12 @@
   <configs>
     <config name="conf_DataIdA" required="true" form-type="SELECT"
       select-data-type="DATE_YMD|DATETIME">
-      <label>C1: Date / Datetime type data item will be converted</label>
+      <label>C1: Date / Datetime type data item to be converted</label>
       <label locale="ja">C1: 変換対象の日付 / 日時型データ項目</label>
     </config>
     <config name="conf_DataIdB" required="true" form-type="SELECT"
       select-data-type="STRING">
-      <label>C2: String type data item that will save Japanese calendar text</label>
+      <label>C2: String type data item to save Japanese calendar text</label>
       <label locale="ja">C2: 和暦テキストを保存する文字列型データ項目</label>
     </config>
   </configs>


### PR DESCRIPTION
`engine-type`を`2`に変更しました。