### PR TITLE
t7394:Google ドライブ: フォルダ検索　エンジンを Nashorn から GraalJS に変更する

### DIFF
--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -23,11 +23,11 @@
     <label locale="ja">C3: 検索するフォルダの名称</label>
   </config>
   <config name="FolderIdItem" form-type="SELECT" select-data-type="STRING">
-    <label>C4: String type data Item that will save Folder ID</label>
+    <label>C4: String type data item that will save Folder ID</label>
     <label locale="ja">C4: 検索したフォルダの ID を保存する文字型データ項目</label>
   </config>
   <config name="WebViewUrlItem" form-type="SELECT" select-data-type="STRING">
-    <label>C5: String type data Item that will save web view url of Folder</label>
+    <label>C5: String type data item that will save web view url of Folder</label>
     <label locale="ja">C5: 検索したフォルダの表示 URL を保存する文字型データ項目</label>
   </config>
 </configs>
@@ -44,8 +44,8 @@ function main() {
     throw "Folder Name is blank";
   }
   //get C4&C5
-  const idData = configs.get("FolderIdItem");
-  const urlData = configs.get("WebViewUrlItem");
+  const idData = configs.getObject("FolderIdItem");
+  const urlData = configs.getObject("WebViewUrlItem");
   //If neither C4 nor C5 are set,throw error
   if (idData === null && urlData === null) {
     throw "Neither of Data Items to save result are set.";
@@ -69,14 +69,11 @@ function main() {
   const folderIdsStr = folderIdList.join("\n");
   const folderInfoStr = folderUrlList.join("\n");
 
-  const idDataDef = engine.findDataDefinitionByNumber(idData);
-  const urlDataDef = engine.findDataDefinitionByNumber(urlData);
-
   //set ID to Data Item
-  setIdData(idDataDef, folderIdsStr, folderNum);
+  setFolderData(idData, folderIdsStr, folderNum);
 
   //set URL to Data Item
-  setFolderData(urlDataDef, folderInfoStr, folderNum);
+  setFolderData(urlData, folderInfoStr, folderNum);
 }
 
 /**
@@ -110,29 +107,13 @@ function searchFolder(oauth, q) {
 }
 
 /**
- * フォルダIDをデータ項目にセットする
- * @param {ProcessDataDefinitionView} idDataDef 保存先データ項目の ProcessDataDefinitionView
- * @param {String} folderIdsStr 保存するフォルダ ID
- * @param {Number} folderNum フォルダの数
- */
-function setIdData(idDataDef, folderIdsStr, folderNum) {
-  if (idDataDef !== null) {
-    //Multiple Judge
-    if (idDataDef.matchDataType("STRING_TEXTFIELD") && folderNum > 1) {
-      throw "Multiple folders are found. Can't set data to single-line string type data item.";
-    }
-    engine.setData(idDataDef, folderIdsStr);
-  }
-}
-
-/**
  * フォルダの情報をデータ項目にセットする
  * @param {ProcessDataDefinitionView} dataDef 保存先データ項目の ProcessDataDefinitionView
- * @param {Object} folderInfoStr 保存するフォルダ情報
+ * @param {String} folderInfoStr 保存するフォルダ情報
  * @param {Number} folderNum フォルダの数
  */
 function setFolderData(dataDef, folderInfoStr, folderNum) {
-  if (dataDef != null && dataDef != "") {
+  if (dataDef !== null) {
     //Multiple Judge
     if (dataDef.matchDataType("STRING_TEXTFIELD") && folderNum > 1) {
       throw "Multiple folders are found.Can't set data to single-line string Data Item.";

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-12-07</last-modified>
+<last-modified>2020-12-10</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Drive: Search Folder</label>
@@ -24,10 +24,10 @@
   </config>
   <config name="FolderIdItem" form-type="SELECT" select-data-type="STRING">
     <label>C4: Data Item that will save Folder ID</label>
-    <label locale="ja">C4: 検索したフォルダの ID を保存するデータ項目</label>
+    <label locale="ja">C4: 検索したフォルダの ID を保存する文字型データ項目</label>
   </config>
   <config name="WebViewUrlItem" form-type="SELECT" select-data-type="STRING">
-    <label>C5: Data Item that will save web view url of Folder</label>
+    <label>C5: String type data Item that will save web view url of Folder</label>
     <label locale="ja">C5: 検索したフォルダの表示 URL を保存するデータ項目</label>
   </config>
 </configs>
@@ -55,54 +55,45 @@ function main() {
   }
   const oauth = configs.get("OAuth");
 
-  // get OAuth token
-  let token;
-  token = httpClient.getOAuth2Token(oauth);
   const folderNameRep = folderName.replace(/['\\]/g, "\\$&");
-  const q =
-    "mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '" +
-    folderNameRep +
-    "' and '" +
-    parentFolderId +
-    "' in parents";
-  const json = searchFolder(token, q);
+  const q = `mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '${folderNameRep}' and '${parentFolderId}' in parents`;
+  const json = searchFolder(oauth, q);
 
-  let folderIdList;
-  let folderUrlList;
   const fileNum = json.files.length;
-  if (fileNum == 0) {
-    throw "Folder " + folderName + " doesn't exist.";
+  if (fileNum === 0) {
+    throw `Could not found Folder ${folderName} with Parent Folder ID ${parentFolderId}`;
   }
+  const folderIdList = [];
+  const folderUrlList = [];
   for (let i = 0; i < fileNum; i++) {
-    if (i > 0) {
-      folderIdList += "\n";
-      folderUrlList += "\n";
-    }
-    folderIdList += json.files[i].id;
-    folderUrlList += json.files[i].webViewLink;
+    folderIdList.push(json.files[i].id);
+    folderUrlList.push(json.files[i].webViewLink);
   }
+  const folderIdsStr = folderIdList.join("\n");
+  const folderUrlsStr = folderUrlList.join("\n");
 
   //set ID to Data Item
-  idtoDataItem(idData, folderIdList, fileNum);
+  setIdData(idData, folderIdsStr, fileNum);
 
   //set URL to Data Item
-  urltoDataItem(urlData, folderUrlList, fileNum);
+  setUrlData(urlData, folderUrlsStr, fileNum);
 }
 
 /**
  * Google ドライブのフォルダを検索
- * @param {String} token OAuth2 Access Token を取得する
- * @param {String} q MIMEタイプ
+ * @param {String} oauth OAuth2 Access Token を取得する
+ * @param {String} q 検索クエリ
+ * @return {Object} jsonRes レスポンス本文の JSON オブジェクト
  */
-function searchFolder(token, q) {
+function searchFolder(oauth, q) {
   const url = "https://www.googleapis.com/drive/v3/files";
   const response = httpClient
     .begin()
-    .bearer(token)
+    .authSetting(oauth)
     .queryParam("q", q)
-    .queryParam("pageSize", String(1000))
+    .queryParam("pageSize", "1000")
     .queryParam("fields", "files(id,webViewLink)")
-    .queryParam("includeTeamDriveItems", "true")
+    .queryParam("incluedeItemsFromAllDrives", "true")
     .queryParam("supportsAllDrives", "true")
     .get(url);
   const status = response.getStatusCode();
@@ -114,41 +105,41 @@ function searchFolder(token, q) {
   }
   engine.log("status:" + status);
 
-  jsonRes = JSON.parse(responseTxt);
+  const jsonRes = JSON.parse(responseTxt);
   return jsonRes;
 }
 
 /**
  * フォルダIDを配列にセットする
- * @param {String} idData フォルダID
- * @param {Object} folderIdList フォルダIDを格納する配列
- * @param {String} fileNum ファイル番号
+ * @param {String} idData 検索したフォルダの ID
+ * @param {Object} folderIdsStr フォルダ ID を格納する配列のオブジェクト
+ * @param {String} fileNum 検索したフォルダの数
  */
-function idtoDataItem(idData, folderIdList, fileNum) {
+function setIdData(idData, folderIdsStr, fileNum) {
   if (idData != null && idData != "") {
     const idDataDef = engine.findDataDefinitionByNumber(idData);
     //Multiple Judge
     if (idDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
       throw "Multiple folders are found.Can't set data to single-line string Data Item.";
     }
-    engine.setDataByNumber(idData, folderIdList);
+    engine.setDataByNumber(idData, folderIdsStr);
   }
 }
 
 /**
  * フォルダURLを配列セットする
- * @param {String} urlData フォルダURL
- * @param {Object} folderUrlList フォルダURLを格納する配列
- * @param {String} fileNum ファイル番号
+ * @param {String} urlData 検索したフォルダの表示 URL
+ * @param {Object} folderUrlsStr フォルダ URL を格納する配列のオブジェクト
+ * @param {String} fileNum 検索したフォルダの数
  */
-function urltoDataItem(urlData, folderUrlList, fileNum) {
+function setUrlData(urlData, folderUrlsStr, fileNum) {
   if (urlData != null && urlData != "") {
     const urlDataDef = engine.findDataDefinitionByNumber(urlData);
     //Multiple Judge
     if (urlDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
       throw "Multiple folders are found.Can't set data to single-line string Data Item.";
     }
-    engine.setDataByNumber(urlData, folderUrlList);
+    engine.setDataByNumber(urlData, folderUrlsStr);
   }
 }
 

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-12-14</last-modified>
+<last-modified>2020-12-15</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Drive: Search Folder</label>

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-07-01</last-modified>
+<last-modified>2020-12-07</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>1</engine-type>
+<engine-type>2</engine-type>
 <label>Google Drive: Search Folder</label>
 <label locale="ja">Google ドライブ: フォルダ検索</label>
 <summary>Search for the folder with the specific name, directly under the specified folder on Google Drive.</summary>
@@ -34,85 +34,122 @@
 
 <script><![CDATA[
 main();
-function main(){
+function main() {
   let parentFolderId = configs.get("ParentFolderId");
-  if (parentFolderId == "" ||parentFolderId == null) {
+  if (parentFolderId === "" || parentFolderId === null) {
     parentFolderId = "root";
   }
   const folderName = configs.get("FolderName");
-  if (folderName == "" ||folderName == null) {
+  if (folderName === "" || folderName === null) {
     throw "Folder Name is blank";
   }
   //get C4&C5
   const idData = configs.get("FolderIdItem");
   const urlData = configs.get("WebViewUrlItem");
   //If neither C4 nor C5 are set,throw error
-  if((idData === null || idData === "") && (urlData === null || urlData === "")){
+  if (
+    (idData === null || idData === "") &&
+    (urlData === null || urlData === "")
+  ) {
     throw "Neither of Data Items to save result are set.";
   }
   const oauth = configs.get("OAuth");
 
   // get OAuth token
   let token;
-  token = httpClient.getOAuth2Token( oauth );
-  const folderNameRep = folderName.replace(/['\\]/g,"\\$&");
-  const q = "mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '" + folderNameRep + "' and '" + parentFolderId + "' in parents";
-  const json = searchFolder(token,q);
-  
-  let folderIdList = "";
-  let folderUrlList = "";
+  token = httpClient.getOAuth2Token(oauth);
+  const folderNameRep = folderName.replace(/['\\]/g, "\\$&");
+  const q =
+    "mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '" +
+    folderNameRep +
+    "' and '" +
+    parentFolderId +
+    "' in parents";
+  const json = searchFolder(token, q);
+
+  let folderIdList;
+  let folderUrlList;
   const fileNum = json.files.length;
-  if (fileNum == 0){
+  if (fileNum == 0) {
     throw "Folder " + folderName + " doesn't exist.";
   }
-  for(let i = 0; i < fileNum; i++){
-    if (i > 0){
+  for (let i = 0; i < fileNum; i++) {
+    if (i > 0) {
       folderIdList += "\n";
       folderUrlList += "\n";
     }
     folderIdList += json.files[i].id;
     folderUrlList += json.files[i].webViewLink;
   }
+
   //set ID to Data Item
-  if (idData != null && idData != "") {
-    const idDataDef = engine.findDataDefinitionByNumber(idData);
-    //Multiple Judge
-    if(idDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1){
-      throw "Multiple folders are found.Can't set data to single-line string Data Item."
-    }
-    engine.setDataByNumber(idData,folderIdList);
-  }
+  idtoDataItem(idData, folderIdList, fileNum);
+
   //set URL to Data Item
-  if (urlData != null && urlData != "") {
-    const urlDataDef = engine.findDataDefinitionByNumber(urlData);
-    //Multiple Judge
-    if(urlDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1){
-      throw "Multiple folders are found.Can't set data to single-line string Data Item."
-    }
-    engine.setDataByNumber(urlData,folderUrlList);
-  }
+  urltoDataItem(urlData, folderUrlList, fileNum);
 }
-//search folder on google drive
+
+/**
+ * Google ドライブのフォルダを検索
+ * @param {String} token OAuth2 Access Token を取得する
+ * @param {String} q MIMEタイプ
+ */
 function searchFolder(token, q) {
-  const url = 'https://www.googleapis.com/drive/v3/files';
-  const response = httpClient.begin()
+  const url = "https://www.googleapis.com/drive/v3/files";
+  const response = httpClient
+    .begin()
     .bearer(token)
-    .queryParam("q",q)
-    .queryParam("pageSize",1000)
+    .queryParam("q", q)
+    .queryParam("pageSize", String(1000))
     .queryParam("fields", "files(id,webViewLink)")
-    .queryParam("includeTeamDriveItems","true")
-    .queryParam("supportsTeamDrives","true")
+    .queryParam("includeTeamDriveItems", "true")
+    .queryParam("supportsAllDrives", "true")
     .get(url);
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
   if (status >= 300) {
-    const error = "Failed to search \n status:" + status + "\n" + responseTxt;
+    const error = `Failed to search\nstatus:${status}`;
+    engine.log(responseTxt);
     throw error;
   }
-  engine.log("status:" + status + "\n" + responseTxt);
-  
+  engine.log("status:" + status);
+
   jsonRes = JSON.parse(responseTxt);
   return jsonRes;
+}
+
+/**
+ * フォルダIDを配列にセットする
+ * @param {String} idData フォルダID
+ * @param {Object} folderIdList フォルダIDを格納する配列
+ * @param {String} fileNum ファイル番号
+ */
+function idtoDataItem(idData, folderIdList, fileNum) {
+  if (idData != null && idData != "") {
+    const idDataDef = engine.findDataDefinitionByNumber(idData);
+    //Multiple Judge
+    if (idDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
+      throw "Multiple folders are found.Can't set data to single-line string Data Item.";
+    }
+    engine.setDataByNumber(idData, folderIdList);
+  }
+}
+
+/**
+ * フォルダURLを配列セットする
+ * @param {String} urlData フォルダURL
+ * @param {Object} folderUrlList フォルダURLを格納する配列
+ * @param {String} fileNum ファイル番号
+ */
+function urltoDataItem(urlData, folderUrlList, fileNum) {
+  if (urlData != null && urlData != "") {
+    const urlDataDef = engine.findDataDefinitionByNumber(urlData);
+    //Multiple Judge
+    if (urlDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
+      throw "Multiple folders are found.Can't set data to single-line string Data Item.";
+    }
+    engine.setDataByNumber(urlData, folderUrlList);
+  }
 }
 
 ]]></script>

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-12-10</last-modified>
+<last-modified>2020-12-14</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Drive: Search Folder</label>
@@ -11,8 +11,8 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/addons/googledrive-foldersearch/</help-page-url>
 <configs>
   <config name="OAuth" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/drive.metadata.readonly">
-    <label>C1: OAuth2 Setting Name</label>
-    <label locale="ja">C1: OAuth2設定名</label>
+    <label>C1: OAuth2 Setting</label>
+    <label locale="ja">C1: OAuth2設定</label>
   </config>
   <config name="ParentFolderId" el-enabled="true">
     <label>C2: Parent Folder ID (When empty, search in My Drive root)</label>
@@ -23,12 +23,12 @@
     <label locale="ja">C3: 検索するフォルダの名称</label>
   </config>
   <config name="FolderIdItem" form-type="SELECT" select-data-type="STRING">
-    <label>C4: Data Item that will save Folder ID</label>
+    <label>C4: String type data Item that will save Folder ID</label>
     <label locale="ja">C4: 検索したフォルダの ID を保存する文字型データ項目</label>
   </config>
   <config name="WebViewUrlItem" form-type="SELECT" select-data-type="STRING">
     <label>C5: String type data Item that will save web view url of Folder</label>
-    <label locale="ja">C5: 検索したフォルダの表示 URL を保存するデータ項目</label>
+    <label locale="ja">C5: 検索したフォルダの表示 URL を保存する文字型データ項目</label>
   </config>
 </configs>
 
@@ -47,10 +47,7 @@ function main() {
   const idData = configs.get("FolderIdItem");
   const urlData = configs.get("WebViewUrlItem");
   //If neither C4 nor C5 are set,throw error
-  if (
-    (idData === null || idData === "") &&
-    (urlData === null || urlData === "")
-  ) {
+  if (idData === null && urlData === null) {
     throw "Neither of Data Items to save result are set.";
   }
   const oauth = configs.get("OAuth");
@@ -59,29 +56,32 @@ function main() {
   const q = `mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '${folderNameRep}' and '${parentFolderId}' in parents`;
   const json = searchFolder(oauth, q);
 
-  const fileNum = json.files.length;
-  if (fileNum === 0) {
+  const folderNum = json.files.length;
+  if (folderNum === 0) {
     throw `Could not found Folder ${folderName} with Parent Folder ID ${parentFolderId}`;
   }
   const folderIdList = [];
   const folderUrlList = [];
-  for (let i = 0; i < fileNum; i++) {
+  for (let i = 0; i < folderNum; i++) {
     folderIdList.push(json.files[i].id);
     folderUrlList.push(json.files[i].webViewLink);
   }
   const folderIdsStr = folderIdList.join("\n");
-  const folderUrlsStr = folderUrlList.join("\n");
+  const folderInfoStr = folderUrlList.join("\n");
+
+  const idDataDef = engine.findDataDefinitionByNumber(idData);
+  const urlDataDef = engine.findDataDefinitionByNumber(urlData);
 
   //set ID to Data Item
-  setIdData(idData, folderIdsStr, fileNum);
+  setIdData(idDataDef, folderIdsStr, folderNum);
 
   //set URL to Data Item
-  setUrlData(urlData, folderUrlsStr, fileNum);
+  setFolderData(urlDataDef, folderInfoStr, folderNum);
 }
 
 /**
  * Google ドライブのフォルダを検索
- * @param {String} oauth OAuth2 Access Token を取得する
+ * @param {String} oauth OAuth2 認証設定
  * @param {String} q 検索クエリ
  * @return {Object} jsonRes レスポンス本文の JSON オブジェクト
  */
@@ -110,36 +110,34 @@ function searchFolder(oauth, q) {
 }
 
 /**
- * フォルダIDを配列にセットする
- * @param {String} idData 検索したフォルダの ID
- * @param {Object} folderIdsStr フォルダ ID を格納する配列のオブジェクト
- * @param {String} fileNum 検索したフォルダの数
+ * フォルダIDをデータ項目にセットする
+ * @param {ProcessDataDefinitionView} idDataDef 保存先データ項目の ProcessDataDefinitionView
+ * @param {String} folderIdsStr 保存するフォルダ ID
+ * @param {Number} folderNum フォルダの数
  */
-function setIdData(idData, folderIdsStr, fileNum) {
-  if (idData != null && idData != "") {
-    const idDataDef = engine.findDataDefinitionByNumber(idData);
+function setIdData(idDataDef, folderIdsStr, folderNum) {
+  if (idDataDef !== null) {
     //Multiple Judge
-    if (idDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
-      throw "Multiple folders are found.Can't set data to single-line string Data Item.";
+    if (idDataDef.matchDataType("STRING_TEXTFIELD") && folderNum > 1) {
+      throw "Multiple folders are found. Can't set data to single-line string type data item.";
     }
-    engine.setDataByNumber(idData, folderIdsStr);
+    engine.setData(idDataDef, folderIdsStr);
   }
 }
 
 /**
- * フォルダURLを配列セットする
- * @param {String} urlData 検索したフォルダの表示 URL
- * @param {Object} folderUrlsStr フォルダ URL を格納する配列のオブジェクト
- * @param {String} fileNum 検索したフォルダの数
+ * フォルダの情報をデータ項目にセットする
+ * @param {ProcessDataDefinitionView} dataDef 保存先データ項目の ProcessDataDefinitionView
+ * @param {Object} folderInfoStr 保存するフォルダ情報
+ * @param {Number} folderNum フォルダの数
  */
-function setUrlData(urlData, folderUrlsStr, fileNum) {
-  if (urlData != null && urlData != "") {
-    const urlDataDef = engine.findDataDefinitionByNumber(urlData);
+function setFolderData(dataDef, folderInfoStr, folderNum) {
+  if (dataDef != null && dataDef != "") {
     //Multiple Judge
-    if (urlDataDef.matchDataType("STRING_TEXTFIELD") && fileNum > 1) {
+    if (dataDef.matchDataType("STRING_TEXTFIELD") && folderNum > 1) {
       throw "Multiple folders are found.Can't set data to single-line string Data Item.";
     }
-    engine.setDataByNumber(urlData, folderUrlsStr);
+    engine.setData(dataDef, folderInfoStr);
   }
 }
 

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2020-12-15</last-modified>
+<last-modified>2020-12-17</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Drive: Search Folder</label>
@@ -44,10 +44,10 @@ function main() {
     throw "Folder Name is blank";
   }
   //get C4&C5
-  const idData = configs.getObject("FolderIdItem");
-  const urlData = configs.getObject("WebViewUrlItem");
+  const idDataDef = configs.getObject("FolderIdItem");
+  const urlDataDef = configs.getObject("WebViewUrlItem");
   //If neither C4 nor C5 are set,throw error
-  if (idData === null && urlData === null) {
+  if (idDataDef === null && urlDataDef === null) {
     throw "Neither of Data Items to save result are set.";
   }
   const oauth = configs.get("OAuth");
@@ -58,7 +58,7 @@ function main() {
 
   const folderNum = json.files.length;
   if (folderNum === 0) {
-    throw `Could not found Folder ${folderName} with Parent Folder ID ${parentFolderId}`;
+    throw `Could not find Folder ${folderName} with Parent Folder ID ${parentFolderId}`;
   }
   const folderIdList = [];
   const folderUrlList = [];
@@ -67,13 +67,13 @@ function main() {
     folderUrlList.push(json.files[i].webViewLink);
   }
   const folderIdsStr = folderIdList.join("\n");
-  const folderInfoStr = folderUrlList.join("\n");
+  const folderUrlsStr = folderUrlList.join("\n");
 
   //set ID to Data Item
-  setFolderData(idData, folderIdsStr, folderNum);
+  setFolderData(idDataDef, folderIdsStr, folderNum);
 
   //set URL to Data Item
-  setFolderData(urlData, folderInfoStr, folderNum);
+  setFolderData(urlDataDef, folderUrlsStr, folderNum);
 }
 
 /**


### PR DESCRIPTION
以下の点を修正しました。
- GraasJSに対応
- TypeErrorを解消
httpClient の queryParam の数字で型変換エラーが発生。明示的に String にキャストすることで解消。既知のバグ。

103行目
```
.queryParam("pageSize", 1000)
```
↓
```
.queryParam("pageSize", String(1000))
```