### PR TITLE
Update slack-chat-post-webhook.xml

### DIFF
--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2019-01-21</last-modified>
+<last-modified>2021-01-12</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>1</engine-type>
+<engine-type>2</engine-type>
 <label>Slack: Post Chat (Incoming Webhook)</label>
 <label locale="ja">Slack: チャット投稿 (Incoming Webhook)</label>
 <summary>Send a message to Slack with Incoming Webhook.</summary>
@@ -68,12 +68,11 @@ if (configs.get("Text") !== "" && configs.get("Text") !== null){
 
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
-  if (status >= 300) {
-    const error = "Failed to send \n status:" + status + "\n" + responseTxt;
+  if (status !== 200) {
+  engine.log(`${responseTxt}`);
+  throw `Failed to send. status: ${status}`;
     throw error;
   }
-  engine.log("status:" + status);
-  engine.log(responseTxt);
 }
 function attachAdd(attachment, config, attachName){
   const value = configs.get(config);


### PR DESCRIPTION
畠中さん

ソースコードを修正しました。よろしくお願いいたします。

　engineを2に変更しました。
　status >= 300　の時にエラー文言を出力していたので、status != 200　に変更しました。