### PR TITLE
ハイフンを含むカレンダーIDに対応

### DIFF
--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -92,7 +92,7 @@ function main() {
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 演算 / Calculating ==
-    if (calendarId.search(/^[a-zA-Z0-9!#$%&()*+,.:;=?@[]^_{}-]+$/) !== -1) {
+    if (calendarId.search(/^[\w!-/:-@¥[-`{-~]+$/) === -1) {
     throw "Invalid Calendar ID";
   }
 
@@ -466,9 +466,9 @@ test('Failed to insert event - timezone:GMT+04:30', () => {
 
   engine.setTimeZoneOffsetInMinutes(270); // テストスクリプトではタイムゾーンの値をコントロール可能 timezone = 'GMT+04:30' に設定する
 
-  const meetDef = prepareConfigs(configs, 'fghij67890', 'event6', '2022-01-06 10:03:00', '2022-01-06 18:03:00', 'location6', 'description6');
+  const meetDef = prepareConfigs(configs, 'fghij*!@67890.com', 'event6', '2022-01-06 10:03:00', '2022-01-06 18:03:00', 'location6', 'description6');
   httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'fghij67890', 'event6', '2022-01-06T10:03:00', '2022-01-06T18:03:00', 'GMT+04:30', 'location6', 'description6', meetDef);
+    assertPostRequest(request, 'fghij*!@67890.com', 'event6', '2022-01-06T10:03:00', '2022-01-06T18:03:00', 'GMT+04:30', 'location6', 'description6', meetDef);
     return httpClient.createHttpResponse(400, 'application/json', '{}');
   });
 
@@ -494,10 +494,10 @@ test('Success', () => {
         idDef,
         urlDef,
         meetDef
-    } = prepareConfigs(configs, 'ghijk78901@a-sample.com', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
+    } = prepareConfigs(configs, 'ghijk_78901@a-sample.com', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
     
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'ghijk78901@a-sample.com', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
+        assertPostRequest(request, 'ghijk_78901@a-sample.com', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('calender123', 'location7', 'description7')));
     });
 

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2022-03-08</last-modified>
+<last-modified>2022-03-10</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -370,10 +370,40 @@ test('Event End Date comes before Event Start Date', () => {
 
 
 /**
- * カレンダーIDにサポート外の文字が含まれていてエラーになる場合
+ * カレンダーIDにサポート外の文字 $ が含まれていてエラーになる場合
  */
-test('Invalid Calendar ID', () => {
-    prepareConfigs(configs, 'efghi^\w\.#?()＠56789!""#$%&\'+,/:;<=>[]^``.com', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+test('Invalid Calendar ID - used $', () => {
+    prepareConfigs(configs, 'efghi$＠56789.com', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Invalid Calendar ID');
+    }
+});
+
+/**
+ * カレンダーIDにサポート外の文字 & が含まれていてエラーになる場合
+ */
+test('Invalid Calendar ID - used &', () => {
+    prepareConfigs(configs, 'efghi＠56789!&.com', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Invalid Calendar ID');
+    }
+});
+
+/**
+ * カレンダーIDにサポート外の文字 : が含まれていてエラーになる場合
+ */
+test('Invalid Calendar ID - used :', () => {
+    prepareConfigs(configs, 'efghi＠56:789.com', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -485,6 +515,7 @@ test('Failed to insert event - timezone:GMT+04:30', () => {
 /**
  * POST API 成功
  *（予定を追加する）
+ *（カレンダー ID に許可されている全ての記号が含まれている）
  *（予定 ID 、予定 URL 、Google Meet の URL を保存するデータ項目全てを設定）
  *（タイムゾーン GMT+09:00）
  */

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2022-03-07</last-modified>
+<last-modified>2022-03-08</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -92,7 +92,7 @@ function main() {
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 演算 / Calculating ==
-    if (calendarId.search(/[^\w\-_.!*'@]/) !== -1) {
+  if (calendarId.search(/^[\w\-_.!*'@]+$/) === -1) {
     throw "Invalid Calendar ID";
   }
 
@@ -373,7 +373,7 @@ test('Event End Date comes before Event Start Date', () => {
  * カレンダーIDにサポート外の文字が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID', () => {
-    prepareConfigs(configs, 'efghi^\w\.#?()＠56789', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+    prepareConfigs(configs, 'efghi^\w\.#?()＠56789!""#$%&\'+,/:;<=>[]^``.com', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -494,10 +494,10 @@ test('Success', () => {
         idDef,
         urlDef,
         meetDef
-    } = prepareConfigs(configs, 'ghijk_78901@a-sample.com', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
+    } = prepareConfigs(configs, 'ghijk_78901-_.!*\'@a-sample.com', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
     
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'ghijk_78901@a-sample.com', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
+        assertPostRequest(request, 'ghijk_78901-_.!*\'@a-sample.com', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('calender123', 'location7', 'description7')));
     });
 

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2022-02-21</last-modified>
+<last-modified>2022-03-07</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -92,7 +92,7 @@ function main() {
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 演算 / Calculating ==
-    if (calendarId.search(/^[\w!-/:-@¥[-`{-~]+$/) === -1) {
+    if (calendarId.search(/[^\w\-_.!*'@]/) !== -1) {
     throw "Invalid Calendar ID";
   }
 
@@ -373,7 +373,7 @@ test('Event End Date comes before Event Start Date', () => {
  * カレンダーIDにサポート外の文字が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID', () => {
-    prepareConfigs(configs, 'efghi^\w\.＠56789', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+    prepareConfigs(configs, 'efghi^\w\.#?()＠56789', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {

--- a/google-calendar-event-insert.xml
+++ b/google-calendar-event-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2022-02-14</last-modified>
+<last-modified>2022-02-21</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Insert Event</label>
@@ -92,7 +92,7 @@ function main() {
   const meetUrlDataDef = configs.getObject("conf_meetUrl");
 
   //// == 演算 / Calculating ==
-  if (calendarId.search(/[^\w\.@]/) !== -1) {
+    if (calendarId.search(/^[a-zA-Z0-9!#$%&()*+,.:;=?@[]^_{}-]+$/) !== -1) {
     throw "Invalid Calendar ID";
   }
 
@@ -307,7 +307,7 @@ const prepareConfigs = (configs, calendarId, eventTitle, startDate, endDate, loc
  * Google ドライブに接続する UserID に対応する QuserView がなくエラーになる場合
  */
 test('User not found', () => {
-    prepareConfigs(configs, 'abcde12345', 'event1', '2022-01-01 10:03:00', '2022-01-01 18:03:00', 'location1', 'description1');
+    prepareConfigs(configs, 'abcde@123.com', 'event1', '2022-01-01 10:03:00', '2022-01-01 18:03:00', 'location1', 'description1');
     // 設定されたユーザが削除された場合　未設定と同じ状態に上書きする
     configs.put('conf_User', '');
 
@@ -325,7 +325,7 @@ test('User not found', () => {
  * 予定タイトルが空でエラーになる場合
  */
 test('Event Title is blank', () => {
-    prepareConfigs(configs, 'bcdef23456', '', '2022-01-02 10:03:00', '2022-01-02 18:03:00', 'location2', 'description2');
+    prepareConfigs(configs, 'bcdef@234.com', '', '2022-01-02 10:03:00', '2022-01-02 18:03:00', 'location2', 'description2');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -341,7 +341,7 @@ test('Event Title is blank', () => {
  * 開始時刻が空でエラーになる場合
  */
 test('Event Start Date is blank', () => {
-    prepareConfigs(configs, 'cdefg34567', 'event3', null, '2022-01-03 18:03:00', 'location3', 'description3');
+    prepareConfigs(configs, 'cdefg@345.com', 'event3', null, '2022-01-03 18:03:00', 'location3', 'description3');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -357,7 +357,7 @@ test('Event Start Date is blank', () => {
  * 終了時刻が開始時刻より前でエラーになる場合
  */
 test('Event End Date comes before Event Start Date', () => {
-    prepareConfigs(configs, 'defgh45678', 'event4', '2022-01-04 18:03:00', '2022-01-04 10:03:00', 'location4', 'description4');
+    prepareConfigs(configs, 'defgh@456.net', 'event4', '2022-01-04 18:03:00', '2022-01-04 10:03:00', 'location4', 'description4');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -373,7 +373,7 @@ test('Event End Date comes before Event Start Date', () => {
  * カレンダーIDにサポート外の文字が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID', () => {
-    prepareConfigs(configs, 'efghi^\w\.@56789', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
+    prepareConfigs(configs, 'efghi^\w\.＠56789', 'event5', '2022-01-05 10:03:00', '2022-01-05 18:03:00', 'location5', 'description5');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     try {
@@ -494,10 +494,10 @@ test('Success', () => {
         idDef,
         urlDef,
         meetDef
-    } = prepareConfigs(configs, 'ghijk78901', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
+    } = prepareConfigs(configs, 'ghijk78901@a-sample.com', 'event7', '2022-01-07 10:03:00', '2022-01-07 18:03:00', 'location7', 'description7');
     
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'ghijk78901', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
+        assertPostRequest(request, 'ghijk78901@a-sample.com', 'event7', '2022-01-07T10:03:00', '2022-01-07T18:03:00', 'GMT+09:00', 'location7', 'description7', meetDef);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('calender123', 'location7', 'description7')));
     });
 
@@ -521,7 +521,7 @@ test('Success - All of Data Items to save result are not set - location, descrip
     
     engine.setTimeZoneOffsetInMinutes(0); // テストスクリプトではタイムゾーンの値をコントロール可能　timezone = 'GMT'　に設定する
 
-    prepareConfigs(configs, 'hijkl89012', 'event8', '2022-01-08 10:03:00', null, '', '');
+    prepareConfigs(configs, 'hijkl@890.net', 'event8', '2022-01-08 10:03:00', null, '', '');
 
     // ID を保存する文字型データ項目を未設定に上書き
     configs.put('conf_eventId', '');
@@ -533,7 +533,7 @@ test('Success - All of Data Items to save result are not set - location, descrip
     configs.put('conf_meetUrl', '');
     
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'hijkl89012', 'event8', '2022-01-08T10:03:00', '2022-01-08T11:03:00', 'GMT', '', '', null);
+        assertPostRequest(request, 'hijkl@890.net', 'event8', '2022-01-08T10:03:00', '2022-01-08T11:03:00', 'GMT', '', '', null);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('calender456', '', '')));
     });
 


### PR DESCRIPTION
@hatanaka-akihiro  さん

375行目の、「カレンダーIDにサポート外の文字が含まれていてエラーになる場合」のテストが通りません。

エラーメッセージが、以下になるのですが、これはどういう意味でしょうか
Expected: a string ending with "Invalid Calendar ID"
     but: was "
  Unexpected method call QbpmConfiguration.getLocale():"
