### PR TITLE
Google スプレッドシート: 行取得　単体テストの追加

### DIFF
--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-03-15</last-modified>
+<last-modified>2022-03-17</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -456,10 +456,10 @@ test('Succeed to get - TEXTFIELD and TEXTAREA', () => {
 
 test('Succeed to get - 10 columns', () => {
     //保存先データ項目がすべて設定されている場合
-    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 2!', '70', 'XA:XJ', ...types);
 
-    const rowData = [...Array(10)].map((_, i) => `値${i+1}`);
+    const rowData = new Array(10).fill().map((_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 2!', 'XA70:XJ70');
         const ret = JSON.stringify({"values":[rowData]});
@@ -474,12 +474,12 @@ test('Succeed to get - 10 columns', () => {
 
 test('Succeed to get - Some data items are not set', () => {
     //保存先データ項目が設定されていない列がある場合
-    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
     configs.put('conf_Column5', '');
     configs.put('conf_Column8', '');
 
-    const rowData = [...Array(10)].map((_, i) => `値${i+1}`);
+    const rowData = new Array(10).fill().map((_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:J1');
         const ret = JSON.stringify({"values":[rowData]});
@@ -498,10 +498,10 @@ test('Succeed to get - Some data items are not set', () => {
 
 test('Succeed to get - Number of Returned values is bigger than 10', () => {
     //取得した行データの値の数が 10 を超える場合
-    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:Z', ...types);
 
-    const rowData = [...Array(11)].map((_, i) => `値${i+1}`);
+    const rowData = new Array(11).fill().map((_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:Z1');
         const ret = JSON.stringify({"values":[rowData]});
@@ -516,10 +516,10 @@ test('Succeed to get - Number of Returned values is bigger than 10', () => {
 
 test('Succeed to get - Number of Returned values is smaller than that of data items', () => {
     //取得した行データの値の数が設定した保存先データ項目数より少ない場合
-    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
 
-    const rowData = [...Array(8)].map((_, i) => `値${i+1}`);
+    const rowData = new Array(8).fill().map((_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:J1');
         const ret = JSON.stringify({"values":[rowData]});

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-03-09</last-modified>
+<last-modified>2022-03-11</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -347,6 +347,7 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
     const columnDefList = [];
     let i = 1;
     type.forEach(element => {
+      //typeで指定したタイプのデータ項目を作成し、C6に一行目から順に設定
       if (element !== null){
         const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
         configs.putObject(`conf_Column${i}`, columnDef);
@@ -359,6 +360,7 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
 };
 
 test('Row Number is invalid', () => {
+    //行番号が不適切な場合
     prepareConfigs(configs, 'id', 'title', 'invalidrow', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
@@ -370,6 +372,7 @@ test('Row Number is invalid', () => {
 });
 
 test('Row Number is empty', () => {
+    //行番号が入力されていない場合
     prepareConfigs(configs, 'id', 'title', '', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
@@ -381,6 +384,7 @@ test('Row Number is empty', () => {
 });
 
 test('Column Range is invalid', () => {
+    //列範囲が不適切である場合
     prepareConfigs(configs, 'id', 'title', '1', 'invalidrange', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
@@ -392,6 +396,7 @@ test('Column Range is invalid', () => {
 });
 
 test('Same Data Item is set twice', () => {
+    //同じデータ項目がC6に2回セットされている場合
     const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
     configs.putObject("conf_Column2", columnDefList[0]);
     try {
@@ -404,11 +409,14 @@ test('Same Data Item is set twice', () => {
 
 /**
  * リクエストのテスト
+ * @param url
  * @param method
  * @param contentType
  * @param body
- * @param name
- * @param parentId
+ * @param enSheetId
+ * @param enSheetTitle
+ * @param rangeArr
+ * @param rowNo
  */
 const assertRequest = ({url, method, contentType, body}, enSheetId, enSheetTitle, rangeArr, rowNo) => {
     expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`);
@@ -423,12 +431,9 @@ const assertRequest = ({url, method, contentType, body}, enSheetId, enSheetTitle
     .queryParam( "majorDimension", "ROWS" )
     .get( uri );
     */
-//存在しないID -> 404
-//存在しないタイトル -> 400
-//からの列・行 -> "No Data in range."
-//prepareConfigs = (configs, sheetId, sheetTitle, row, range, type)
-//const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+
 test('Succeed to get row 1', () => {
+    //行取得に成功する場合
     const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
 
     httpClient.setRequestHandler((request) => {
@@ -444,6 +449,7 @@ test('Succeed to get row 1', () => {
 });
 
 test('404 Error', () => {
+    //APIからエラーが返ってくる場合
     const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
 
     httpClient.setRequestHandler((request) => {
@@ -460,6 +466,7 @@ test('404 Error', () => {
 });
 
 test('All cells are empty', () => {
+    //範囲内のセルがすべて空の場合
     const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
 
     httpClient.setRequestHandler((request) => {

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -377,7 +377,7 @@ test('Row Number is invalid', () => {
 
 test('Row Number is empty', () => {
     //行番号が入力されていない場合
-    prepareConfigs(configs, 'id', 'title', '', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
+    prepareConfigs(configs, 'id', 'title', null, 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
 
     try {
         execute();
@@ -411,28 +411,40 @@ test('Same Data Item is set twice', () => {
     }
 });
 
+test('No Data Item is set', () => {
+    //保存先データ項目がひとつも設定されていない場合
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B');
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('No Data Item is set.');
+    }
+});
+
 /**
  * リクエストのテスト
  * @param url
  * @param method
  * @param contentType
  * @param body
- * @param enSheetId
- * @param enSheetTitle
- * @param rangeArr
- * @param rowNo
+ * @param sheetId
+ * @param sheetTitle
+ * @param range
  */
-const assertRequest = ({url, method, contentType, body}, enSheetId, enSheetTitle, rangeArr, rowNo) => {
-    expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`);
+const assertRequest = ({url, method, contentType, body}, sheetId, sheetTitle, range) => {
+    const enSheetId = encodeURIComponent(sheetId);
+    const enSheetTitle = encodeURIComponent(sheetTitle);
+    expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${range}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`);
     expect(method).toEqual('GET');
 };
 
-test('Succeed to get row 1', () => {
+test('Succeed to get - TEXTFIELD and TEXTAREA', () => {
     //行取得に成功する場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA');
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
+        assertRequest(request, 'id', 'シート 1', 'A1:B1');
         const ret = JSON.stringify({"values":[['A列','B列\n複数行']]});
         return httpClient.createHttpResponse(200, 'application/json', ret);
     });
@@ -442,12 +454,108 @@ test('Succeed to get row 1', () => {
     expect(engine.findData(columnDefList[1])).toEqual('B列\n複数行');
 });
 
-test('404 Error', () => {
-    //APIからエラーが返ってくる場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
+test('Succeed to get - 10 columns', () => {
+    //保存先データ項目がすべて設定されている場合
+    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 2!', '70', 'XA:XJ', ...types);
+
+    const rowData = [...Array(10)].map((_, i) => `値${i+1}`);
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'シート 2!', 'XA70:XJ70');
+        const ret = JSON.stringify({"values":[rowData]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
+    });
+
+    execute();
+    columnDefList.forEach((def, i) => {
+        expect(engine.findData(def)).toEqual(`値${i+1}`);
+    });
+});
+
+test('Succeed to get - Some data items are not set', () => {
+    //保存先データ項目が設定されていないものがある場合
+    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
+    configs.put('conf_Column5', '');
+    configs.put('conf_Column8', '');
+
+    const rowData = [...Array(10)].map((_, i) => `値${i+1}`);
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'シート 1', 'A1:J1');
+        const ret = JSON.stringify({"values":[rowData]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
+    });
+
+    execute();
+    columnDefList.forEach((def, i) => {
+        if (i === 4 || i === 7) { // 5, 8列目は保存先が未設定
+            expect(engine.findData(def)).toEqual('事前文字列');
+            return;
+        }
+        expect(engine.findData(def)).toEqual(`値${i+1}`);
+    });
+});
+
+test('Succeed to get - Number of Returned values is bigger than 10', () => {
+    //取得した行データの値の数が 10 を超える場合
+    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:Z', ...types);
+
+    const rowData = [...Array(11)].map((_, i) => `値${i+1}`);
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'シート 1', 'A1:Z1');
+        const ret = JSON.stringify({"values":[rowData]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
+    });
+
+    execute();
+    columnDefList.forEach((def, i) => {
+        expect(engine.findData(def)).toEqual(`値${i+1}`);
+    });
+});
+
+test('Succeed to get - Number of Returned values is smaller than that of data items', () => {
+    //取得した行データの値の数が設定した保存先データ項目数より少ない場合
+    const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
+
+    const rowData = [...Array(8)].map((_, i) => `値${i+1}`);
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'シート 1', 'A1:J1');
+        const ret = JSON.stringify({"values":[rowData]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
+    });
+
+    execute();
+    columnDefList.forEach((def, i) => {
+        if (i > 7) { // 9列目、10列目の保存される値は null
+            expect(engine.findData(def)).toEqual(null);
+            return;
+        }
+        expect(engine.findData(def)).toEqual(`値${i+1}`);
+    });
+});
+
+test('Succeed to get Numeric data', () => {
+    //数値データは文字列に変換され保存される
+    const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:A', 'STRING_TEXTFIELD');
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
+        assertRequest(request, 'id', 'シート 1', 'A1:A1');
+        const ret = JSON.stringify({"values":[[100]]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
+    });
+
+    execute();
+    expect(engine.findData(columnDefList[0])).toEqual('100');
+});
+
+test('404 Error', () => {
+    //APIからエラーが返ってくる場合
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA');
+
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'title', 'A1:B1', 1);
         return httpClient.createHttpResponse(404, 'application/json', JSON.stringify({}));
     });
 
@@ -461,10 +569,10 @@ test('404 Error', () => {
 
 test('All cells are empty', () => {
     //範囲内のセルがすべて空の場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA');
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
+        assertRequest(request, 'id', 'title', 'A1:B1', 1);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({}));
     });
 
@@ -475,5 +583,23 @@ test('All cells are empty', () => {
         expect(e.message).endsWith('No Data in range.');
     }
 });
+
+test('Validation Error - Unable to save multi-line string to STRING_TEXTFIELD', () => {
+    //単一行データ項目に複数行の文字列を保存しようとしてエラーになる場合
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:A', 'STRING_TEXTFIELD');
+
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'title', 'A1:A1', 1);
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({"values":[['複数行の\n文字列']]}));
+    });
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        //エラーになるのが正しい
+    }
+});
+
 ]]></test>
 </service-task-definition>

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-12-20</last-modified>
+<last-modified>2022-02-16</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -284,7 +284,7 @@ function setDataByLists( valueDefList, dataStringList ) {
           case 'DECIMAL':
             convertedData = new java.math.BigDecimal( dataString );
             break;
-          case 'SELECT': // 一致する選択肢 ID がない場合のエラーは QBPMS のバリデーションに任せる　　　　　
+          case 'SELECT': // 一致する選択肢 ID がない場合のエラーは QBPMS のバリデーションに任せる
             convertedData = new java.util.ArrayList();
             convertedData.add( dataString );
             break;
@@ -346,20 +346,20 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
     configs.put('conf_Range', range);
     const columnDefList = [];
     let i = 0;
-    type.foreach(elememt => function(elememt){
-      if element !== null{
+    type.foreach(element => {
+      if (element !== null){
         const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
-        configs.putObject(`conf_Column1${i}`, columnDef);
+        configs.putObject(`conf_Column${i}`, columnDef);
         columnDefList.put(columnDef);
       }
-      
-    })
+      i++;
+    });
 
     return columnDefList;
 };
 
 test('Row Number is invalid', () => {
-    prepareConfigs(configs, 'id', 'title', 'invalid', 'A:J', ['STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', 'invalidrow', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
         execute();
@@ -370,7 +370,7 @@ test('Row Number is invalid', () => {
 });
 
 test('Row Number is empty', () => {
-    prepareConfigs(configs, 'id', 'title', '', 'A:J', ['STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', '', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
         execute();
@@ -381,7 +381,7 @@ test('Row Number is empty', () => {
 });
 
 test('Column Range is invalid', () => {
-    prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', '1', 'invalidrange', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
 
     try {
         execute();
@@ -392,7 +392,7 @@ test('Column Range is invalid', () => {
 });
 
 test('Same Data Item is set twice', () => {
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
     configs.putObject(`conf_Column2`, columnDefList[0]);
     try {
         execute();
@@ -410,58 +410,68 @@ test('Same Data Item is set twice', () => {
  * @param name
  * @param parentId
  */
-const assertRequest = ({url, method, contentType, body}, id) => {
-    expect(url).toEqual(`https://www.googleapis.com/drive/v3/files/${id}?supportsAllDrives=true`)
-    expect(method).toEqual('PATCH');
-    expect(contentType).toEqual('application/json; charset=UTF-8');
-    const bodyObj = JSON.parse(body);
-    expect(bodyObj.trashed).toEqual(true);
+const assertRequest = ({url, method, contentType, body}, enSheetId, enSheetTitle, rangeArr, rowNo) => {
+    expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`);
+    expect(method).toEqual('GET');
 };
+//`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`
+/*
+  const response = httpClient.begin()
+    .authSetting( oauth )
+    .queryParam( "valueRenderOption", "UNFORMATTED_VALUE" )
+    .queryParam( "dateTimeRenderOption", "FORMATTED_STRING" )
+    .queryParam( "majorDimension", "ROWS" )
+    .get( uri );
+    */
+//存在しないID -> 404
+//存在しないタイトル -> 400
+//からの列・行 -> "No Data in range."
+//prepareConfigs = (configs, sheetId, sheetTitle, row, range, type)
+//const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+test('Succeed to get row 1', () => {
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
 
-test('Succeed to delete multiple files folders', () => {
-    let ids = '';
-    for (let i = 0; i < httpClient.getRequestingLimit(); i++) {
-        ids += `f${i}\n`;
-    }
-    prepareConfigs(configs, ids);
-
-    let requestCount = 0;
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, `f${requestCount++}`);
-        return httpClient.createHttpResponse(200, 'application/json', '{}');
+        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
+        return httpClient.createHttpResponse(200, 'application/json', {values: [['A', '2' , 'う']]});
     });
 
     execute();
 
-    expect(requestCount).toEqual(httpClient.getRequestingLimit());
+    expect('A').toEqual(configs.get(columnDefList[0]));
+    expect('2').toEqual(configs.get(columnDefList[1]));
+    expect('う').toEqual(configs.get(columnDefList[2]));
 });
 
-test('Failed to delete file folder', () => {
-    let ids = '';
-    for (let i = 0; i < 2; i++) {
-        ids += `000${i}\n`;
-    }
-    prepareConfigs(configs, ids);
+test('404 Error', () => {
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
 
-    let requestCount = 0;
     httpClient.setRequestHandler((request) => {
-        try {
-            assertRequest(request, `000${requestCount}`);
-            if (requestCount === 1) {
-                return httpClient.createHttpResponse(400, 'application/json', '{}');
-            } else {
-                return httpClient.createHttpResponse(200, 'application/json', '{}');
-            }
-        } finally {
-            requestCount++;
-        }
+        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
+        return httpClient.createHttpResponse(404, 'application/json', {});
     });
 
     try {
         execute();
         fail('not come here');
     } catch (e) {
-        expect(e.message).endsWith('Failed to delete: 0001\nstatus: 400');
+        expect(e.message).endsWith('Failed to get. status:404');
+    }
+});
+
+test('All cells are empty', () => {
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
+
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
+        return httpClient.createHttpResponse(200, 'application/json', {});
+    });
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('No Data in range.');
     }
 });
 ]]></test>

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -102,8 +102,8 @@ function main(){
   const dataStringList = getRowData( oauth, sheetId, sheetTitle, rowNo, range );
 
   //// == ワークフローデータへの代入 / Data Updating ==
-   setDataByLists( columnDefList, dataStringList );
-  }
+  setDataByLists( columnDefList, dataStringList );
+}
 
 
 /**
@@ -241,7 +241,7 @@ function setDataByLists( valueDefList, dataStringList ) {
     if ( valueDef !== null) {
       if ( i > dataStringList.length - 1 ) { // dataStringList の要素がない場合
         engine.setData( valueDef, null ); 
-		return;
+        return;
       }
       const dataString = dataStringList[i];
 
@@ -272,7 +272,7 @@ function setDataByLists( valueDefList, dataStringList ) {
   * @param {String} dataType  保存先データ項目のデータ型
   * @param {String} dataTypeLabel  保存先データ項目のデータ型の表示名（エラー出力用）
   */
- /*
+/*
   function convertTypeAndSetData( dataDef, dataString, dataType, dataTypeLabel ) {
   
     let convertedData;
@@ -294,8 +294,8 @@ function setDataByLists( valueDefList, dataStringList ) {
           case 'DATETIME':
             const dateFormatter = new java.text.SimpleDateFormat( "yyyy-MM-dd HH:mm" );
             convertedData = new java.sql.Timestamp( dateFormatter.parse( dataString ).getTime() );
-           break;
-       }
+          break;
+        }
       } catch (e) { // 変換できない値の場合はエラー
         throw `Returned value "${dataString}" cannot be saved to ${dataTypeLabel} type data item.`;
       }
@@ -473,7 +473,7 @@ test('Succeed to get - 10 columns', () => {
 });
 
 test('Succeed to get - Some data items are not set', () => {
-    //保存先データ項目が設定されていないものがある場合
+    //保存先データ項目が設定されていない列がある場合
     const types = [...Array(10)].map(() => 'STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
     configs.put('conf_Column5', '');

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -459,7 +459,7 @@ test('Succeed to get - 10 columns', () => {
     const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 2!', '70', 'XA:XJ', ...types);
 
-    const rowData = new Array(10).fill().map((_, i) => `値${i+1}`);
+    const rowData = Array.from({length: 10}, (_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 2!', 'XA70:XJ70');
         const ret = JSON.stringify({"values":[rowData]});
@@ -479,7 +479,7 @@ test('Succeed to get - Some data items are not set', () => {
     configs.put('conf_Column5', '');
     configs.put('conf_Column8', '');
 
-    const rowData = new Array(10).fill().map((_, i) => `値${i+1}`);
+    const rowData = Array.from({length: 10}, (_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:J1');
         const ret = JSON.stringify({"values":[rowData]});
@@ -501,7 +501,7 @@ test('Succeed to get - Number of Returned values is bigger than 10', () => {
     const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:Z', ...types);
 
-    const rowData = new Array(11).fill().map((_, i) => `値${i+1}`);
+    const rowData = Array.from({length: 11}, (_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:Z1');
         const ret = JSON.stringify({"values":[rowData]});
@@ -519,7 +519,7 @@ test('Succeed to get - Number of Returned values is smaller than that of data it
     const types = new Array(10).fill('STRING_TEXTFIELD');
     const columnDefList = prepareConfigs(configs, 'id', 'シート 1', '1', 'A:J', ...types);
 
-    const rowData = new Array(8).fill().map((_, i) => `値${i+1}`);
+    const rowData = Array.from({length: 8}, (_, i) => `値${i+1}`);
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'シート 1', 'A1:J1');
         const ret = JSON.stringify({"values":[rowData]});

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-02-25</last-modified>
+<last-modified>2022-03-09</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -345,7 +345,7 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
     configs.put('conf_RowNo', row);
     configs.put('conf_Range', range);
     const columnDefList = [];
-    let i = 0;
+    let i = 1;
     type.forEach(element => {
       if (element !== null){
         const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
@@ -433,15 +433,14 @@ test('Succeed to get row 1', () => {
 
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'title', ['A', 'C'], 1);
-        const ret = JSON.stringify({values: [['A', '2' , 'う']]});
+        const ret = JSON.stringify({"values":[['A','2','う']]});
         return httpClient.createHttpResponse(200, 'application/json', ret);
     });
 
     execute();
-
-    expect('A').toEqual(configs.get(columnDefList[0]));
-    expect('2').toEqual(configs.get(columnDefList[1]));
-    expect('う').toEqual(configs.get(columnDefList[2]));
+    expect(engine.findData(columnDefList[0])).toEqual('A');
+    expect(engine.findData(columnDefList[1])).toEqual('2');
+    expect(engine.findData(columnDefList[2])).toEqual('う');
 });
 
 test('404 Error', () => {

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-02-16</last-modified>
+<last-modified>2022-02-25</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -346,11 +346,11 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
     configs.put('conf_Range', range);
     const columnDefList = [];
     let i = 0;
-    type.foreach(element => {
+    type.forEach(element => {
       if (element !== null){
         const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
         configs.putObject(`conf_Column${i}`, columnDef);
-        columnDefList.put(columnDef);
+        columnDefList.push(columnDef);
       }
       i++;
     });
@@ -393,7 +393,7 @@ test('Column Range is invalid', () => {
 
 test('Same Data Item is set twice', () => {
     const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
-    configs.putObject(`conf_Column2`, columnDefList[0]);
+    configs.putObject("conf_Column2", columnDefList[0]);
     try {
         execute();
         fail('not come here');
@@ -433,7 +433,8 @@ test('Succeed to get row 1', () => {
 
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'title', ['A', 'C'], 1);
-        return httpClient.createHttpResponse(200, 'application/json', {values: [['A', '2' , 'う']]});
+        const ret = JSON.stringify({values: [['A', '2' , 'う']]});
+        return httpClient.createHttpResponse(200, 'application/json', ret);
     });
 
     execute();
@@ -448,7 +449,7 @@ test('404 Error', () => {
 
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'title', ['A', 'C'], 1);
-        return httpClient.createHttpResponse(404, 'application/json', {});
+        return httpClient.createHttpResponse(404, 'application/json', JSON.stringify({}));
     });
 
     try {
@@ -464,7 +465,7 @@ test('All cells are empty', () => {
 
     httpClient.setRequestHandler((request) => {
         assertRequest(request, 'id', 'title', ['A', 'C'], 1);
-        return httpClient.createHttpResponse(200, 'application/json', {});
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({}));
     });
 
     try {

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-03-14</last-modified>
+<last-modified>2022-03-15</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -37,7 +37,7 @@
   </config>
   <config name="conf_Column2" required="false" form-type="SELECT" select-data-type="STRING">
     <label>C6_2: Data item that stores the value in the 2nd column </label>
-    <label locale="ja">C6_1: 列範囲のうち 2 列目の値を保存するデータ項目</label>
+    <label locale="ja">C6_2: 列範囲のうち 2 列目の値を保存するデータ項目</label>
   </config>
   <config name="conf_Column3" required="false" form-type="SELECT" select-data-type="STRING">
     <label>C6_3: Data item that stores the value in the 3rd column </label>

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-09-22</last-modified>
+<last-modified>2021-12-20</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -326,5 +326,143 @@ j+tjl4NnH1qQvZKltLO8kyi9JEBwOm7/pZSxTmpyNETz/atreUzksgqEFv0XFRB79E1J8dEICQfW
 kNLDRIQIPM3MYDArBhE2JhCeZpYtPc2iIw0ogmoQogMYB5DygA1zAYSCMeGR6pSLWHEOKJZ5i4Z/
 AEwJzTC2ALrNAAAAAElFTkSuQmCC
 </icon>
+<test><![CDATA[
 
+/**
+ * 設定の準備
+ * @param configs
+ * @param sheetId
+ * @param sheetTitle
+ * @param row
+ * @param range
+ * @param {Array} type
+ * @return {Object}
+ */
+const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
+    configs.put('conf_OAuth2', 'Google');
+    configs.put('conf_SheetId', sheetId);
+    configs.put('conf_SheetTitle', sheetTitle);
+    configs.put('conf_RowNo', row);
+    configs.put('conf_Range', range);
+    const columnDefList = [];
+    let i = 0;
+    type.foreach(elememt => function(elememt){
+      if element !== null{
+        const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
+        configs.putObject(`conf_Column1${i}`, columnDef);
+        columnDefList.put(columnDef);
+      }
+      
+    })
+
+    return columnDefList;
+};
+
+test('Row Number is invalid', () => {
+    prepareConfigs(configs, 'id', 'title', 'invalid', 'A:J', ['STRING_TEXTFIELD']);
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Invalid Row number.');
+    }
+});
+
+test('Row Number is empty', () => {
+    prepareConfigs(configs, 'id', 'title', '', 'A:J', ['STRING_TEXTFIELD']);
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Row number is empty.');
+    }
+});
+
+test('Column Range is invalid', () => {
+    prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Invalid Range.');
+    }
+});
+
+test('Same Data Item is set twice', () => {
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'invalid', ['STRING_TEXTFIELD']);
+    configs.putObject(`conf_Column2`, columnDefList[0]);
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('The same data item is set multiple times.');
+    }
+});
+
+/**
+ * リクエストのテスト
+ * @param method
+ * @param contentType
+ * @param body
+ * @param name
+ * @param parentId
+ */
+const assertRequest = ({url, method, contentType, body}, id) => {
+    expect(url).toEqual(`https://www.googleapis.com/drive/v3/files/${id}?supportsAllDrives=true`)
+    expect(method).toEqual('PATCH');
+    expect(contentType).toEqual('application/json; charset=UTF-8');
+    const bodyObj = JSON.parse(body);
+    expect(bodyObj.trashed).toEqual(true);
+};
+
+test('Succeed to delete multiple files folders', () => {
+    let ids = '';
+    for (let i = 0; i < httpClient.getRequestingLimit(); i++) {
+        ids += `f${i}\n`;
+    }
+    prepareConfigs(configs, ids);
+
+    let requestCount = 0;
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, `f${requestCount++}`);
+        return httpClient.createHttpResponse(200, 'application/json', '{}');
+    });
+
+    execute();
+
+    expect(requestCount).toEqual(httpClient.getRequestingLimit());
+});
+
+test('Failed to delete file folder', () => {
+    let ids = '';
+    for (let i = 0; i < 2; i++) {
+        ids += `000${i}\n`;
+    }
+    prepareConfigs(configs, ids);
+
+    let requestCount = 0;
+    httpClient.setRequestHandler((request) => {
+        try {
+            assertRequest(request, `000${requestCount}`);
+            if (requestCount === 1) {
+                return httpClient.createHttpResponse(400, 'application/json', '{}');
+            } else {
+                return httpClient.createHttpResponse(200, 'application/json', '{}');
+            }
+        } finally {
+            requestCount++;
+        }
+    });
+
+    try {
+        execute();
+        fail('not come here');
+    } catch (e) {
+        expect(e.message).endsWith('Failed to delete: 0001\nstatus: 400');
+    }
+});
+]]></test>
 </service-task-definition>

--- a/google-sheets-row-get.xml
+++ b/google-sheets-row-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-03-11</last-modified>
+<last-modified>2022-03-14</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Sheets: Get Row </label>
@@ -333,27 +333,31 @@ AEwJzTC2ALrNAAAAAElFTkSuQmCC
  * @param configs
  * @param sheetId
  * @param sheetTitle
- * @param row
+ * @param rowNo
  * @param range
- * @param {Array} type
+ * @param types
  * @return {Object}
  */
-const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
+const prepareConfigs = (configs, sheetId, sheetTitle, rowNo, range, ...types) => {
     configs.put('conf_OAuth2', 'Google');
     configs.put('conf_SheetId', sheetId);
     configs.put('conf_SheetTitle', sheetTitle);
-    configs.put('conf_RowNo', row);
     configs.put('conf_Range', range);
+
+    // 行番号を設定したデータ項目を作成し、C4 に設定
+    const rowNoDef = engine.createDataDefinition('行番号', 1, 'q_rowNo', 'STRING_TEXTFIELD');
+    engine.setData(rowNoDef, rowNo);
+    configs.putObject('conf_RowNo', rowNoDef);
+
     const columnDefList = [];
-    let i = 1;
-    type.forEach(element => {
-      //typeで指定したタイプのデータ項目を作成し、C6に一行目から順に設定
-      if (element !== null){
-        const columnDef = engine.createDataDefinition(`データ${i}`, i, `q_data${i}`, element);
-        configs.putObject(`conf_Column${i}`, columnDef);
+    types.forEach((type, i) => {
+      // 指定したタイプのデータ項目を作成し、C6 以降に順に設定
+      if (type !== null){
+        const columnDef = engine.createDataDefinition(`データ${i+1}`, i+2, `q_data${i+1}`, type);
+        engine.setData(columnDef, '事前文字列');
+        configs.putObject(`conf_Column${i+1}`, columnDef);
         columnDefList.push(columnDef);
       }
-      i++;
     });
 
     return columnDefList;
@@ -361,7 +365,7 @@ const prepareConfigs = (configs, sheetId, sheetTitle, row, range, type) => {
 
 test('Row Number is invalid', () => {
     //行番号が不適切な場合
-    prepareConfigs(configs, 'id', 'title', 'invalidrow', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', 'invalidrow', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
 
     try {
         execute();
@@ -373,7 +377,7 @@ test('Row Number is invalid', () => {
 
 test('Row Number is empty', () => {
     //行番号が入力されていない場合
-    prepareConfigs(configs, 'id', 'title', '', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', '', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
 
     try {
         execute();
@@ -385,7 +389,7 @@ test('Row Number is empty', () => {
 
 test('Column Range is invalid', () => {
     //列範囲が不適切である場合
-    prepareConfigs(configs, 'id', 'title', '1', 'invalidrange', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
+    prepareConfigs(configs, 'id', 'title', '1', 'invalidrange', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
 
     try {
         execute();
@@ -397,7 +401,7 @@ test('Column Range is invalid', () => {
 
 test('Same Data Item is set twice', () => {
     //同じデータ項目がC6に2回セットされている場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', ['STRING_TEXTFIELD', 'STRING_TEXTFIELD']);
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTFIELD');
     configs.putObject("conf_Column2", columnDefList[0]);
     try {
         execute();
@@ -422,38 +426,28 @@ const assertRequest = ({url, method, contentType, body}, enSheetId, enSheetTitle
     expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`);
     expect(method).toEqual('GET');
 };
-//`https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING&majorDimension=ROWS`
-/*
-  const response = httpClient.begin()
-    .authSetting( oauth )
-    .queryParam( "valueRenderOption", "UNFORMATTED_VALUE" )
-    .queryParam( "dateTimeRenderOption", "FORMATTED_STRING" )
-    .queryParam( "majorDimension", "ROWS" )
-    .get( uri );
-    */
 
 test('Succeed to get row 1', () => {
     //行取得に成功する場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
-        const ret = JSON.stringify({"values":[['A','2','う']]});
+        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
+        const ret = JSON.stringify({"values":[['A列','B列\n複数行']]});
         return httpClient.createHttpResponse(200, 'application/json', ret);
     });
 
     execute();
-    expect(engine.findData(columnDefList[0])).toEqual('A');
-    expect(engine.findData(columnDefList[1])).toEqual('2');
-    expect(engine.findData(columnDefList[2])).toEqual('う');
+    expect(engine.findData(columnDefList[0])).toEqual('A列');
+    expect(engine.findData(columnDefList[1])).toEqual('B列\n複数行');
 });
 
 test('404 Error', () => {
     //APIからエラーが返ってくる場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
+        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
         return httpClient.createHttpResponse(404, 'application/json', JSON.stringify({}));
     });
 
@@ -467,10 +461,10 @@ test('404 Error', () => {
 
 test('All cells are empty', () => {
     //範囲内のセルがすべて空の場合
-    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:C', ['STRING_TEXTFIELD', 'DECIMAL', 'STRING_TEXTAREA'])
+    const columnDefList = prepareConfigs(configs, 'id', 'title', '1', 'A:B', 'STRING_TEXTFIELD', 'STRING_TEXTAREA')
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'id', 'title', ['A', 'C'], 1);
+        assertRequest(request, 'id', 'title', ['A', 'B'], 1);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({}));
     });
 


### PR DESCRIPTION
以下の事柄についての単体テストを追加
・行指定が不適切
・行番号が空
・列指定が不適切
・同じデータ項目を異なる列の出力に指定
・正常に取得できる
・404エラー
・取得した部分のセルがすべて空