### PR TITLE
検索クエリを構成するロジックの修正

### DIFF
--- a/start_event/kintone-record-datetime-field.xml
+++ b/start_event/kintone-record-datetime-field.xml
@@ -3,7 +3,7 @@
     <addon-type>START_EVENT</addon-type>
     <label>Start: kintone: Record's Datetime Field</label>
     <label locale="ja">開始: kintone: レコード 日時フィールド</label>
-    <last-modified>2021-03-18</last-modified>
+    <last-modified>2021-03-19</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>2</engine-type>
     <summary>Start Process when time in Record's datetime field has passed, on a kintone App. It is able to specify
@@ -223,8 +223,9 @@ const getRecords = (apiUri, apiToken, {
 
     let queryString = `${datetimeField} >= "${datetimeFormatter.format(timestampLowerLimit)}" and ${datetimeField} <= NOW()`;
     if (query !== '') {
-        queryString = `(${query}) and ${queryString} order by ${datetimeField} desc, $id desc limit ${limit}`;
+        queryString = `(${query}) and ${queryString}`;
     }
+    queryString = `${queryString} order by ${datetimeField} desc, $id desc limit ${limit}`;
     engine.log(`query: ${queryString}`);
     request = request.queryParam('query', queryString);
     request = request.queryParam('fields[0]', '$id');


### PR DESCRIPTION
アイテムの設定によっては、order by と limit が入らない状態になっていた。