### PR TITLE
T7395:文字型データ項目に保存する場合のみ、Meet URL を作成

### DIFF
--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -39,8 +39,8 @@
     <label locale="ja">C7: 説明情報</label>
   </config>
   <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: Data item that will save Google Calendar URL</label>
-    <label locale="ja">C8: Google カレンダー の URL を保存するデータ項目</label>
+    <label>C8: Data item that will save Event URL</label>
+    <label locale="ja">C8: 予定の URL を保存するデータ項目</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C9: Data item that will save Google Meet URL</label>

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -23,11 +23,11 @@
     <label locale="ja">C3: 予定タイトル</label>
   </config>
   <config name="conf_DataIdD" required="true" form-type="SELECT" select-data-type="DATETIME">
-    <label>C4: Datetime type data item for Event Start</label>
+    <label>C4: Data item for Event Start Datetime</label>
     <label locale="ja">C4: 予定開始時刻が格納されているデータ項目</label>
   </config>
   <config name="conf_DataIdE" required="false" form-type="SELECT"  select-data-type="DATETIME">
-    <label>C5: Datetime type data item for Event End (Not-selected +1:00)</label>
+    <label>C5: Data item for Event End Datetime (Not-selected +1:00)</label>
     <label locale="ja">C5: 予定終了時刻が格納されているデータ項目 (未設定の場合、+1:00)</label>
   </config>
   <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
@@ -39,11 +39,11 @@
     <label locale="ja">C7: 説明情報</label>
   </config>
   <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: String type data item that will save Google Calendar URL</label>
+    <label>C8: Data item that will save Google Calendar URL</label>
     <label locale="ja">C8: Google カレンダー の URL を保存するデータ項目</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C9: String type data item that will save Google Meet URL</label>
+    <label>C9: Data item that will save Google Meet URL</label>
     <label locale="ja">C9: Google Meet の URL を保存するデータ項目</label>
   </config>
 </configs>
@@ -121,8 +121,8 @@ function main() {
  * @param {String} eventDescription 説明情報
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
- * @param {HttpResponseWrapper} eventUrlDataDef Calendar URL を保存する文字型データ項目
- * @param {HttpResponseWrapper} meetUrlDataDef Meet URL を保存する文字型データ項目
+ * @param {ProcessDataDefinitionView} eventUrlDataDef Calendar URL を保存する文字型データ項目
+ * @param {ProcessDataDefinitionView} meetUrlDataDef Meet URL を保存する文字型データ項目
  */
 function insertEvent(
   quser,

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -24,11 +24,11 @@
   </config>
   <config name="conf_DataIdD" required="true" form-type="SELECT" select-data-type="DATETIME">
     <label>C4: Datetime type data item for Event Start</label>
-    <label locale="ja">C4: 予定開始時刻が格納されている日時型データ</label>
+    <label locale="ja">C4: 予定開始時刻が格納されているデータ項目</label>
   </config>
   <config name="conf_DataIdE" required="false" form-type="SELECT"  select-data-type="DATETIME">
     <label>C5: Datetime type data item for Event End (Not-selected +1:00)</label>
-    <label locale="ja">C5: 予定終了時刻が格納されている日時型データ項目 (未設定の場合、+1:00)</label>
+    <label locale="ja">C5: 予定終了時刻が格納されているデータ項目 (未設定の場合、+1:00)</label>
   </config>
   <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
     <label>C6: Location</label>
@@ -40,7 +40,7 @@
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C8: String type data item that will save Google Meet URL</label>
-    <label locale="ja">C8: Google Meet の URL を保存する文字型データデータ項目</label>
+    <label locale="ja">C8: Google Meet の URL を保存するデータ項目</label>
   </config>
 </configs>
  

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-05</last-modified>
+<last-modified>2021-03-09</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -38,9 +38,13 @@
     <label>C7: Description</label>
     <label locale="ja">C7: 説明情報</label>
   </config>
+  <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
+    <label>C8: String type data item that will save Google Calendar URL</label>
+    <label locale="ja">C8: Google カレンダー の URL を保存するデータ項目</label>
+  </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: String type data item that will save Google Meet URL</label>
-    <label locale="ja">C8: Google Meet の URL を保存するデータ項目</label>
+    <label>C9: String type data item that will save Google Meet URL</label>
+    <label locale="ja">C9: Google Meet の URL を保存するデータ項目</label>
   </config>
 </configs>
  
@@ -79,6 +83,7 @@ function main() {
     eventDescription = "";
   }
 
+  const eventUrlDataDef = configs.getObject("conf_eventUrl");
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 演算 / Calculating ==
@@ -102,6 +107,7 @@ function main() {
     eventDescription,
     startDate,
     endDate,
+    eventUrlDataDef,
     meetUrlDataDef
   );
 }
@@ -115,6 +121,7 @@ function main() {
  * @param {String} eventDescription 説明情報
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
+ * @param {HttpResponseWrapper} eventUrlDataDef Calendar URL を保存する文字型データ項目
  * @param {HttpResponseWrapper} meetUrlDataDef Meet URL を保存する文字型データ項目
  */
 function insertEvent(
@@ -125,6 +132,7 @@ function insertEvent(
   eventDescription,
   startDate,
   endDate,
+  eventUrlDataDef,
   meetUrlDataDef
 ) {
   const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
@@ -166,7 +174,11 @@ function insertEvent(
 
   const responseStr = response.getResponseAsString();
   const eventJson = JSON.parse(responseStr);
+  const eventUrl = eventJson.htmlLink;
   const meetUrl = eventJson.hangoutLink;
+  if (eventUrlDataDef !== null) {
+    engine.setData(eventUrlDataDef, eventUrl);
+  }
   if (meetUrlDataDef !== null) {
     engine.setData(meetUrlDataDef, meetUrl);
   }

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -86,23 +86,9 @@ function main() {
   if (endDate.getTime() < startDate.getTime()) {
     throw "Event End Date comes before Event Start Date";
   }
-  const sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-  const eventStart = sdf.format(startDate);
-  const eventEnd = sdf.format(endDate);
-
-  const eventTimeZone = engine.getTimeZoneId();
 
   //// == 予定を追加する / Insert Event ==
-  insertEvent(
-    quser,
-    calendarId,
-    eventSummary,
-    eventLocation,
-    eventDescription,
-    eventStart,
-    eventTimeZone,
-    eventEnd
-  );
+  insertEvent(quser, calendarId, eventSummary, eventLocation, eventDescription);
 }
 
 /**
@@ -112,21 +98,21 @@ function main() {
  * @param {String} eventSummary 予定タイトル
  * @param {String} eventLocation 場所情報
  * @param {String} eventDescription 説明情報
- * @param {String} eventStart 予定開始時刻
- * @param {String} eventTimeZone タイムゾーン
- * @param {String} eventEnd 予定終了時刻
  */
 function insertEvent(
   quser,
   calendarId,
   eventSummary,
   eventLocation,
-  eventDescription,
-  eventStart,
-  eventTimeZone,
-  eventEnd
+  eventDescription
 ) {
   const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
+
+  const sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+  const eventStart = sdf.format(startDate);
+  const eventEnd = sdf.format(endDate);
+
+  const eventTimeZone = engine.getTimeZoneId();
 
   const myObj = {};
   myObj.summary = eventSummary;
@@ -147,24 +133,24 @@ function insertEvent(
   myObj.conferenceData.createRequest.conferenceSolutionKey.type =
     "hangoutsMeet";
 
-  var response = "";
+  let response = null;
 
   if (eventDescription != "" || eventLocation != "") {
-    var response = httpClient
+    response = httpClient
       .begin()
       .googleOAuth2(quser, "Calendar")
       .queryParam("conferenceDataVersion", "1")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
   } else {
-    var response = httpClient
+    response = httpClient
       .begin()
       .googleOAuth2(quser, "Calendar")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
   }
 
-  var status = response.getStatusCode();
+  const status = response.getStatusCode();
   if (status >= 300) {
     const accessLog = `---POST request---${status}\n${response.getResponseAsString()}`;
     engine.log(accessLog);

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-02-26</last-modified>
+<last-modified>2021-03-01</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -11,24 +11,24 @@
  
 <configs>
   <config name="conf_User" required="true" form-type="QUSER">
-    <label>C1: User Who Connects with Google Calendar</label>
+    <label>C1: User Who Connects to Google Calendar</label>
     <label locale="ja">C1: Google カレンダー に接続するユーザ</label>
   </config>
   <config name="conf_DataIdB" form-type="TEXTFIELD">
-    <label>C2: Calendar ID(When empty,inserted to the primary calendar)</label>
-    <label locale="ja">C2: Calendar ID(空白の場合プライマリのカレンダーに追加されます)</label>
+    <label>C2: Calendar ID (When empty, inserted to the primary calendar)</label>
+    <label locale="ja">C2: Calendar ID (空白の場合プライマリのカレンダーに追加されます)</label>
   </config>
   <config name="conf_DataIdC" required="true" el-enabled="true" form-type="TEXTFIELD">
     <label>C3: Event Title</label>
     <label locale="ja">C3: 予定タイトル</label>
   </config>
   <config name="conf_DataIdD" required="true" form-type="SELECT" select-data-type="DATETIME">
-    <label>C4: Select DATETIME DATA for Event Start</label>
+    <label>C4: Datetime type data item for Event Start</label>
     <label locale="ja">C4: 予定開始時刻が格納されている日時型データを選択してください</label>
   </config>
   <config name="conf_DataIdE" required="false" form-type="SELECT"  select-data-type="DATETIME">
-    <label>C5: Select DATETIME DATA for Event End (Not-selected +1:00)</label>
-    <label locale="ja">C5: 予定終了時刻が格納されている日時型データを選択してください（未設定の場合、+1:00）</label>
+    <label>C5: Datetime type data item for Event End (Not-selected +1:00)</label>
+    <label locale="ja">C5: 予定終了時刻が格納されている日時型データを選択してください (未設定の場合、+1:00)</label>
   </config>
   <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
     <label>C6: Location</label>
@@ -39,8 +39,8 @@
     <label locale="ja">C7: 説明情報</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: Select String-type data item that stores Meet URL</label>
-    <label locale="ja">C8: 作られたイベントの Meet URL が格納される文字型データを選択してください。</label>
+    <label>C8: Select String type data item that will save Google Meet URL</label>
+    <label locale="ja">C8: Google Meet の URL を保存する文字型データデータ項目</label>
   </config>
 </configs>
  
@@ -79,6 +79,9 @@ function main() {
     eventDescription = "";
   }
 
+  let response = null;
+  const meetUrlDataDef = configs.getObject("conf_meetUrl");
+
   //// == 演算 / Calculating ==
   if (calendarId.search(/[^\w\.@]/) !== -1) {
     throw "Invalid Calendar ID";
@@ -98,9 +101,16 @@ function main() {
     eventSummary,
     eventLocation,
     eventDescription,
+    response,
+    meetUrlDataDef,
     startDate,
     endDate
   );
+
+  setUrl(response);
+  if (response !== null) {
+    engine.setData(meetUrlDataDef, myObj.hangoutLink);
+  }
 }
 
 /**
@@ -110,8 +120,10 @@ function main() {
  * @param {String} eventSummary 予定タイトル
  * @param {String} eventLocation 場所情報
  * @param {String} eventDescription 説明情報
- * @param {String} startDate 開始日時
- * @param {String} endDate 終了日時
+ * @param {Object} response レスポンス
+ * @param {} meetUrlDataDef Meet URL を保存する文字型データ項目
+ * @param {AddableTimestamp} startDate 開始日時
+ * @param {AddableTimestamp} endDate 終了日時
  */
 function insertEvent(
   quser,
@@ -119,6 +131,8 @@ function insertEvent(
   eventSummary,
   eventLocation,
   eventDescription,
+  response,
+  meetUrlDataDef,
   startDate,
   endDate
 ) {
@@ -139,14 +153,10 @@ function insertEvent(
   myObj.source = {};
   myObj.conferenceData = {};
   myObj.conferenceData.createRequest = {};
-  myObj.conferenceData.createRequest.requestId =
-    "q-" + processInstance.getProcessInstanceId();
+  myObj.conferenceData.createRequest.requestId = `q-${processInstance.getProcessInstanceId()}`;
   myObj.conferenceData.createRequest.conferenceSolutionKey = {};
   myObj.conferenceData.createRequest.conferenceSolutionKey.type =
     "hangoutsMeet";
-
-  let response = null;
-  const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   if (meetUrlDataDef !== null) {
     response = httpClient
@@ -155,7 +165,7 @@ function insertEvent(
       .queryParam("conferenceDataVersion", "1")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
-    engine.setData(meetUrlDataDef, myObj.hangoutLink);
+    return response;
   } else {
     response = httpClient
       .begin()

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-04</last-modified>
+<last-modified>2021-03-05</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -11,7 +11,7 @@
  
 <configs>
   <config name="conf_User" required="true" form-type="QUSER">
-    <label>C1: User Who Connects to Google Calendar</label>
+    <label>C1: User who connects to Google Calendar</label>
     <label locale="ja">C1: Google カレンダー に接続するユーザ</label>
   </config>
   <config name="conf_DataIdB" form-type="TEXTFIELD">
@@ -24,11 +24,11 @@
   </config>
   <config name="conf_DataIdD" required="true" form-type="SELECT" select-data-type="DATETIME">
     <label>C4: Datetime type data item for Event Start</label>
-    <label locale="ja">C4: 予定開始時刻が格納されている日時型データを選択してください</label>
+    <label locale="ja">C4: 予定開始時刻が格納されている日時型データ</label>
   </config>
   <config name="conf_DataIdE" required="false" form-type="SELECT"  select-data-type="DATETIME">
     <label>C5: Datetime type data item for Event End (Not-selected +1:00)</label>
-    <label locale="ja">C5: 予定終了時刻が格納されている日時型データを選択してください (未設定の場合、+1:00)</label>
+    <label locale="ja">C5: 予定終了時刻が格納されている日時型データ項目 (未設定の場合、+1:00)</label>
   </config>
   <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
     <label>C6: Location</label>
@@ -39,7 +39,7 @@
     <label locale="ja">C7: 説明情報</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: Select String type data item that will save Google Meet URL</label>
+    <label>C8: String type data item that will save Google Meet URL</label>
     <label locale="ja">C8: Google Meet の URL を保存する文字型データデータ項目</label>
   </config>
 </configs>
@@ -79,6 +79,8 @@ function main() {
     eventDescription = "";
   }
 
+  const meetUrlDataDef = configs.getObject("conf_meetUrl");
+
   //// == 演算 / Calculating ==
   if (calendarId.search(/[^\w\.@]/) !== -1) {
     throw "Invalid Calendar ID";
@@ -91,10 +93,6 @@ function main() {
     throw "Event End Date comes before Event Start Date";
   }
 
-  const response = "";
-
-  const meetUrlDataDef = configs.getObject("conf_meetUrl");
-
   //// == 予定を追加する / Insert Event ==
   insertEvent(
     quser,
@@ -102,10 +100,9 @@ function main() {
     eventSummary,
     eventLocation,
     eventDescription,
-    response,
-    meetUrlDataDef,
     startDate,
-    endDate
+    endDate,
+    meetUrlDataDef
   );
 }
 
@@ -116,10 +113,9 @@ function main() {
  * @param {String} eventSummary 予定タイトル
  * @param {String} eventLocation 場所情報
  * @param {String} eventDescription 説明情報
- * @param {ProcessDataDefinitionView} response レスポンス
- * @param {HttpResponseWrapper} meetUrlDataDef Meet URL を保存する文字型データ項目
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
+ * @param {HttpResponseWrapper} meetUrlDataDef Meet URL を保存する文字型データ項目
  */
 function insertEvent(
   quser,
@@ -127,10 +123,9 @@ function insertEvent(
   eventSummary,
   eventLocation,
   eventDescription,
-  response,
-  meetUrlDataDef,
   startDate,
-  endDate
+  endDate,
+  meetUrlDataDef
 ) {
   const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 
@@ -154,26 +149,19 @@ function insertEvent(
   myObj.conferenceData.createRequest.conferenceSolutionKey.type =
     "hangoutsMeet";
 
+  let request = httpClient.begin().googleOAuth2(quser, "Calendar");
   if (meetUrlDataDef !== null) {
-    response = httpClient
-      .begin()
-      .googleOAuth2(quser, "Calendar")
-      .queryParam("conferenceDataVersion", "1")
-      .body(JSON.stringify(myObj), "application/json")
-      .post(uri);
-  } else {
-    response = httpClient
-      .begin()
-      .googleOAuth2(quser, "Calendar")
-      .body(JSON.stringify(myObj), "application/json")
-      .post(uri);
+    request = request.queryParam("conferenceDataVersion", "1");
   }
+  const response = request
+    .body(JSON.stringify(myObj), "application/json")
+    .post(uri);
 
   const status = response.getStatusCode();
   if (status >= 300) {
     const accessLog = `---POST request---${status}\n${response.getResponseAsString()}`;
     engine.log(accessLog);
-    throw `Failed to insert event.\nstatus:${status}`;
+    throw `Failed to insert event. status:${status}`;
   }
 
   const responseStr = response.getResponseAsString();

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-09</last-modified>
+<last-modified>2021-03-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -38,13 +38,17 @@
     <label>C7: Description</label>
     <label locale="ja">C7: 説明</label>
   </config>
+  <config name="conf_eventId" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
+    <label>C8: Data item that will save Event ID</label>
+    <label locale="ja">C8: 予定 ID を保存するデータ項目</label>
+  </config>
   <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C8: Data item that will save Event URL</label>
-    <label locale="ja">C8: 予定の URL を保存するデータ項目</label>
+    <label>C9: Data item that will save Event URL</label>
+    <label locale="ja">C9: 予定の URL を保存するデータ項目</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C9: Data item that will save Google Meet URL</label>
-    <label locale="ja">C9: Google Meet の URL を保存するデータ項目</label>
+    <label>C10: Data item that will save Google Meet URL</label>
+    <label locale="ja">C10: Google Meet の URL を保存するデータ項目</label>
   </config>
 </configs>
  
@@ -85,6 +89,7 @@ function main() {
 
   const eventUrlDataDef = configs.getObject("conf_eventUrl");
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
+  const eventIdDataDef = configs.getObject("conf_eventId");
 
   //// == 演算 / Calculating ==
   if (calendarId.search(/[^\w\.@]/) !== -1) {
@@ -107,6 +112,7 @@ function main() {
     eventDescription,
     startDate,
     endDate,
+    eventIdDataDef,
     eventUrlDataDef,
     meetUrlDataDef
   );
@@ -121,6 +127,7 @@ function main() {
  * @param {String} eventDescription 説明情報
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
+ * @param {ProcessDataDefinitionView} eventIdDataDef Event ID を保存する文字型データ項目
  * @param {ProcessDataDefinitionView} eventUrlDataDef Calendar URL を保存する文字型データ項目
  * @param {ProcessDataDefinitionView} meetUrlDataDef Meet URL を保存する文字型データ項目
  */
@@ -132,6 +139,7 @@ function insertEvent(
   eventDescription,
   startDate,
   endDate,
+  eventIdDataDef,
   eventUrlDataDef,
   meetUrlDataDef
 ) {
@@ -174,8 +182,12 @@ function insertEvent(
 
   const responseStr = response.getResponseAsString();
   const eventJson = JSON.parse(responseStr);
+  const eventId = eventJson.id;
   const eventUrl = eventJson.htmlLink;
   const meetUrl = eventJson.hangoutLink;
+  if (eventIdDataDef !== null) {
+    engine.setData(eventIdDataDef, eventId);
+  }
   if (eventUrlDataDef !== null) {
     engine.setData(eventUrlDataDef, eventUrl);
   }

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-02-25</last-modified>
+<last-modified>2021-02-26</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -37,6 +37,10 @@
   <config name="conf_DataIdG" required="false" el-enabled="true" form-type="TEXTAREA">
     <label>C7: Description</label>
     <label locale="ja">C7: 説明情報</label>
+  </config>
+  <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
+    <label>C8: Select String-type data item that stores Meet URL</label>
+    <label locale="ja">C8: 作られたイベントの Meet URL が格納される文字型データを選択してください。</label>
   </config>
 </configs>
  
@@ -88,7 +92,15 @@ function main() {
   }
 
   //// == 予定を追加する / Insert Event ==
-  insertEvent(quser, calendarId, eventSummary, eventLocation, eventDescription);
+  insertEvent(
+    quser,
+    calendarId,
+    eventSummary,
+    eventLocation,
+    eventDescription,
+    startDate,
+    endDate
+  );
 }
 
 /**
@@ -98,32 +110,32 @@ function main() {
  * @param {String} eventSummary 予定タイトル
  * @param {String} eventLocation 場所情報
  * @param {String} eventDescription 説明情報
+ * @param {String} startDate 開始日時
+ * @param {String} endDate 終了日時
  */
 function insertEvent(
   quser,
   calendarId,
   eventSummary,
   eventLocation,
-  eventDescription
+  eventDescription,
+  startDate,
+  endDate
 ) {
   const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 
   const sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-  const eventStart = sdf.format(startDate);
-  const eventEnd = sdf.format(endDate);
-
-  const eventTimeZone = engine.getTimeZoneId();
 
   const myObj = {};
   myObj.summary = eventSummary;
   myObj.location = eventLocation;
   myObj.description = eventDescription;
   myObj.start = {};
-  myObj.start.dateTime = eventStart;
-  myObj.start.timeZone = eventTimeZone;
+  myObj.start.dateTime = sdf.format(startDate);
+  myObj.start.timeZone = engine.getTimeZoneId();
   myObj.end = {};
-  myObj.end.dateTime = eventEnd;
-  myObj.end.timeZone = eventTimeZone;
+  myObj.end.dateTime = sdf.format(endDate);
+  myObj.end.timeZone = engine.getTimeZoneId();
   myObj.source = {};
   myObj.conferenceData = {};
   myObj.conferenceData.createRequest = {};
@@ -134,14 +146,16 @@ function insertEvent(
     "hangoutsMeet";
 
   let response = null;
+  const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
-  if (eventDescription != "" || eventLocation != "") {
+  if (meetUrlDataDef !== null) {
     response = httpClient
       .begin()
       .googleOAuth2(quser, "Calendar")
       .queryParam("conferenceDataVersion", "1")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
+    engine.setData(meetUrlDataDef, myObj.hangoutLink);
   } else {
     response = httpClient
       .begin()

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-16</last-modified>
+<last-modified>2021-03-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -30,7 +30,7 @@
     <label>C5: Data item for Event End Datetime (Not-selected +1:00)</label>
     <label locale="ja">C5: 終了時刻が格納されているデータ項目 (未設定の場合、+1:00)</label>
   </config>
-  <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTAREA">
+  <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
     <label>C6: Location</label>
     <label locale="ja">C6: 場所</label>
   </config>
@@ -44,7 +44,7 @@
   </config>
   <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C9: Data item that will save Event URL</label>
-    <label locale="ja">C9: 予定の URL を保存するデータ項目</label>
+    <label locale="ja">C9: 予定 URL を保存するデータ項目</label>
   </config>
   <config name="conf_meetUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C10: Data item that will save Google Meet URL</label>
@@ -87,9 +87,9 @@ function main() {
     eventDescription = "";
   }
 
+  const eventIdDataDef = configs.getObject("conf_eventId");
   const eventUrlDataDef = configs.getObject("conf_eventUrl");
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
-  const eventIdDataDef = configs.getObject("conf_eventId");
 
   //// == 演算 / Calculating ==
   if (calendarId.search(/[^\w\.@]/) !== -1) {
@@ -128,7 +128,7 @@ function main() {
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
  * @param {ProcessDataDefinitionView} eventIdDataDef Event ID を保存する文字型データ項目
- * @param {ProcessDataDefinitionView} eventUrlDataDef Calendar URL を保存する文字型データ項目
+ * @param {ProcessDataDefinitionView} eventUrlDataDef Event URL を保存する文字型データ項目
  * @param {ProcessDataDefinitionView} meetUrlDataDef Meet URL を保存する文字型データ項目
  */
 function insertEvent(

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -169,18 +169,18 @@ function insertEvent(
       .post(uri);
   }
 
-  const responseStr = response.getResponseAsString();
-  const eventJson = JSON.parse(responseStr);
-  const meetUrl = eventJson.hangoutLink;
-  if (meetUrlDataDef !== null) {
-    engine.setData(meetUrlDataDef, meetUrl);
-  }
-
   const status = response.getStatusCode();
   if (status >= 300) {
     const accessLog = `---POST request---${status}\n${response.getResponseAsString()}`;
     engine.log(accessLog);
     throw `Failed to insert event.\nstatus:${status}`;
+  }
+
+  const responseStr = response.getResponseAsString();
+  const eventJson = JSON.parse(responseStr);
+  const meetUrl = eventJson.hangoutLink;
+  if (meetUrlDataDef !== null) {
+    engine.setData(meetUrlDataDef, meetUrl);
   }
 }
 ]]></script>

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-01</last-modified>
+<last-modified>2021-03-04</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -79,9 +79,6 @@ function main() {
     eventDescription = "";
   }
 
-  let response = null;
-  const meetUrlDataDef = configs.getObject("conf_meetUrl");
-
   //// == 演算 / Calculating ==
   if (calendarId.search(/[^\w\.@]/) !== -1) {
     throw "Invalid Calendar ID";
@@ -93,6 +90,10 @@ function main() {
   if (endDate.getTime() < startDate.getTime()) {
     throw "Event End Date comes before Event Start Date";
   }
+
+  const response = "";
+
+  const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 予定を追加する / Insert Event ==
   insertEvent(
@@ -106,11 +107,6 @@ function main() {
     startDate,
     endDate
   );
-
-  setUrl(response);
-  if (response !== null) {
-    engine.setData(meetUrlDataDef, myObj.hangoutLink);
-  }
 }
 
 /**
@@ -165,13 +161,19 @@ function insertEvent(
       .queryParam("conferenceDataVersion", "1")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
-    return response;
   } else {
     response = httpClient
       .begin()
       .googleOAuth2(quser, "Calendar")
       .body(JSON.stringify(myObj), "application/json")
       .post(uri);
+  }
+
+  const responseStr = response.getResponseAsString();
+  const eventJson = JSON.parse(responseStr);
+  const meetUrl = eventJson.hangoutLink;
+  if (meetUrlDataDef !== null) {
+    engine.setData(meetUrlDataDef, meetUrl);
   }
 
   const status = response.getStatusCode();

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -120,8 +120,8 @@ function main() {
  * @param {String} eventSummary 予定タイトル
  * @param {String} eventLocation 場所情報
  * @param {String} eventDescription 説明情報
- * @param {Object} response レスポンス
- * @param {} meetUrlDataDef Meet URL を保存する文字型データ項目
+ * @param {ProcessDataDefinitionView} response レスポンス
+ * @param {HttpResponseWrapper} meetUrlDataDef Meet URL を保存する文字型データ項目
  * @param {AddableTimestamp} startDate 開始日時
  * @param {AddableTimestamp} endDate 終了日時
  */

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -24,19 +24,19 @@
   </config>
   <config name="conf_DataIdD" required="true" form-type="SELECT" select-data-type="DATETIME">
     <label>C4: Data item for Event Start Datetime</label>
-    <label locale="ja">C4: 予定開始時刻が格納されているデータ項目</label>
+    <label locale="ja">C4: 開始時刻が格納されているデータ項目</label>
   </config>
   <config name="conf_DataIdE" required="false" form-type="SELECT"  select-data-type="DATETIME">
     <label>C5: Data item for Event End Datetime (Not-selected +1:00)</label>
-    <label locale="ja">C5: 予定終了時刻が格納されているデータ項目 (未設定の場合、+1:00)</label>
+    <label locale="ja">C5: 終了時刻が格納されているデータ項目 (未設定の場合、+1:00)</label>
   </config>
-  <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTFIELD">
+  <config name="conf_DataIdF" required="false" el-enabled="true" form-type="TEXTAREA">
     <label>C6: Location</label>
-    <label locale="ja">C6: 場所情報</label>
+    <label locale="ja">C6: 場所</label>
   </config>
   <config name="conf_DataIdG" required="false" el-enabled="true" form-type="TEXTAREA">
     <label>C7: Description</label>
-    <label locale="ja">C7: 説明情報</label>
+    <label locale="ja">C7: 説明</label>
   </config>
   <config name="conf_eventUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
     <label>C8: Data item that will save Event URL</label>

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-02-19</last-modified>
+<last-modified>2021-02-25</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -34,7 +34,7 @@
     <label>C6: Location</label>
     <label locale="ja">C6: 場所情報</label>
   </config>
-  <config name="conf_DataIdG" required="false" el-enabled="true" form-type="TEXTFIELD">
+  <config name="conf_DataIdG" required="false" el-enabled="true" form-type="TEXTAREA">
     <label>C7: Description</label>
     <label locale="ja">C7: 説明情報</label>
   </config>
@@ -139,12 +139,30 @@ function insertEvent(
   myObj.end.dateTime = eventEnd;
   myObj.end.timeZone = eventTimeZone;
   myObj.source = {};
+  myObj.conferenceData = {};
+  myObj.conferenceData.createRequest = {};
+  myObj.conferenceData.createRequest.requestId =
+    "q-" + processInstance.getProcessInstanceId();
+  myObj.conferenceData.createRequest.conferenceSolutionKey = {};
+  myObj.conferenceData.createRequest.conferenceSolutionKey.type =
+    "hangoutsMeet";
 
-  const response = httpClient
-    .begin()
-    .googleOAuth2(quser, "Calendar")
-    .body(JSON.stringify(myObj), "application/json")
-    .post(uri);
+  var response = "";
+
+  if (eventDescription != "" || eventLocation != "") {
+    var response = httpClient
+      .begin()
+      .googleOAuth2(quser, "Calendar")
+      .queryParam("conferenceDataVersion", "1")
+      .body(JSON.stringify(myObj), "application/json")
+      .post(uri);
+  } else {
+    var response = httpClient
+      .begin()
+      .googleOAuth2(quser, "Calendar")
+      .body(JSON.stringify(myObj), "application/json")
+      .post(uri);
+  }
 
   var status = response.getStatusCode();
   if (status >= 300) {


### PR DESCRIPTION
以下の変更を行いました。

- 文字型データ項目(`eventDescription`, `eventLocation`)のどちらかが空でない場合、Meet URL を作成。
- 説明情報を`TEXTFIELD`から`TEXTAREA`に変更。