### PR TITLE
Google カレンダー: 予定追加　ヘルプページ URL の修正

### DIFF
--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-03-18</last-modified>
+<last-modified>2021-04-12</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
 <label locale="ja">Google カレンダー: 予定追加</label>
 <summary>Insert an event to Google Calendar.</summary>
 <summary locale="ja">Google カレンダーに予定を追加します。</summary>
-<help-page-url>https://support.questetra.com/addons/services/googlecalendar-insertevent/</help-page-url>
-<help-page-url locale="ja">https://support.questetra.com/ja/addons/services/googlecalendar-insertevent/</help-page-url>
+<help-page-url>https://support.questetra.com/addons/googlecalendar-insertevent/</help-page-url>
+<help-page-url locale="ja">https://support.questetra.com/ja/addons/googlecalendar-insertevent/</help-page-url>
  
 <configs>
   <config name="conf_User" required="true" form-type="QUSER">


### PR DESCRIPTION
スクリプト部分に変更はなし。