### PR TITLE
t8086:Box: ファイルダウンロード　単体テストの追加

### DIFF
--- a/box-file-download.xml
+++ b/box-file-download.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-02-09</last-modified>
+<last-modified>2021-12-13</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Box: Download File</label>
@@ -169,4 +169,138 @@ zgIg8yBSf2cdxdayXaleGSbk0+Xd/+gyUtexiPRlXkgrtd4s9YeRzptzr2NldU0LkiTmlS3JUnVA
 0t3VK0qRhwj5VJk/p12lsjxdAeUPoDWhCpW4KtFTlVJhwpRhpOFf2sMkpQn9NGtGyOb8QZRj/TQL
 Lu9plr1c/TiV9QipHqUeEHckTOQZYBwpOkF0LLTiwragsHgvyfo/g3CBMFgjn40AAAAASUVORK5C
 YII=</icon>
+<test><![CDATA[
+/**
+ * 設定の準備
+ * @param configs
+ * @param fileId
+ * @param fileName
+ * @param files
+ * @return fileDef: {Object}
+ */
+const prepareConfigs = (configs, fileId, fileName, files) => {
+    configs.put('conf_OAuth2', 'Box');
+    configs.put('conf_FileId', fileId);
+    configs.put('conf_FileName', fileName);
+    const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
+    configs.putObject('uploadedFile', fileDef);
+    engine.setData(fileDef, files);
+
+    return fileDef;
+};
+
+/**
+ * 指定サイズのテキストファイルを作成
+ * @param name
+ * @param size
+ */
+const createQfile = (name, size) => {
+    let text = '';
+    while (text.length < size) {
+        if (text.length !== 0 && text.length * 2 < size) {
+            text += text;
+        } else {
+            text += 'a';
+        }
+    }
+    return engine.createQfile(name, 'text/plain; charset=US-ASCII', text);
+};
+
+test('File ID is empty', () => {
+    const fileDef = prepareConfigs(configs, '', '', null);
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('fileId is blank');
+    }
+});
+
+test('Failed to find file', () => {
+    const fileDef = prepareConfigs(configs, '1234567890', '', null);
+    httpClient.setRequestHandler(({url, method, contentType}) => {
+        engine.log(url);
+        switch (url) {
+            case 'https://api.box.com/2.0/files/1234567890/': {
+                expect(method).toEqual('GET');
+                const responseObj = {};
+                return httpClient.createHttpResponse(404, 'application/json', JSON.stringify(responseObj));
+            }
+            case 'https://api.box.com/2.0/files/1234567890/content/': {
+                expect(method).toEqual('PUT');
+                return httpClient.createHttpResponse(404, 'application/json', '{}');
+            }
+            default:
+                fail('Request Error');
+        }
+    });
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Failed to download file. status: 404');
+    }
+});
+
+test('Failed to find file', () => {
+    const fileDef = prepareConfigs(configs, '1234567890', '', null);
+    httpClient.setRequestHandler(({url, method, contentType}) => {
+        engine.log(url);
+        switch (url) {
+            case 'https://api.box.com/2.0/files/1234567890/': {
+                expect(method).toEqual('GET');
+                const responseObj = {};
+                return httpClient.createHttpResponse(403, 'application/json', JSON.stringify(responseObj));
+            }
+            case 'https://api.box.com/2.0/files/1234567890/content/': {
+                expect(method).toEqual('PUT');
+                return httpClient.createHttpResponse(403, 'application/json', '{}');
+            }
+            default:
+                fail('Request Error');
+        }
+    });
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Failed to download file. status: 403');
+    }
+});
+
+test('Succeeded to find file', () => {
+    const file = createQfile('file.txt', '100')
+    const fileDef = prepareConfigs(configs, '1234567890', 'fileName', null);
+    httpClient.setRequestHandler(({url, method, contentType}) => {
+        engine.log(url);
+        switch (url) {
+            case 'https://api.box.com/2.0/files/1234567890/': {
+                expect(method).toEqual('GET');
+                const responseObj = {};
+                return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+            }
+            case 'https://api.box.com/2.0/files/1234567890/content/': {
+                expect(method).toEqual('PUT');
+                return httpClient.createHttpResponse(200, 'application/json', file);
+            }
+            default:
+                fail('Request Error');
+        }
+    });
+
+    execute();
+
+    const files = new java.util.ArrayList();
+    const qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(
+      fileName, contentType, content
+    )
+    files.add( qfile );
+    except(engine.findData(fileDef)).toEqual(files)
+    except(engine.findData(fileDef)[0].getName()).toEqual('fileName')
+
+
+]]></test>
 </service-task-definition>

--- a/box-file-download.xml
+++ b/box-file-download.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-12-13</last-modified>
+<last-modified>2021-12-17</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Box: Download File</label>
@@ -182,6 +182,7 @@ YII=</icon>
 const prepareConfigs = (configs, fileId, fileIdIsFixed, fileName, files) => {
     configs.put('conf_OAuth2', 'Box');
 
+    //fileIdIsFixed が true なら固定値、false ならデータ項目
     if (fileIdIsFixed) {
       configs.put('conf_FileId', fileId);
     }else{

--- a/box-file-download.xml
+++ b/box-file-download.xml
@@ -174,14 +174,24 @@ YII=</icon>
  * 設定の準備
  * @param configs
  * @param fileId
+ * @param fileIdIsFixed
  * @param fileName
  * @param files
  * @return fileDef: {Object}
  */
-const prepareConfigs = (configs, fileId, fileName, files) => {
+const prepareConfigs = (configs, fileId, fileIdIsFixed, fileName, files) => {
     configs.put('conf_OAuth2', 'Box');
-    configs.put('conf_FileId', fileId);
+
+    if (fileIdIsFixed) {
+      configs.put('conf_FileId', fileId);
+    }else{
+      const fileIdDef = engine.createDataDefinition('文字', 2, 'q_string', 'STRING_TEXTFIELD');
+      configs.putObject('conf_FileId', fileIdDef);
+      engine.setData(fileIdDef, fileId);
+    }
+    
     configs.put('conf_FileName', fileName);
+
     const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
     configs.putObject('conf_Files', fileDef);
     engine.setData(fileDef, files);
@@ -194,6 +204,7 @@ const prepareConfigs = (configs, fileId, fileName, files) => {
  * @param file
  * @param name
  * @param contentType
+ * @param encoding
  * @param body
  */
 const assertFile = (file, name, contentType, encoding, body) => {
@@ -204,8 +215,12 @@ const assertFile = (file, name, contentType, encoding, body) => {
     expect(text).toEqual(body);
 };
 
+/**
+ * C2 に指定したデータ項目の値が空の場合
+ * ファイルIDはデータ項目で指定
+ */
 test('File ID is empty', () => {
-    const fileDef = prepareConfigs(configs, '', '', null);
+    const fileDef = prepareConfigs(configs, '', false,  '', null);
 
     try {
         execute();
@@ -215,8 +230,12 @@ test('File ID is empty', () => {
     }
 });
 
+/**
+ * 404エラーが返ってくる場合
+ * ファイルIDはデータ項目で指定
+ */
 test('Failed to find file', () => {
-    const fileDef = prepareConfigs(configs, '1234567890', '', null);
+    const fileDef = prepareConfigs(configs, '1234567890', false, '', null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {
@@ -242,8 +261,12 @@ test('Failed to find file', () => {
     }
 });
 
+/**
+ * 403エラーが返ってくる場合
+ * ファイルIDは固定値で指定
+ */
 test('Failed to download file', () => {
-    const fileDef = prepareConfigs(configs, '1234567890', '', null);
+    const fileDef = prepareConfigs(configs, '1234567890', true, '', null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {
@@ -269,9 +292,13 @@ test('Failed to download file', () => {
     }
 });
 
+/**
+ * ファイル型データ項目に他のファイルが入っていない状態で、ダウンロードに成功した場合
+ * ファイルIDは固定値で指定
+ */
 test('Succeeded to download file / File is null', () => {
     const fileName = "test.txt";
-    const fileDef = prepareConfigs(configs, '1234567890', fileName, null);
+    const fileDef = prepareConfigs(configs, '1234567890', true, fileName, null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {
@@ -296,12 +323,16 @@ test('Succeeded to download file / File is null', () => {
     assertFile(files.get(0), fileName, 'text/plain', 'UTF-8', 'こんにちは\n');
 });
 
+/**
+ * ファイル型データ項目に他のファイルが入っている状態で、ダウンロードに成功した場合
+ * ファイルIDはデータ項目で指定
+ */
 test('Succeeded to download file / File is not null', () => {
     let files = new java.util.ArrayList();
     files.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
     files.add(engine.createQfile('test.xml', 'text/xml; charset=UTF-16', '<xml>さようなら</xml>'));
     const fileName = "test.txt";
-    const fileDef = prepareConfigs(configs, '1234567890', fileName, files);
+    const fileDef = prepareConfigs(configs, '1234567890', false, fileName, files);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {
@@ -326,9 +357,13 @@ test('Succeeded to download file / File is not null', () => {
     assertFile(files_data.get(2), fileName, 'text/plain', 'EUC-JP', 'さようなら\n');
 });
 
+/**
+ * ファイル名の指定をせずにダウンロードに成功した場合
+ * ファイルIDはデータ項目で指定
+ */
 test('File Name is empty', () => {
     const fileName = "test.txt";
-    const fileDef = prepareConfigs(configs, '1234567890', "", null);
+    const fileDef = prepareConfigs(configs, '1234567890', false, "", null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {

--- a/box-file-download.xml
+++ b/box-file-download.xml
@@ -183,27 +183,25 @@ const prepareConfigs = (configs, fileId, fileName, files) => {
     configs.put('conf_FileId', fileId);
     configs.put('conf_FileName', fileName);
     const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
-    configs.putObject('uploadedFile', fileDef);
+    configs.putObject('conf_Files', fileDef);
     engine.setData(fileDef, files);
 
     return fileDef;
 };
 
 /**
- * 指定サイズのテキストファイルを作成
+ * ファイルのテスト
+ * @param file
  * @param name
- * @param size
+ * @param contentType
+ * @param body
  */
-const createQfile = (name, size) => {
+const assertFile = (file, name, contentType, encoding, body) => {
+    expect(file.getName()).toEqual(name);
+    expect(file.getContentType()).toEqual(contentType);
     let text = '';
-    while (text.length < size) {
-        if (text.length !== 0 && text.length * 2 < size) {
-            text += text;
-        } else {
-            text += 'a';
-        }
-    }
-    return engine.createQfile(name, 'text/plain; charset=US-ASCII', text);
+    fileRepository.readFile(file, encoding, line => text += line + '\n');
+    expect(text).toEqual(body);
 };
 
 test('File ID is empty', () => {
@@ -228,7 +226,7 @@ test('Failed to find file', () => {
                 return httpClient.createHttpResponse(404, 'application/json', JSON.stringify(responseObj));
             }
             case 'https://api.box.com/2.0/files/1234567890/content/': {
-                expect(method).toEqual('PUT');
+                expect(method).toEqual('GET');
                 return httpClient.createHttpResponse(404, 'application/json', '{}');
             }
             default:
@@ -244,7 +242,7 @@ test('Failed to find file', () => {
     }
 });
 
-test('Failed to find file', () => {
+test('Failed to download file', () => {
     const fileDef = prepareConfigs(configs, '1234567890', '', null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
@@ -255,7 +253,7 @@ test('Failed to find file', () => {
                 return httpClient.createHttpResponse(403, 'application/json', JSON.stringify(responseObj));
             }
             case 'https://api.box.com/2.0/files/1234567890/content/': {
-                expect(method).toEqual('PUT');
+                expect(method).toEqual('GET');
                 return httpClient.createHttpResponse(403, 'application/json', '{}');
             }
             default:
@@ -271,20 +269,50 @@ test('Failed to find file', () => {
     }
 });
 
-test('Succeeded to find file', () => {
-    const file = createQfile('file.txt', '100')
-    const fileDef = prepareConfigs(configs, '1234567890', 'fileName', null);
+test('Succeeded to download file / File is null', () => {
+    const fileName = "test.txt";
+    const fileDef = prepareConfigs(configs, '1234567890', fileName, null);
     httpClient.setRequestHandler(({url, method, contentType}) => {
         engine.log(url);
         switch (url) {
             case 'https://api.box.com/2.0/files/1234567890/': {
                 expect(method).toEqual('GET');
-                const responseObj = {};
+                const responseObj = {name: "dummy"};
                 return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
             }
             case 'https://api.box.com/2.0/files/1234567890/content/': {
-                expect(method).toEqual('PUT');
-                return httpClient.createHttpResponse(200, 'application/json', file);
+                expect(method).toEqual('GET');
+                return httpClient.createHttpResponse(200, 'text/plain; charset=UTF-8', 'こんにちは');
+            }
+            default:
+                fail('Request Error');
+        }
+    });
+    
+    execute();
+
+    const files = engine.findData(fileDef);
+    expect(files.size()).toEqual(1);
+    assertFile(files.get(0), fileName, 'text/plain', 'UTF-8', 'こんにちは\n');
+});
+
+test('Succeeded to download file / File is not null', () => {
+    let files = new java.util.ArrayList();
+    files.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+    files.add(engine.createQfile('test.xml', 'text/xml; charset=UTF-16', '<xml>さようなら</xml>'));
+    const fileName = "test.txt";
+    const fileDef = prepareConfigs(configs, '1234567890', fileName, files);
+    httpClient.setRequestHandler(({url, method, contentType}) => {
+        engine.log(url);
+        switch (url) {
+            case 'https://api.box.com/2.0/files/1234567890/': {
+                expect(method).toEqual('GET');
+                const responseObj = {name: "dummy"};
+                return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+            }
+            case 'https://api.box.com/2.0/files/1234567890/content/': {
+                expect(method).toEqual('GET');
+                return httpClient.createHttpResponse(200, 'text/plain; charset=EUC-JP', 'さようなら');
             }
             default:
                 fail('Request Error');
@@ -293,14 +321,36 @@ test('Succeeded to find file', () => {
 
     execute();
 
-    const files = new java.util.ArrayList();
-    const qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(
-      fileName, contentType, content
-    )
-    files.add( qfile );
-    except(engine.findData(fileDef)).toEqual(files)
-    except(engine.findData(fileDef)[0].getName()).toEqual('fileName')
+    const files_data = engine.findData(fileDef);
+    expect(files_data.size()).toEqual(3);
+    assertFile(files_data.get(2), fileName, 'text/plain', 'EUC-JP', 'さようなら\n');
+});
 
+test('File Name is empty', () => {
+    const fileName = "test.txt";
+    const fileDef = prepareConfigs(configs, '1234567890', "", null);
+    httpClient.setRequestHandler(({url, method, contentType}) => {
+        engine.log(url);
+        switch (url) {
+            case 'https://api.box.com/2.0/files/1234567890/': {
+                expect(method).toEqual('GET');
+                const responseObj = {name: fileName};
+                return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+            }
+            case 'https://api.box.com/2.0/files/1234567890/content/': {
+                expect(method).toEqual('GET');
+                return httpClient.createHttpResponse(200, 'text/plain; charset=UTF-8', 'こんにちは');
+            }
+            default:
+                fail('Request Error');
+        }
+    });
+    
+    execute();
 
+    const files = engine.findData(fileDef);
+    expect(files.size()).toEqual(1);
+    assertFile(files.get(0), fileName, 'text/plain', 'UTF-8', 'こんにちは\n');
+});
 ]]></test>
 </service-task-definition>


### PR DESCRIPTION
以下の項目をテストする。

- ファイルIDが空の場合
- 404エラーが返ってくる場合
- 403エラーが返ってくる場合
- ファイル型データ項目に他のファイルが入っていない状態でダウンロードに成功した場合
- ファイル型データ項目に他のファイルが入っている状態でダウンロードに成功した場合
- ファイル名の指定をせずにダウンロードに成功した場合(ファイル型データ項目に他のファイルは入っていない)