### PR TITLE
T7737 予定 URL を保存できるように

### DIFF
--- a/google-calendar-event-move.xml
+++ b/google-calendar-event-move.xml
@@ -70,7 +70,8 @@ function main() {
         throw "Invalid Source Calendar ID";
     }
 
-    moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef);
+    moveEvent(quser, calendarId, eventId, destination);
+    getHtmlLink(quser, destination, eventId, htmlLinkDataDef);
 }
 
 /**
@@ -80,7 +81,7 @@ function main() {
  * @param {String} eventId 予定ID
  * @param {String} destination 移動先カレンダーID
  */
-function moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef) {
+function moveEvent(quser, calendarId, eventId, destination) {
 
     const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}/move`;
 
@@ -95,23 +96,12 @@ function moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef) {
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();
     engine.log(`Event ID: ${eventId}`);
-    engine.log(`Status: ${status}`);
     if (status >= 300) {
+        engine.log(`Status: ${status}`);
         engine.log(responseStr);
         throw `Failed to move.`;
     }
-    const respJson = JSON.parse(responseStr);
-    const eventStatus = respJson['status'];
-    engine.log(`Succeeded to move: ${eventStatus}`);
-
-    if (htmlLinkDataDef !== null) {
-        if (eventStatus === 'cancelled') {
-            getHtmlLink(quser, destination, eventId, htmlLinkDataDef);
-        } else {
-            const htmlLink = respJson['htmlLink'];
-            engine.setData(htmlLinkDataDef, htmlLink);
-        }
-    }
+    engine.log('Succeeded to move');
 }
 
 /**
@@ -122,6 +112,9 @@ function moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef) {
  * @param htmlLinkDataDef
  */
 function getHtmlLink(quser, calendarId, eventId, htmlLinkDataDef) {
+    if (htmlLinkDataDef === null) {
+        return;
+    }
     const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`;
 
     const response = httpClient.begin()
@@ -131,6 +124,7 @@ function getHtmlLink(quser, calendarId, eventId, htmlLinkDataDef) {
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();
     if (status >= 300) {
+        engine.log(`Status: ${status}`);
         engine.log(responseStr);
         throw `Failed to get htmlLink.`;
     }

--- a/google-calendar-event-move.xml
+++ b/google-calendar-event-move.xml
@@ -44,15 +44,8 @@ function main() {
     if (quser === null) {
         throw `User not found.`;
     }
-    let calendarId = configs.get("conf_CalendarId");
-    if (calendarId === "" || calendarId === null) {
-        calendarId = "primary";
-    }
-
-    const destination = configs.get("conf_Destination");
-    if (destination === "" || destination === null) {
-        calendarId = "primary";
-    }
+    const calendarId = getCalendarId("conf_CalendarId");
+    const destination = getCalendarId("conf_Destination");
 
     const eventId = engine.findData(configs.getObject("conf_EventId"));
     if (eventId === "" || eventId === null) {
@@ -72,6 +65,19 @@ function main() {
 
     moveEvent(quser, calendarId, eventId, destination);
     getHtmlLink(quser, destination, eventId, htmlLinkDataDef);
+}
+
+/**
+ * configs から カレンダー ID を取得する
+ * @param confName 設定名
+ * @returns {string} カレンダー ID
+ */
+function getCalendarId(confName) {
+    let calendarId = configs.get(confName);
+    if (calendarId === "" || calendarId === null) {
+        return "primary";
+    }
+    return calendarId;
 }
 
 /**

--- a/google-calendar-event-move.xml
+++ b/google-calendar-event-move.xml
@@ -1,36 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2021-05-19</last-modified>
-<license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
-<label>Google Calendar: Move Event to another Calendar</label>
-<label locale="ja">Google カレンダー: 予定のカレンダー移動</label>
-<summary>Move an event on Google Calendar to another calendar.</summary>
-<summary locale="ja">Google カレンダーの予定を別のカレンダーに移動します。</summary>
-<help-page-url>https://support.questetra.com/bpmn-icons/service-task-google-calendar-event-move/</help-page-url>
-<help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-calendar-event-move/</help-page-url>
+<?xml version="1.0" encoding="UTF-8"?>
+<service-task-definition>
+    <last-modified>2021-06-17</last-modified>
+    <license>(C) Questetra, Inc. (MIT License)</license>
+    <engine-type>2</engine-type>
+    <label>Google Calendar: Move Event to another Calendar</label>
+    <label locale="ja">Google カレンダー: 予定のカレンダー移動</label>
+    <summary>Move an event on Google Calendar to another calendar.</summary>
+    <summary locale="ja">Google カレンダーの予定を別のカレンダーに移動します。</summary>
+    <help-page-url>https://support.questetra.com/bpmn-icons/service-task-google-calendar-event-move/</help-page-url>
+    <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-calendar-event-move/
+    </help-page-url>
 
-<configs>
-  <config name="conf_User" required="true" form-type="QUSER">
-    <label>C1: User who connects to Google Calendar</label>
-    <label locale="ja">C1: Google カレンダー に接続するユーザ</label>
-  </config>
-  <config name="conf_CalendarId" form-type="TEXTFIELD">
-    <label>C2: Calendar ID of the current event (Primary Calendar if blank)</label>
-    <label locale="ja">C2: 予定の移動元カレンダー ID (空白の場合、プライマリのカレンダー)</label>
-  </config>
-  <config name="conf_Destination" form-type="TEXTFIELD">
-    <label>C3: Destination Calendar ID (Primary Calendar if blank)</label>
-    <label locale="ja">C3: 予定の移動先カレンダー ID (空白の場合、プライマリのカレンダー)</label>
-  </config>
-  <config name="conf_EventId" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-    <label>C4: Event ID</label>
-    <label locale="ja">C4: 予定 ID</label>
-  </config>
-</configs>
+    <configs>
+        <config name="conf_User" required="true" form-type="QUSER">
+            <label>C1: User who connects to Google Calendar</label>
+            <label locale="ja">C1: Google カレンダー に接続するユーザ</label>
+        </config>
+        <config name="conf_CalendarId" form-type="TEXTFIELD">
+            <label>C2: Calendar ID of the current event (Primary Calendar if blank)</label>
+            <label locale="ja">C2: 予定の移動元カレンダー ID (空白の場合、プライマリのカレンダー)</label>
+        </config>
+        <config name="conf_Destination" form-type="TEXTFIELD">
+            <label>C3: Destination Calendar ID (Primary Calendar if blank)</label>
+            <label locale="ja">C3: 予定の移動先カレンダー ID (空白の場合、プライマリのカレンダー)</label>
+        </config>
+        <config name="conf_EventId" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
+            <label>C4: Event ID</label>
+            <label locale="ja">C4: 予定 ID</label>
+        </config>
+        <config name="conf_htmlLink" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
+            <label>C5: Data item to save Event URL</label>
+            <label locale="ja">C5: 予定 URL を保存するデータ項目</label>
+        </config>
+    </configs>
 
 
-<script><![CDATA[
+    <script><![CDATA[
 main();
+
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
     const quser = configs.getObject("conf_User");
@@ -52,6 +59,8 @@ function main() {
         throw "Event ID isn't set";
     }
 
+    const htmlLinkDataDef = configs.getObject("conf_htmlLink");
+
     //// == 演算 / Calculating ==
     if (destination.search(/[^\w\.@]/) !== -1) {
         throw "Invalid Destination Calendar ID";
@@ -60,7 +69,8 @@ function main() {
     if (calendarId.search(/[^\w\.@]/) !== -1) {
         throw "Invalid Source Calendar ID";
     }
-    moveEvent(quser, calendarId, eventId, destination);
+
+    moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef);
 }
 
 /**
@@ -70,13 +80,13 @@ function main() {
  * @param {String} eventId 予定ID
  * @param {String} destination 移動先カレンダーID
  */
-function moveEvent(quser, calendarId, eventId, destination) {
+function moveEvent(quser, calendarId, eventId, destination, htmlLinkDataDef) {
 
     const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}/move`;
 
     const myObj = {};
     myObj.destination = destination;
-    
+
     const response = httpClient.begin()
         .googleOAuth2(quser, "Calendar")
         .body(JSON.stringify(myObj), "application/json")
@@ -90,35 +100,71 @@ function moveEvent(quser, calendarId, eventId, destination) {
         engine.log(responseStr);
         throw `Failed to move.`;
     }
-    engine.log("Succeeded to move");
+    const respJson = JSON.parse(responseStr);
+    const eventStatus = respJson['status'];
+    engine.log(`Succeeded to move: ${eventStatus}`);
+
+    if (htmlLinkDataDef !== null) {
+        if (eventStatus === 'cancelled') {
+            getHtmlLink(quser, destination, eventId, htmlLinkDataDef);
+        } else {
+            const htmlLink = respJson['htmlLink'];
+            engine.setData(htmlLinkDataDef, htmlLink);
+        }
+    }
+}
+
+/**
+ * イベントを再取得し、HTML Link を保存する
+ * @param quser
+ * @param calendarId
+ * @param eventId
+ * @param htmlLinkDataDef
+ */
+function getHtmlLink(quser, calendarId, eventId, htmlLinkDataDef) {
+    const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`;
+
+    const response = httpClient.begin()
+        .googleOAuth2(quser, "Calendar")
+        .get(uri);
+
+    const status = response.getStatusCode();
+    const responseStr = response.getResponseAsString();
+    if (status >= 300) {
+        engine.log(responseStr);
+        throw `Failed to get htmlLink.`;
+    }
+    const respJson = JSON.parse(responseStr);
+    const htmlLink = respJson['htmlLink'];
+    engine.setData(htmlLinkDataDef, htmlLink);
+    engine.log("Succeeded to get htmlLink");
 }
 ]]></script>
- 
- 
-<icon>
-iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEt0lEQVRYR8VXX2xTVRj/ndv2tmv3
-p1cGDyqM8SBRx9jcNBEMW7apSMKYMWoiD9sSEhITQ33AB23DyOaDJmoxGqPRbBgwEhMdUSRKS4ri
-XMA/I4jJhkZQIEhgbdm69ra395hz72572t5u3UbwvDS99/vO+Z3v+/2+77sE//MiCzm/vT/cRYjQ
-AtAGAG4A7JetMQARgIwBJBTwVh4udd95AbT2hd1Wm7CLqtRDiHbovItSRIhA/EpK3RfqkyJzOcwJ
-oO3VcA9RyVulHpx/EAMC0N6gTxouBqIogPb+sJ8Qsmve65ZkQPwBb9WLZqamANoHwkMEpLukvUs0
-oiBDQW9Vb755AQD+5utrrGirs8FmmZcqpjAmp1UcPJlAPKm/ppTuC/okD2+cszPLuUDJoGHwTm85
-1t5p0f5ejaoYnVCwuUGEw2Z+7ZkkcPy3JDautUFyEagUGD6dxHvH4hkHSumTPCcyABjbLRbyF0+4
-D3dWoKZa0Jwvh1WEzqXQ9aAdLrs5gJgMfP2rjLY6EcvK9a2PjiXx5hEeACLpNK011JEB0NEf7gMh
-e4ytm9dY0V4ngpaYYzMzgQBTCYpDIwlcn+J2onRvwCf1MZ8sgIEwKyRVxkb+7nLcf7ce/qWstAp8
-fkrGB8EElwZEgj63lAGgVzjyBX/Q69tdaFxtXcrZmm8qDRwakbH/uyyAWUJqXNAiYKb53VudeKy+
-CNsWAIsp4N1v4/jmzKwUZn0NRWgAOvrDIRDSwu/b0+LAMw/bYeOy8PcNFYOhBG5MqRo/Hq0X4RQB
-Rr7xKwrGLirY1mTHsoqsuCIxijeOzGD0vJILm9ITAZ/UqkdgIHyBgNTwFtuaRexoK8tIjpHp4EkZ
-Tz1kR3UlwU9/KojJVJPc8GkZVU4BlybT6Gyyo5oDwNTzyqcxXJ5U8+M2FvC6G/UIDEQKyL7pXhs8
-T5Shoky/DdM0y6do1Zl7aVLFqT9S6Gy2g7Gdke3Ln5NgfjyA81fTeP6jadOkBbxuUhRA3UoLXu5y
-YXllbhWUFeBaVMWxs0m03idizQq9TjBwZgBGJhTs+Sw2NwCzFNx1h4DnNjrgduUCiMsUCYXi93/S
-WFUtYGW1ThIWgdGJFNatsqLSmfUZv5LGx3kKmFXBmaBPaihKwgdqrXip05mpaPlX+DdK8dUvMrY/
-4tB4UiwCjJi7D5hEIIeEJq23Y50NL2x2aixni/WCHycUbG0SYRWAUgFcvK5ix/tTBSnIkaFZIere
-5MCzG7IyZCRkveDaTRW1KywYGdf7Qu08HGAl+LXDM5pE+WU0paKl2LOlDFsaxWytZu0UwHSC4mac
-YnmFoCnCWAwgAye5BNi556xGvH10BsfPpbjzaTTglbTxrmgz2vu0CxvuuTWl+JMfEjjwvZwFYNaM
-tOHTigtGQ+JngQVU3gLTwpmARhUFqwvaMfPkB5KdHQ48Xi/CsshpyEAyHacYPBFH4KyegqIDieFw
-a4fRvIBwoTfe3MahlO4PeqWe/BzdnrHc5OZzRoBLRxchGOInpYURkkYpRc+iPkyMgzR1WOABgad0
-IDQKCr+Shn9Jn2b5t2UVEwAbIhoo4CaErDcaCwFYT2cfqaG5blwyBxYW6sVb/wdgbxw/u9E3bAAA
-AABJRU5ErkJggg==
-</icon>
- 
+
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEt0lEQVRYR8VXX2xTVRj/ndv2tmv3
+        p1cGDyqM8SBRx9jcNBEMW7apSMKYMWoiD9sSEhITQ33AB23DyOaDJmoxGqPRbBgwEhMdUSRKS4ri
+        XMA/I4jJhkZQIEhgbdm69ra395hz72572t5u3UbwvDS99/vO+Z3v+/2+77sE//MiCzm/vT/cRYjQ
+        AtAGAG4A7JetMQARgIwBJBTwVh4udd95AbT2hd1Wm7CLqtRDiHbovItSRIhA/EpK3RfqkyJzOcwJ
+        oO3VcA9RyVulHpx/EAMC0N6gTxouBqIogPb+sJ8Qsmve65ZkQPwBb9WLZqamANoHwkMEpLukvUs0
+        oiBDQW9Vb755AQD+5utrrGirs8FmmZcqpjAmp1UcPJlAPKm/ppTuC/okD2+cszPLuUDJoGHwTm85
+        1t5p0f5ejaoYnVCwuUGEw2Z+7ZkkcPy3JDautUFyEagUGD6dxHvH4hkHSumTPCcyABjbLRbyF0+4
+        D3dWoKZa0Jwvh1WEzqXQ9aAdLrs5gJgMfP2rjLY6EcvK9a2PjiXx5hEeACLpNK011JEB0NEf7gMh
+        e4ytm9dY0V4ngpaYYzMzgQBTCYpDIwlcn+J2onRvwCf1MZ8sgIEwKyRVxkb+7nLcf7ce/qWstAp8
+        fkrGB8EElwZEgj63lAGgVzjyBX/Q69tdaFxtXcrZmm8qDRwakbH/uyyAWUJqXNAiYKb53VudeKy+
+        CNsWAIsp4N1v4/jmzKwUZn0NRWgAOvrDIRDSwu/b0+LAMw/bYeOy8PcNFYOhBG5MqRo/Hq0X4RQB
+        Rr7xKwrGLirY1mTHsoqsuCIxijeOzGD0vJILm9ITAZ/UqkdgIHyBgNTwFtuaRexoK8tIjpHp4EkZ
+        Tz1kR3UlwU9/KojJVJPc8GkZVU4BlybT6Gyyo5oDwNTzyqcxXJ5U8+M2FvC6G/UIDEQKyL7pXhs8
+        T5Shoky/DdM0y6do1Zl7aVLFqT9S6Gy2g7Gdke3Ln5NgfjyA81fTeP6jadOkBbxuUhRA3UoLXu5y
+        YXllbhWUFeBaVMWxs0m03idizQq9TjBwZgBGJhTs+Sw2NwCzFNx1h4DnNjrgduUCiMsUCYXi93/S
+        WFUtYGW1ThIWgdGJFNatsqLSmfUZv5LGx3kKmFXBmaBPaihKwgdqrXip05mpaPlX+DdK8dUvMrY/
+        4tB4UiwCjJi7D5hEIIeEJq23Y50NL2x2aixni/WCHycUbG0SYRWAUgFcvK5ix/tTBSnIkaFZIere
+        5MCzG7IyZCRkveDaTRW1KywYGdf7Qu08HGAl+LXDM5pE+WU0paKl2LOlDFsaxWytZu0UwHSC4mac
+        YnmFoCnCWAwgAye5BNi556xGvH10BsfPpbjzaTTglbTxrmgz2vu0CxvuuTWl+JMfEjjwvZwFYNaM
+        tOHTigtGQ+JngQVU3gLTwpmARhUFqwvaMfPkB5KdHQ48Xi/CsshpyEAyHacYPBFH4KyegqIDieFw
+        a4fRvIBwoTfe3MahlO4PeqWe/BzdnrHc5OZzRoBLRxchGOInpYURkkYpRc+iPkyMgzR1WOABgad0
+        IDQKCr+Shn9Jn2b5t2UVEwAbIhoo4CaErDcaCwFYT2cfqaG5blwyBxYW6sVb/wdgbxw/u9E3bAAA
+        AABJRU5ErkJggg==
+    </icon>
+
 </service-task-definition>


### PR DESCRIPTION
予定をカレンダー移動すると、予定 URL が変わる。（もしかしたら、変わらない場合もあるかもしれない)

予定 URL を再取得して、保存する機能を追加。

- last-modified の変更
- config C5 を追加
- script の変更

以外は、インデントを整えただけです。