### PR TITLE
T7985:カラム数が違う時に行数が正しく表示されるように修正

### DIFF
--- a/converter-excelcsv-to-table.xml
+++ b/converter-excelcsv-to-table.xml
@@ -50,7 +50,7 @@ function main() {
       // ListArray に行を追加する
       const newRow = myTable.addRow();
       // テーブル型データ項目の値の行数
-      const numOfRows = myFiles.size();
+      const numOfRows = myTable.size();
       if (cellsArray.length !== newRow.size()) {
         throw `Incorrect number of rows at line ${numOfRows}`;
       }
@@ -394,7 +394,7 @@ test("over-columns", () => {
   const fileArrayList = engine.createQfile(
     "テスト.csv",
     "text/tab-separated-values; charset=x-UTF-16LE-BOM",
-    "hogehoge\t123.45\t2021-10-21\tfalse\thogehoge\n"
+    "hogehoge\t123.45\t2021-10-21\tfalse\nfugafuga\t543.21\t2021-01-23\ttrue\tfalse"
   );
   // ArrayList に CSV ファイルを追加
   files.add(fileArrayList);
@@ -414,7 +414,7 @@ test("over-columns", () => {
     execute();
     fail("not come here");
   } catch (e) {
-    expect(e.message).endsWith("Incorrect number of rows at line 1");
+    expect(e.message).endsWith("Incorrect number of rows at line 2");
   }
 });
 


### PR DESCRIPTION
単体テストのテーブル型データ項目よりも多い列数(over-columns)にて`Incorrect number of rows at line 2`となるようにしました。