### PR TITLE
T7516：Gmail: メール取得　未設定の保存先データ項目があっても動作するように

### DIFF
--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-11-27</last-modified>
+<last-modified>2020-12-14</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -471,9 +471,24 @@ function setDataIfNotNull( def, value ) {
 
   ]]>
 </script>
-<!-- アイコン未設定（Icon Maker に Gmail のアイコンがない）
-<icon>
 
+<icon>
+iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADPUlEQVRYR8WXX0hTURzHv2dzy5bb
+1HKKRH+gtx7K2izooXI+BVH41F+IglAJmhVICr2kgRG6DFRERXBpGIgkZA/Oeigir+VzIGQE1bTU
+yXYdy90Tu+5u997dea9p3PO2nd+fz/md359zCXReRKv/76cPW4ysoYKAnARoCSj2gCCP16dYAMEM
+QKYo6OuYhRsqHvnIarGtCjB7wlWELNSCohJAthajACIg6MAKmhxvmJ9r6awJECgrrSSEPgKwTaNj
+uViYUnKncHyiI5N+RoC5clcbpaj6R8cSNULQXjDGVCvZUgQIlDn7CSHnN8O5YINSOlA4PnlBbjMN
+YDNPnuZMIRISgMSdt2/myeW2KCVV4pxIAvDZbsS0kHCGAgdsdQ0w2HPBPvchMvpCMxexWmGrb4Sx
+qBiRl8NgB31i3TBi2CdURwqg3NUCCo8gme8b5g0IK8q8R7C+BuC4NUFMJU7YG70gZnNSLnj3JuL6
+yUXgdYwxNfHfPEC8yWSxht/iOi949Q7IMkmcccFFLHquI/ZtRhEip/oWtlacS9tjB/sQ7nwi/j+y
+YuG2x5sVDxBwuy4RoE8soQTA71MOodaHWB4ZSh3IakWetwvG3XsVweJXEO5slexR4HKhn/HxALPu
+0m6AXtUEkBASrsR80AlbQ7Mk5HIKJQCA9Dj8E9cSAK5PAErWA8AHg2VBLBbV5FQGwJTDzxxaBShz
+zScHS8JcxitQdZcuoAhAseAYZ/KFCFC5WhoApQBRnV2AglyGCMDhZ1YtzrpdqgCxwA+w/b2wemoB
+YlCMQ+zrF4Sf9sBWd1+yrw6g4QriAPMXz8C4cxdyH3fxDUq8loeeIdTWDPORY7A3tqgDyK5ANQkF
+AN6ywQD7Ay/MzqOg0SiW7t1GdPIDv6UZAOIk1FCGEoDE+bYcd+PP1CS4pWDyxNoBRGWopREpASgl
+glYASSNSasU7Rt+CmFL9fEMAA70Id7eJeaWtmK8E2TDKqfIg+9TZZOmtTH/m54DaMu0/AHtTqu3S
+UAgLN66A+zWXUpUPIx5ANo7VHG1gX3kcxw3q+iARTqTrk0yA0PVR+j8ise5neSoSOn6YCBC6fpqJ
+S023j9MN1Lsm1b9qWLIw6P4tOAAAAABJRU5ErkJggg==
 </icon>
--->
+
 </service-task-definition>

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-11-17</last-modified>
+<!--
+<last-modified>2020-11-26</last-modified>
+-->
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -65,57 +67,36 @@ function main(){
   //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
   const auth = configs.get("conf_auth");
   const messageId = retrieveMessageId();
-
-  const fromAddressDef = configs.getObject("conf_fromAddress");
-  const fromNameDef = configs.getObject("conf_fromName");
-  const recipientAddressesDef = configs.getObject("conf_recipientAddresses");
-  const recipientNamesDef = configs.getObject("conf_recipientNames");
-  const sentDatetimeDef = configs.getObject("conf_sentDatetime");
-  const subjectDef = configs.getObject("conf_subject");
-  const bodyDef = configs.getObject("conf_body");
-  const attachmentsDef = configs.getObject("conf_attachments");
+  const defs = retrieveDefs();
 
   const apiToken = httpClient.getOAuth2Token( auth );
-  let files = engine.findData( attachmentsDef );
-  if (files === null) {
-    files = new java.util.ArrayList();
-  }
+  const files = retrieveFiles( defs.attachmentsDef );
 
   //// == 演算 / Calculating ==
+  const hasNoDefs = Object.values(defs).every( def => def === null );
+  if ( hasNoDefs ) return; // 保存先データ項目が１つも設定されていなければ何もせず正常終了
   const apiUri = determineApiUri( messageId );
-  const message = {
-    "from": {
-      "email": "",
-      "name": ""
-    },
-    "recipients": {
-      "emails": [],
-      "names": []
-    },
-    "datetime": "",
-    "subject": "",
-    "body": "",
-    "attachments": []
-  };
-  getMessage( apiUri, apiToken, message );
+  const message = getMessage( apiUri, apiToken );
 
-  getAttachments( apiUri, apiToken, message.attachments );
-  convertAndAddAttachments( message.attachments, files );
+  if ( defs.attachmentsDef !== null ) {
+    getAttachments( apiUri, apiToken, message.attachments );
+    convertAndAddAttachments( message.attachments, files );
+  }
 
   //// == ワークフローデータへの代入 / Data Updating ==
-  engine.setData( fromAddressDef, message.from.email );
-  engine.setData( fromNameDef, message.from.name );
-  engine.setData( recipientAddressesDef, message.recipients.emails.join('\n') );
-  engine.setData( recipientNamesDef, message.recipients.names.join('\n') );
-  engine.setData( sentDatetimeDef, new java.sql.Timestamp(Date.parse(message.datetime)) );
-  engine.setData( subjectDef, message.subject );
-  engine.setData( bodyDef, message.body );
-  engine.setData( attachmentsDef, files );
+  setDataIfNotNull( defs.fromAddressDef, message.from.email );
+  setDataIfNotNull( defs.fromNameDef, message.from.name );
+  setDataIfNotNull( defs.recipientAddressesDef, message.recipients.emails.join('\n') );
+  setDataIfNotNull( defs.recipientNamesDef, message.recipients.names.join('\n') );
+  setDataIfNotNull( defs.sentDatetimeDef, new java.sql.Timestamp(Date.parse(message.datetime)) );
+  setDataIfNotNull( defs.subjectDef, message.subject );
+  setDataIfNotNull( defs.bodyDef, message.body );
+  setDataIfNotNull( defs.attachmentsDef, files );
 }
 
 /**
   * config からメール ID を読み出す
-  * @return {Stromg} messageId  メール ID
+  * @return {String} messageId  メール ID
   */
 function retrieveMessageId() {
   const messageIdDef = configs.getObject( "conf_messageId" );
@@ -124,6 +105,32 @@ function retrieveMessageId() {
     messageId = engine.findData( messageIdDef );
   }
   return messageId;
+}
+
+/**
+  * config から保存先データ項目の ProcessDataDefinitionView を読み出す
+  * @return {Object} defs  保存先データ項目の ProcessDataDefinitionView を格納した JSON オブジェクト
+  */
+function retrieveDefs() {
+  const items = ["fromAddress", "fromName", "recipientAddresses", "recipientNames", "sentDatetime", "subject", "body", "attachments"];
+  const defs = {};
+  items.forEach( item => defs[`${item}Def`] = configs.getObject(`conf_${item}`) );
+  return defs;
+}
+
+/**
+  * ワークフローデータからファイル型データ項目の値（ファイルの配列）を読み出す
+  * @return {ListArray<Qfile>} files  ファイルの配列
+  */
+function retrieveFiles( attachmentsDef ) {
+  let files = null;
+  if ( attachmentsDef !== null ) {
+    files = engine.findData( attachmentsDef );
+  }
+  if ( files === null ) {
+    files = new java.util.ArrayList();
+  }
+  return files;
 }
 
 /**
@@ -144,9 +151,9 @@ function determineApiUri( messageId ) {
   * Gmail REST API にメール取得の GET リクエストを送信し、必要な情報を JSON オブジェクトに格納する
   * @param {String} apiUri  API の URI
   * @param {String} apiToken  API トークン
-  * @param {Object} message  メール情報を格納する JSON オブジェクト
+  * @return {Object} message  メール情報を格納した JSON オブジェクト
   */
-function getMessage( apiUri, apiToken, message ) {
+function getMessage( apiUri, apiToken ) {
   const response = httpClient.begin()
     .bearer( apiToken )
     .get( apiUri );
@@ -163,18 +170,32 @@ function getMessage( apiUri, apiToken, message ) {
 
   // when successful, parse the message content
   const json = JSON.parse(responseJson);
-  // const rawMessage = base64.decodeFromUrlSafeString(json.raw);
-
-  extractFromPayload( json.payload, message );
+  const message = extractFromPayload( json.payload );
+  return message;
 }
 
 /**
   * Gmail REST API のメール取得のレスポンスの payload フィールドから
   * 必要な情報を抜き出し、JSON オブジェクトに格納する
   * @param {Object} payload  Gmail REST API のメール取得のレスポンスの payload フィールド
-  * @param {Object} message  メール情報を格納する JSON オブジェクト
+  * @return {Object} message  メール情報を格納した JSON オブジェクト
   */
-function extractFromPayload( payload, message ) {
+function extractFromPayload( payload ) {
+  const message = {
+    "from": {
+      "email": "",
+      "name": ""
+    },
+    "recipients": {
+      "emails": [],
+      "names": []
+    },
+    "datetime": "",
+    "subject": "",
+    "body": "",
+    "attachments": []
+  };
+
   // ヘッダの処理
   let fromHeader = "";
   let senderHeader = ""; // From ヘッダが無い場合に Sender ヘッダの値を使う
@@ -216,12 +237,12 @@ function extractFromPayload( payload, message ) {
   const mimeType = payload.mimeType;
   if ( mimeType === "text/plain" || mimeType === "text/html" ) { // 本文のみのメール
     message.body = parseTextPart( payload );
-    return;
   }
   if ( mimeType.startsWith("multipart/") ) { // マルチパートのメール
     message.body = parseMultiPart( payload, message.attachments );
-    return;
   }
+
+  return message;
 }
 
 /**
@@ -424,6 +445,16 @@ function convertAndAddAttachments( attachments, files ) {
     );
     files.add( qfile );
   });
+}
+
+/**
+  * 保存先データ項目の ProcessDataDefinitionView が null でない場合のみ値を代入する
+  * @param {ProcessDataDefinitionView} def  保存先データ項目の ProcessDataDefinitionView
+  * @param {Object} value  データ項目に代入する値
+  */
+function setDataIfNotNull(def, value) {
+  if ( def === null ) return; // データ項目が設定されていなければ何もしない
+  engine.setData( def, value );
 }
 
   ]]>

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-12-17</last-modified>
+<last-modified>2020-12-24</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -81,10 +81,10 @@ function main(){
   }
 
   // To, Cc, Bcc の順に連結
-  const recipientEmails = message.recipients.To.emails
-    .concat( message.recipients.Cc.emails, message.recipients.Bcc.emails );
-  const recipientNames = message.recipients.To.names
-    .concat( message.recipients.Cc.names, message.recipients.Bcc.names );
+  const recipientEmails = message.recipients.to.emails
+    .concat( message.recipients.cc.emails, message.recipients.bcc.emails );
+  const recipientNames = message.recipients.to.names
+    .concat( message.recipients.cc.names, message.recipients.bcc.names );
 
   //// == ワークフローデータへの代入 / Data Updating ==
   setDataIfNotNull( defs.fromAddressDef, message.from.email );
@@ -202,15 +202,15 @@ function extractFromPayload( payload ) {
       "name": ""
     },
     "recipients": {
-      "To": {
+      "to": {
         "emails": [],
         "names": []
       },
-      "Cc": {
+      "cc": {
         "emails": [],
         "names": []
       },
-      "Bcc": {
+      "bcc": {
         "emails": [],
         "names": []
       }
@@ -222,41 +222,37 @@ function extractFromPayload( payload ) {
   };
 
   // ヘッダの処理
-  let fromHeader = "";
-  let senderHeader = ""; // From ヘッダが無い場合に Sender ヘッダの値を使う
+  // From ヘッダは Gmail の仕様で必ず 1 件, Date ヘッダも 1 件
+  // To, Cc, Bcc は複数件の可能性があるので配列に追加して処理
+  // Subject が複数件ある場合は最初の Subject ヘッダを採用する
   payload.headers.forEach( header => {
-    if ( header.name === "From" ) {
-      fromHeader = header.value;
+    let headerNameLower = header.name.toLowerCase();
+    if ( headerNameLower === "from" ) {
+      // From ヘッダをメールアドレスと名前に分ける
+      const fromAddresses = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
+      if ( fromAddresses !== null && fromAddresses.length !== 0 ) {
+        message.from.email = fromAddresses[0].getAddress();
+        message.from.name = fromAddresses[0].getPersonal();
+      }
     }
-    if ( header.name === "Sender" ) {
-      senderHeader = header.value;
-    }
-    if ( header.name === "To" || header.name === "Cc" || header.name === "Bcc" ) {
+    if ( headerNameLower === "to" || headerNameLower === "cc" || headerNameLower === "bcc" ) {
       const addresses  = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
       if ( addresses !== null && addresses.length !== 0 ) {
         addresses.forEach( addr => {
-          message.recipients[header.name].emails.push( addr.getAddress() );
-          message.recipients[header.name].names.push( addr.getPersonal() );
+          message.recipients[headerNameLower].emails.push( addr.getAddress() );
+          message.recipients[headerNameLower].names.push( addr.getPersonal() );
         });
       }
     }
-    if ( header.name === "Date" ) {
+    if ( headerNameLower === "date" ) {
       message.datetime = header.value;
     }
-    if ( header.name === "Subject" ) {
-      message.subject = header.value;
+    if ( headerNameLower === "subject" ) {
+      if ( message.subject === "" ) { // 最初の Subject ヘッダを採用する
+        message.subject = header.value;
+      }
     }
   });
-  // From ヘッダが無い、もしくは空文字列の場合は Sender ヘッダの値を使う
-  if ( fromHeader === "" ) {
-    fromHeader = senderHeader;
-  }
-  // From ヘッダをメールアドレスと名前に分ける
-  const fromAddresses = emailService.parseAddressHeader( fromHeader ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
-  if ( fromAddresses !== null && fromAddresses.length !== 0 ) {
-    message.from.email = fromAddresses[0].getAddress();
-    message.from.name = fromAddresses[0].getPersonal();
-  }
 
   // パート（本文、添付ファイル）の処理
   const mimeType = payload.mimeType;
@@ -346,30 +342,26 @@ function attachment( part, index ) {
 
   const disposition = getDisposition( part );
   const contentType = getContentType( part );
-  if ( disposition === null ) { // 添付ファイルとみなさない
-    return null;
-  }
-  if ( disposition === "attachment" ) { // ファイル名がなくても添付ファイルとみなす
+  if ( disposition === "attachment" || part.body.attachmentId !== undefined ) { // ファイル名がなくても添付ファイルとみなす
     let filename = part.filename;
     if ( filename === undefined || filename === null || filename === "" ) {
       filename = "noname"; // Default
     }
     const file = {
-        "filename": filename,
-        "contentType": contentType,
-        "body": part.body
+      "filename": filename,
+      "contentType": contentType,
+      "body": part.body
     }
     return file;
-  }
-  if ( disposition === "inline" ) { // ファイル名がある場合のみ添付ファイルとみなす
+  } else { // ファイル名 があれば添付ファイルとみなす
     const filename = part.filename;
     if ( filename === undefined || filename === null || filename === "" ) {
       return null;
     }
     const file = {
-        "filename": filename,
-        "contentType": contentType,
-        "body": part.body
+      "filename": filename,
+      "contentType": contentType,
+      "body": part.body
     }
     return file;
   }
@@ -385,7 +377,7 @@ function getDisposition( part ) {
     return null;
   }
   const dispositionHeaders = part.headers.filter( header => {
-    if ( header.name === "Content-Disposition" ) {
+    if ( header.name.toLowerCase() === "content-disposition" ) {
           return true;
         } 
   });
@@ -406,7 +398,7 @@ function getContentType( part ) {
     return "application/octet-stream"; // Default
   }
   const contentTypeHeaders = part.headers.filter( header => {
-    if ( header.name === "Content-Type" ) {
+    if ( header.name.toLowerCase() === "content-type" ) {
           return true;
         } 
   });

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-12-24</last-modified>
+<last-modified>2020-12-25</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
 <summary locale="ja">Gmail のメールを取得します。</summary>
 <configs>
-  <config name="conf_auth" required="true" form-type="OAUTH2">
-    <label>C1: Authorization Setting to connect Gmail</label>
-    <label locale="ja">C1: Gmail に接続するための認証設定</label>
+  <config name="conf_auth" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/gmail.readonly">
+    <label>C1: OAuth2 Setting</label>
+    <label locale="ja">C1: OAuth2 設定</label>
   </config>
   <config name="conf_messageId" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C2: Message ID</label>
@@ -64,7 +64,7 @@ main();
 function main(){
   //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
   const auth = configs.get("conf_auth");
-  const messageId = retrieveMessageId();
+  const messageId = engine.findData( configs.getObject("conf_messageId") );
   const defs = retrieveDefs();
   const files = retrieveFiles( defs.attachmentsDef );
 
@@ -98,19 +98,6 @@ function main(){
 }
 
 /**
-  * config からメール ID を読み出す
-  * @return {String} messageId  メール ID
-  */
-function retrieveMessageId() {
-  const messageIdDef = configs.getObject( "conf_messageId" );
-  let messageId = configs.get( "conf_messageId" );
-  if ( messageIdDef !== null ) {
-    messageId = engine.findData( messageIdDef );
-  }
-  return messageId;
-}
-
-/**
   * config から保存先データ項目の ProcessDataDefinitionView を読み出す
   * 値を保存するデータ項目が重複して設定されている場合はエラーとする
   * @return {Object} defs  保存先データ項目の ProcessDataDefinitionView を格納した JSON オブジェクト
@@ -118,15 +105,15 @@ function retrieveMessageId() {
 function retrieveDefs() {
   const items = ["fromAddress", "fromName", "recipientAddresses", "recipientNames", "sentDatetime", "subject", "body", "attachments"];
   const defs = {};
-  const dataItemNumList = []; // データ項目の重複確認用
+  const dataItemNumSet = new Set(); // データ項目の重複確認用
   items.forEach( item => {
     const dataItemDef = configs.getObject(`conf_${item}`);
     if ( dataItemDef !== null ) { // データ項目が設定されている場合は重複を確認する
       const dataItemNum = dataItemDef.getNumber();
-      if ( dataItemNumList.indexOf( dataItemNum ) !== -1 ) { // データ項目番号が重複していればエラー
+      if ( dataItemNumSet.has( dataItemNum ) ) { // データ項目番号が重複していればエラー
         throw "The same data item is set multiple times.";
       }
-      dataItemNumList.push( dataItemNum ); // データ項目の重複確認用
+      dataItemNumSet.add( dataItemNum ); // データ項目の重複確認用
     }
     defs[`${item}Def`] = dataItemDef;
   });
@@ -226,31 +213,34 @@ function extractFromPayload( payload ) {
   // To, Cc, Bcc は複数件の可能性があるので配列に追加して処理
   // Subject が複数件ある場合は最初の Subject ヘッダを採用する
   payload.headers.forEach( header => {
-    let headerNameLower = header.name.toLowerCase();
-    if ( headerNameLower === "from" ) {
-      // From ヘッダをメールアドレスと名前に分ける
-      const fromAddresses = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
-      if ( fromAddresses !== null && fromAddresses.length !== 0 ) {
-        message.from.email = fromAddresses[0].getAddress();
-        message.from.name = fromAddresses[0].getPersonal();
-      }
-    }
-    if ( headerNameLower === "to" || headerNameLower === "cc" || headerNameLower === "bcc" ) {
-      const addresses  = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
-      if ( addresses !== null && addresses.length !== 0 ) {
-        addresses.forEach( addr => {
-          message.recipients[headerNameLower].emails.push( addr.getAddress() );
-          message.recipients[headerNameLower].names.push( addr.getPersonal() );
-        });
-      }
-    }
-    if ( headerNameLower === "date" ) {
-      message.datetime = header.value;
-    }
-    if ( headerNameLower === "subject" ) {
-      if ( message.subject === "" ) { // 最初の Subject ヘッダを採用する
-        message.subject = header.value;
-      }
+    const headerNameLower = header.name.toLowerCase();
+    switch ( headerNameLower ) {
+      case 'from':
+        const fromAddresses = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
+        if ( fromAddresses !== null && fromAddresses.length !== 0 ) {
+          message.from.email = fromAddresses[0].getAddress();
+          message.from.name = fromAddresses[0].getPersonal();
+        }
+        break;
+      case 'to':
+      case 'cc':
+      case 'bcc':
+        const addresses  = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
+        if ( addresses !== null && addresses.length !== 0 ) {
+          addresses.forEach( addr => {
+            message.recipients[headerNameLower].emails.push( addr.getAddress() );
+            message.recipients[headerNameLower].names.push( addr.getPersonal() );
+          });
+        }
+        break;
+      case 'date':
+        message.datetime = header.value;
+        break;
+      case 'subject':
+        if ( message.subject === "" ) { // 最初の Subject ヘッダを採用する
+          message.subject = header.value;
+        }
+        break;
     }
   });
 
@@ -370,21 +360,14 @@ function attachment( part, index ) {
 /**
   * MIME メールのパートの "Content-Disposition" ヘッダの値を返す
   * @param {Object} part  パート
-  * @return {String} disposition  "Content-Disposition" ヘッダの値（ヘッダが無い場合は null）
+  * @return {String} disposition  "Content-Disposition" ヘッダの値（ヘッダが無い場合は undefined）
   */
 function getDisposition( part ) {
   if ( part.headers === undefined ) { // パートにヘッダが無い場合は null を返す
     return null;
   }
-  const dispositionHeaders = part.headers.filter( header => {
-    if ( header.name.toLowerCase() === "content-disposition" ) {
-          return true;
-        } 
-  });
-  if ( dispositionHeaders.length === 0 ) { // 無い場合は null を返す
-    return null;
-  }
-  return dispositionHeaders[0].value.split(";")[0].toLowerCase();
+  const dispositionHeader = part.headers.find( header => header.name.toLowerCase() === "content-disposition" );
+  return dispositionHeader.value.split(";")[0].toLowerCase();
 }
 
 /**
@@ -394,18 +377,15 @@ function getDisposition( part ) {
   * @return {String} contentType  "Content-Type" ヘッダの値
   */
 function getContentType( part ) {
+  const defaultContentType = "application/octet-stream";
   if ( part.headers === undefined ) { // パートにヘッダが無い場合はデフォルト値を返す
-    return "application/octet-stream"; // Default
+    return defaultContentType;
   }
-  const contentTypeHeaders = part.headers.filter( header => {
-    if ( header.name.toLowerCase() === "content-type" ) {
-          return true;
-        } 
-  });
-  if ( contentTypeHeaders.length === 0 ) { // 無い場合はデフォルト値を返す
-    return "application/octet-stream"; // Default
+  const contentTypeHeader = part.headers.find( header => header.name.toLowerCase() === "content-type" );
+  if ( contentTypeHeader === undefined ) { // 無い場合はデフォルト値を返す
+    return defaultContentType;
   }
-  return contentTypeHeaders[0].value;
+  return contentTypeHeader.value;
 }
 
 /**
@@ -428,29 +408,23 @@ function getAttachments( apiUri, auth, attachments ) {
   const httpLimit = httpClient.getRequestingLimit();
   let httpCount = 1; // HTTP リクエストの上限超えチェック用のカウンタ（メール取得のリクエスト後なので初期値は1）
   attachments.forEach( attachment => {
-    if ( attachment.body.data === undefined ) { // data がなければ、attachmentId から data を取得して格納
-      httpCount++;
-      if ( httpCount > httpLimit ) {
-        throw "Number of HTTP requests is over the limit.";
-      }
-      const response = httpClient.begin()
-        .authSetting( auth )
-        .get( `${apiUri}/attachments/${attachment.body.attachmentId}` );
-
-      // when error thrown
-      const responseJson = response.getResponseAsString();
-      const status = response.getStatusCode();
-      if (status >= 300) {
-        engine.log(`API URI: ${apiUri}/attachments/${attachment.body.attachmentId}`);
-        const accessLog = `---GET request--- ${status}\n${responseJson}\n`;
-        engine.log( accessLog );
-        throw `Failed to get attachment. status: ${status}`;
-      }
-
-      // when successful, parse the message content
-      const json = JSON.parse(responseJson);
-      attachment.body["data"] = json.data;
+    if ( attachment.body.data !== undefined ) { return; } // data があれば何もしない
+    httpCount++;
+    if ( httpCount > httpLimit ) { throw "Number of HTTP requests is over the limit."; }
+    const response = httpClient.begin()
+      .authSetting( auth )
+      .get( `${apiUri}/attachments/${attachment.body.attachmentId}` );
+    const responseJson = response.getResponseAsString();
+    const status = response.getStatusCode();
+    if (status >= 300) { // when error thrown
+      engine.log(`API URI: ${apiUri}/attachments/${attachment.body.attachmentId}`);
+      const accessLog = `---GET request--- ${status}\n${responseJson}\n`;
+      engine.log( accessLog );
+      throw `Failed to get attachment. status: ${status}`;
     }
+    // when successful, parse the message content
+    const json = JSON.parse(responseJson);
+    attachment.body["data"] = json.data;
   });
 }
 

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-11-26</last-modified>
+<last-modified>2020-11-27</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -66,18 +66,16 @@ function main(){
   const auth = configs.get("conf_auth");
   const messageId = retrieveMessageId();
   const defs = retrieveDefs();
-
-  const apiToken = httpClient.getOAuth2Token( auth );
   const files = retrieveFiles( defs.attachmentsDef );
 
   //// == 演算 / Calculating ==
   const hasNoDefs = Object.values(defs).every( def => def === null );
   if ( hasNoDefs ) return; // 保存先データ項目が１つも設定されていなければ何もせず正常終了
   const apiUri = determineApiUri( messageId );
-  const message = getMessage( apiUri, apiToken );
+  const message = getMessage( apiUri, auth );
 
   if ( defs.attachmentsDef !== null ) {
-    getAttachments( apiUri, apiToken, message.attachments );
+    getAttachments( apiUri, auth, message.attachments );
     convertAndAddAttachments( message.attachments, files );
   }
 
@@ -154,12 +152,12 @@ function determineApiUri( messageId ) {
 /**
   * Gmail REST API にメール取得の GET リクエストを送信し、必要な情報を JSON オブジェクトに格納する
   * @param {String} apiUri  API の URI
-  * @param {String} apiToken  API トークン
+  * @param {String} auth  認証設定名
   * @return {Object} message  メール情報を格納した JSON オブジェクト
   */
-function getMessage( apiUri, apiToken ) {
+function getMessage( apiUri, auth ) {
   const response = httpClient.begin()
-    .bearer( apiToken )
+    .authSetting( auth )
     .get( apiUri );
 
   // when error thrown
@@ -404,7 +402,7 @@ function getContentType( part ) {
   * ない場合は Gmail REST API に添付ファイル取得の GET リクエストを送信し、
   * 本体データを追加する
   * @param {String} apiUri  API の URI（/messages/{messageId} まで）
-  * @param {String} apiToken  API トークン
+  * @param {String} auth  認証設定名
   * @param {Array<Object>} attachments  添付ファイルの情報（オブジェクト）が格納された配列
   *  配列内の添付ファイルの情報の形式は：
   *   {
@@ -415,7 +413,7 @@ function getContentType( part ) {
   *     }
   *   }
   */
-function getAttachments( apiUri, apiToken, attachments ) {
+function getAttachments( apiUri, auth, attachments ) {
   const httpLimit = httpClient.getRequestingLimit();
   let httpCount = 1; // HTTP リクエストの上限超えチェック用のカウンタ（メール取得のリクエスト後なので初期値は1）
   attachments.forEach( attachment => {
@@ -425,7 +423,7 @@ function getAttachments( apiUri, apiToken, attachments ) {
         throw "Number of HTTP requests is over the limit";
       }
       const response = httpClient.begin()
-        .bearer( apiToken )
+        .authSetting( auth )
         .get( `${apiUri}/attachments/${attachment.body.attachmentId}` );
 
       // when error thrown
@@ -466,7 +464,7 @@ function convertAndAddAttachments( attachments, files ) {
   * @param {ProcessDataDefinitionView} def  保存先データ項目の ProcessDataDefinitionView
   * @param {Object} value  データ項目に代入する値
   */
-function setDataIfNotNull(def, value) {
+function setDataIfNotNull( def, value ) {
   if ( def === null ) return; // データ項目が設定されていなければ何もしない
   engine.setData( def, value );
 }

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<!--
 <last-modified>2020-11-26</last-modified>
--->
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -83,11 +81,17 @@ function main(){
     convertAndAddAttachments( message.attachments, files );
   }
 
+  // To, Cc, Bcc の順に連結
+  const recipientEmails = message.recipients.To.emails
+    .concat( message.recipients.Cc.emails, message.recipients.Bcc.emails );
+  const recipientNames = message.recipients.To.names
+    .concat( message.recipients.Cc.names, message.recipients.Bcc.names );
+
   //// == ワークフローデータへの代入 / Data Updating ==
   setDataIfNotNull( defs.fromAddressDef, message.from.email );
   setDataIfNotNull( defs.fromNameDef, message.from.name );
-  setDataIfNotNull( defs.recipientAddressesDef, message.recipients.emails.join('\n') );
-  setDataIfNotNull( defs.recipientNamesDef, message.recipients.names.join('\n') );
+  setDataIfNotNull( defs.recipientAddressesDef, recipientEmails.join('\n') );
+  setDataIfNotNull( defs.recipientNamesDef, recipientNames.join('\n') );
   setDataIfNotNull( defs.sentDatetimeDef, new java.sql.Timestamp(Date.parse(message.datetime)) );
   setDataIfNotNull( defs.subjectDef, message.subject );
   setDataIfNotNull( defs.bodyDef, message.body );
@@ -187,8 +191,18 @@ function extractFromPayload( payload ) {
       "name": ""
     },
     "recipients": {
-      "emails": [],
-      "names": []
+      "To": {
+        "emails": [],
+        "names": []
+      },
+      "Cc": {
+        "emails": [],
+        "names": []
+      },
+      "Bcc": {
+        "emails": [],
+        "names": []
+      }
     },
     "datetime": "",
     "subject": "",
@@ -210,8 +224,8 @@ function extractFromPayload( payload ) {
       const addresses  = emailService.parseAddressHeader( header.value ); // java.util.List<EmailServiceWrapper.InternetAddressWrapper>
       if ( addresses !== null && addresses.length !== 0 ) {
         addresses.forEach( addr => {
-          message.recipients.emails.push( addr.getAddress() );
-          message.recipients.names.push( addr.getPersonal() );
+          message.recipients[header.name].emails.push( addr.getAddress() );
+          message.recipients[header.name].names.push( addr.getPersonal() );
         });
       }
     }

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -71,6 +71,7 @@ function main(){
   //// == 演算 / Calculating ==
   const hasNoDefs = Object.values(defs).every( def => def === null );
   if ( hasNoDefs ) return; // 保存先データ項目が１つも設定されていなければ何もせず正常終了
+
   const apiUri = determineApiUri( messageId );
   const message = getMessage( apiUri, auth );
 
@@ -111,12 +112,24 @@ function retrieveMessageId() {
 
 /**
   * config から保存先データ項目の ProcessDataDefinitionView を読み出す
+  * 値を保存するデータ項目が重複して設定されている場合はエラーとする
   * @return {Object} defs  保存先データ項目の ProcessDataDefinitionView を格納した JSON オブジェクト
   */
 function retrieveDefs() {
   const items = ["fromAddress", "fromName", "recipientAddresses", "recipientNames", "sentDatetime", "subject", "body", "attachments"];
   const defs = {};
-  items.forEach( item => defs[`${item}Def`] = configs.getObject(`conf_${item}`) );
+  const dataItemNumList = []; // データ項目の重複確認用
+  items.forEach( item => {
+    const dataItemDef = configs.getObject(`conf_${item}`);
+    if ( dataItemDef !== null ) { // データ項目が設定されている場合は重複を確認する
+      const dataItemNum = dataItemDef.getNumber();
+      if ( dataItemNumList.indexOf( dataItemNum ) !== -1 ) { // データ項目番号が重複していればエラー
+        throw "The same data item is set multiple times.";
+      }
+      dataItemNumList.push( dataItemNum ); // データ項目の重複確認用
+    }
+    defs[`${item}Def`] = dataItemDef;
+  });
   return defs;
 }
 
@@ -420,7 +433,7 @@ function getAttachments( apiUri, auth, attachments ) {
     if ( attachment.body.data === undefined ) { // data がなければ、attachmentId から data を取得して格納
       httpCount++;
       if ( httpCount > httpLimit ) {
-        throw "Number of HTTP requests is over the limit";
+        throw "Number of HTTP requests is over the limit.";
       }
       const response = httpClient.begin()
         .authSetting( auth )

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-12-14</last-modified>
+<last-modified>2020-12-17</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -339,14 +339,14 @@ function parseMultiPart( part, attachments ) {
   * @return {Object} file  添付ファイルの情報（添付ファイルのパートでない場合は null）
   */
 function attachment( part, index ) {
-  const disposition = getDisposition( part );
-  const contentType = getContentType( part );
-
-  if ( disposition === null ) {
-    return null;
-  }
   // マルチパート内の先頭パートは添付ファイルとみなさない
   if ( index === 0 ) {
+    return null;
+  }
+
+  const disposition = getDisposition( part );
+  const contentType = getContentType( part );
+  if ( disposition === null ) { // 添付ファイルとみなさない
     return null;
   }
   if ( disposition === "attachment" ) { // ファイル名がなくても添付ファイルとみなす
@@ -381,6 +381,9 @@ function attachment( part, index ) {
   * @return {String} disposition  "Content-Disposition" ヘッダの値（ヘッダが無い場合は null）
   */
 function getDisposition( part ) {
+  if ( part.headers === undefined ) { // パートにヘッダが無い場合は null を返す
+    return null;
+  }
   const dispositionHeaders = part.headers.filter( header => {
     if ( header.name === "Content-Disposition" ) {
           return true;
@@ -399,6 +402,9 @@ function getDisposition( part ) {
   * @return {String} contentType  "Content-Type" ヘッダの値
   */
 function getContentType( part ) {
+  if ( part.headers === undefined ) { // パートにヘッダが無い場合はデフォルト値を返す
+    return "application/octet-stream"; // Default
+  }
   const contentTypeHeaders = part.headers.filter( header => {
     if ( header.name === "Content-Type" ) {
           return true;

--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2020-12-25</last-modified>
+<last-modified>2020-12-28</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>Get an email message in Gmail.</summary>
@@ -360,13 +360,16 @@ function attachment( part, index ) {
 /**
   * MIME メールのパートの "Content-Disposition" ヘッダの値を返す
   * @param {Object} part  パート
-  * @return {String} disposition  "Content-Disposition" ヘッダの値（ヘッダが無い場合は undefined）
+  * @return {String} disposition  "Content-Disposition" ヘッダの値（ヘッダが無い場合は null）
   */
 function getDisposition( part ) {
   if ( part.headers === undefined ) { // パートにヘッダが無い場合は null を返す
     return null;
   }
   const dispositionHeader = part.headers.find( header => header.name.toLowerCase() === "content-disposition" );
+  if ( dispositionHeader === undefined ) { // 無い場合は null を返す
+    return null;
+  }
   return dispositionHeader.value.split(";")[0].toLowerCase();
 }
 


### PR DESCRIPTION
以下の点を修正しました。
* 未設定の保存先データ項目があっても動作するように
* To/Cc/Bcc のメールアドレス、表示名一覧が To → Cc → Bcc の順になるように

未対応事項
* アイコンの設定（IconMaker への登録待ち）