### PR TITLE
t8322 単体テストコードを追加

### DIFF
--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-04-26</last-modified>
+<last-modified>2022-04-28</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
@@ -8,10 +8,6 @@
 <summary>Send a message to Slack with Bots.</summary>
 <summary locale="ja">Bots 機能を使って Slack にメッセージを投稿します。</summary>
 <configs>
-  <config name="Token" deprecated="true">
-    <label>C1-deprecated: Slack Bot Token</label>
-    <label locale="ja">C1-deprecated: Slack Bot のトークン</label>
-  </config>
   <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
@@ -50,7 +46,6 @@
 <script><![CDATA[
 main();
 function main() {
-  const token = configs.get("Token");
   const oauth2 = configs.get("conf_OAuth2");
   let text = "";
   if (configs.get("Text") !== "" && configs.get("Text") !== null){
@@ -72,18 +67,17 @@ function main() {
     throw "Message to send isn't set.";
   }
 
-  sendMessage(token, oauth2, channel, text, attachment);
+  sendMessage(oauth2, channel, text, attachment);
 }
 
 /**
   * Send Message with Bots  チャット投稿
-  * @param {String} token
   * @param {String} oauth2 
   * @param {String} channel
   * @param {String} text 
   * @param {String} attachment
   */  
-function sendMessage(token, oauth2, channel, text, attachment) {
+function sendMessage(oauth2, channel, text, attachment) {
   let jsonReq = {};
   jsonReq["text"] = text;
   jsonReq["channel"] = channel;
@@ -95,17 +89,12 @@ function sendMessage(token, oauth2, channel, text, attachment) {
   }
 
   jsonReq["attachments"] = attachArray;
-
  
-  let request = httpClient.begin()
-  if (oauth2 !== "" && oauth2 !== null || token === "" || token === null){
-    request = request.authSetting(oauth2);
-  }else {
-    request = request.bearer(token);
-  } 
-    request = request.body(JSON.stringify(jsonReq), "application/json; charset=UTF-8");
-    const response = request.post("https://slack.com/api/chat.postMessage");
-
+  const url = 'https://slack.com/api/chat.postMessage';
+  const response = httpClient.begin()
+    .authSetting(oauth2)
+    .body(JSON.stringify(jsonReq), "application/json; charset=UTF-8")
+    .post(url);
   const status = response.getStatusCode();
   const responseTxt = response.getResponseAsString();
 
@@ -172,7 +161,6 @@ aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==</icon>
  * @return attachment
  */
 const prepareConfigs = (configs, channelName, text, fallback, color, title, titleLink, attachText) => {
-  configs.put('Token', 'Slack');
   configs.put('conf_OAuth2', 'Slack');
   configs.put('ChannelName', channelName);
   configs.put('Text', text);
@@ -225,7 +213,8 @@ const assertPostRequest = ({url, method, contentType, body}, channel, text, atta
 
 
 /**
- * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力でエラーになる場合
+ * チャット投稿失敗の場合
+ * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力
  */
 test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'channel1', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
@@ -241,10 +230,29 @@ test('Message to send isn\'t set', () => {
 });
 
 
+
 /**
- * GET API リクエストでエラーになる場合
+ * チャット投稿失敗の場合
+ * チャンネル　Attachment 要約　Attachment 色　以外が未入力
  */
-test('GET Failed', () => {
+test('Failed - channel Attachment-fallback Attachment-color', () => {
+  prepareConfigs(configs, 'channel8', '', 'fallback8', '#ff0000', '', '', '');
+
+  const attachment = {
+    "fallback": "fallback8",
+    "color": "#ff0000"
+  }
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Message to send isn't set`);
+});
+
+
+
+/**
+ * POST API リクエストでエラーになる場合
+ */
+test('POST Failed', () => {
   const attachment = prepareConfigs(configs, 'channel2', 'text2', 'fallback2', '#ff0000', 'title2', 'https://titleLink2', 'attachText2');
 
   httpClient.setRequestHandler((request) => {
@@ -283,13 +291,9 @@ const preparePostResponse = (channel,text) => {
 
 /**
  * チャット投稿成功の場合
- * oauth2を設定
  */
 test('Success', () => {
   const attachment = prepareConfigs(configs, 'channel3', 'text3', 'fallback3', '#ff0000', 'title3', 'https://titleLink3', 'attachText3');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
 
   httpClient.setRequestHandler((request) => {
     assertPostRequest(request, 'channel3', 'text3', attachment);
@@ -304,14 +308,10 @@ test('Success', () => {
 
 /**
  * チャット投稿成功の場合
- * Token を設定
  * Attachment 未入力
  */
 test('Success - no Attachments', () => {
   prepareConfigs(configs, 'channel4', 'text4', '', '', '', '', '');
-
-  //conf_OAuth2 を未設定の状態に上書き
-  configs.put('conf_OAuth2', '');
 
   const attachment = {};
 
@@ -327,115 +327,11 @@ test('Success - no Attachments', () => {
 
 
 /**
- * チャット投稿失敗の場合
- * oauth2を設定
- * 存在しないチャンネル
- */
-test('Failed - Non-existent channel', () => {
-  const attachment = prepareConfigs(configs, 'no-channel5', 'text5', 'fallback5', '#ff0000', 'title5', 'https://titleLink5', 'attachText5');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
-
-  httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'no-channel5', 'text5', attachment);
-    const responseObj = {
-      "ok": false,
-      "error": "channel_not_found"
-    };
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-  });
-
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);  
- });
- 
-
-   
-/**
- * チャット投稿失敗の場合
- * oauth2を設定
- * Botがjoinしていないチャンネル名
- */
-test('Failed - Channel that bot is not joining', () => {
-  const attachment = prepareConfigs(configs, 'no-join6', 'text6', 'fallback6', '#ff0000', 'title6', 'https://titleLink6', 'attachText6');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
-
-  httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'no-join6', 'text6', attachment);
-    const responseObj = {
-      "ok": false,
-      "error": "not_in_channel"
-    };
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-  });
-
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
-});
-
-
-
-/**
- * チャット投稿失敗の場合
- * oauth2を設定
- * Botがjoinしていないプライベートチャンネル
- */
-test('Failed - Private channel that bot is not joining', () => {
-  const attachment = prepareConfigs(configs, 'no-join7', 'text7', 'fallback7', '#ff0000', 'title7', 'https://titleLink7', 'attachText7');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
-
-  httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'no-join7', 'text7', attachment);
-    const responseObj = {
-      "ok": false,
-      "error": "channel_not_found"
-    };
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-  });
-
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
-});
-
-
-
-/**
- * チャット投稿失敗の場合
- * Token を設定
- * チャンネル　Attachment 要約　Attachment 色　以外が未入力
- */
-test('Failed - channel Attachment-fallback Attachment-color', () => {
-  prepareConfigs(configs, 'channel8', '', 'fallback8', '#ff0000', '', '', '');
-
-  //conf_OAuth2 を未設定の状態に上書き
-  configs.put('conf_OAuth2', '');
-
-  const attachment = {
-    "fallback": "fallback",
-    "color": "#ff0000"
-  }
-
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Message to send isn't set`);
-});
-
-
-
-/**
  * チャット投稿成功の場合
- * oauth2を設定
  * チャンネル　Attachment 色　Attachment テキスト　以外が未入力
  */
 test('Success - channel Attachment-color Attachment-text ', () => {
   prepareConfigs(configs, 'channel9', '', '', '#ff0000', '', '', 'attachText9');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
   
   const attachment = {
     "color": "#ff0000",
@@ -455,14 +351,10 @@ test('Success - channel Attachment-color Attachment-text ', () => {
 
 /**
  * チャット投稿成功の場合
- * oauth2を設定
  * Cannel Attachment タイトル　Attachment タイトルリンク　Attachment テキスト　を入力
  */
 test('Success - channel Attachment-title Attachment-titlelink Attachment-text ', () => {
   prepareConfigs(configs, 'channel10', '', '', '', 'title10', 'https://titleLink10', 'attachText10');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
   
   const attachment = {
     "title": "title10",
@@ -483,14 +375,10 @@ test('Success - channel Attachment-title Attachment-titlelink Attachment-text ',
 
 /**
  * チャット投稿成功の場合
- * oauth2を設定
  * Attachment 色が無効
  */
 test('Success - Invalid color setting', () => {
   const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'https://titleLink11', 'attachText11');
-
-  //Token を未設定の状態に上書き
-  configs.put('Token', '');
 
   httpClient.setRequestHandler((request) => {
     assertPostRequest(request, 'channel11', 'text11', attachment);
@@ -499,6 +387,50 @@ test('Success - Invalid color setting', () => {
 
   // <script> のスクリプトを実行
   execute();
+});
+
+
+
+/**
+ * チャット投稿失敗の場合
+ * 存在しないチャンネル
+ */
+test('Failed - Non-existent channel', () => {
+  const attachment = prepareConfigs(configs, 'no-channel5', 'text5', 'fallback5', '#ff0000', 'title5', 'https://titleLink5', 'attachText5');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'no-channel5', 'text5', attachment);
+    const responseObj = {
+      "ok": false,
+      "error": "channel_not_found"
+    };
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);  
+ });
+ 
+
+   
+/**
+ * チャット投稿失敗の場合
+ * Botがjoinしていないチャンネル名
+ */
+test('Failed - Channel that bot is not joining', () => {
+  const attachment = prepareConfigs(configs, 'no-join6', 'text6', 'fallback6', '#ff0000', 'title6', 'https://titleLink6', 'attachText6');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'no-join6', 'text6', attachment);
+    const responseObj = {
+      "ok": false,
+      "error": "not_in_channel"
+    };
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);
 });
 
 ]]></test>

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-04-25</last-modified>
+<last-modified>2022-04-26</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
@@ -237,7 +237,6 @@ test('Message to send isn\'t set', () => {
   }
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-
    expect(execute).toThrow(`Message to send isn\'t set.`);
 });
 
@@ -299,7 +298,6 @@ test('Success', () => {
 
   // <script> のスクリプトを実行
   execute();
-
 });
 
 
@@ -309,7 +307,7 @@ test('Success', () => {
  * Token を設定
  * Attachment 未入力
  */
-test('Success - set Token and no Attachments', () => {
+test('Success - no Attachments', () => {
   prepareConfigs(configs, 'channel4', 'text4', '', '', '', '', '');
 
   //conf_OAuth2 を未設定の状態に上書き
@@ -324,7 +322,6 @@ test('Success - set Token and no Attachments', () => {
 
   // <script> のスクリプトを実行
   execute();
-
 });
 
 
@@ -346,13 +343,162 @@ test('Failed - Non-existent channel', () => {
       "ok": false,
       "error": "channel_not_found"
     };
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(responseObj)));
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);  
+ });
+ 
+
+   
+/**
+ * チャット投稿失敗の場合
+ * oauth2を設定
+ * Botがjoinしていないチャンネル名
+ */
+test('Failed - Channel that bot is not joining', () => {
+  const attachment = prepareConfigs(configs, 'no-join6', 'text6', 'fallback6', '#ff0000', 'title6', 'https://titleLink6', 'attachText6');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'no-join6', 'text6', attachment);
+    const responseObj = {
+      "ok": false,
+      "error": "not_in_channel"
+    };
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
    expect(execute).toThrow(`Failed to send`);
+});
 
 
+
+/**
+ * チャット投稿失敗の場合
+ * oauth2を設定
+ * Botがjoinしていないプライベートチャンネル
+ */
+test('Failed - Private channel that bot is not joining', () => {
+  const attachment = prepareConfigs(configs, 'no-join7', 'text7', 'fallback7', '#ff0000', 'title7', 'https://titleLink7', 'attachText7');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'no-join7', 'text7', attachment);
+    const responseObj = {
+      "ok": false,
+      "error": "channel_not_found"
+    };
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);
+});
+
+
+
+/**
+ * チャット投稿失敗の場合
+ * Token を設定
+ * チャンネル　Attachment 要約　Attachment 色　以外が未入力
+ */
+test('Failed - channel Attachment-fallback Attachment-color', () => {
+  prepareConfigs(configs, 'channel8', '', 'fallback8', '#ff0000', '', '', '');
+
+  //conf_OAuth2 を未設定の状態に上書き
+  configs.put('conf_OAuth2', '');
+
+  const attachment = {
+    "fallback": "fallback",
+    "color": "#ff0000"
+  }
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Message to send isn't set`);
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * oauth2を設定
+ * チャンネル　Attachment 色　Attachment テキスト　以外が未入力
+ */
+test('Success - channel Attachment-color Attachment-text ', () => {
+  prepareConfigs(configs, 'channel9', '', '', '#ff0000', '', '', 'attachText9');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+  
+  const attachment = {
+    "color": "#ff0000",
+    "text": "attachText9"
+  }
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel9', '', attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('channel9', '')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * oauth2を設定
+ * Cannel Attachment タイトル　Attachment タイトルリンク　Attachment テキスト　を入力
+ */
+test('Success - channel Attachment-title Attachment-titlelink Attachment-text ', () => {
+  prepareConfigs(configs, 'channel10', '', '', '', 'title10', 'https://titleLink10', 'attachText10');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+  
+  const attachment = {
+    "title": "title10",
+    "title_link": "https://titleLink10",
+    "text": "attachText10"
+  }
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel10', '', attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('channel10', '')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * oauth2を設定
+ * Attachment 色が無効
+ */
+test('Success - Invalid color setting', () => {
+  const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'https://titleLink11', 'attachText11');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel11', 'text11', attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('channel11', 'text11')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
 });
 
 ]]></test>

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -219,11 +219,6 @@ const assertPostRequest = ({url, method, contentType, body}, channel, text, atta
 test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'channel1', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
 
-  const attachment = {
-    "fallback": "fallback1",
-    "color": "#ff0000",
-    "title_link": "https://titleLink1"
-  }
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
    expect(execute).toThrow(`Message to send isn\'t set.`);
@@ -233,15 +228,11 @@ test('Message to send isn\'t set', () => {
 
 /**
  * チャット投稿失敗の場合
- * チャンネル　Attachment 要約　Attachment 色　以外が未入力
+ * チャンネル　Attachment 要約　Attachment 色　を入力
  */
 test('Failed - channel Attachment-fallback Attachment-color', () => {
   prepareConfigs(configs, 'channel8', '', 'fallback8', '#ff0000', '', '', '');
 
-  const attachment = {
-    "fallback": "fallback8",
-    "color": "#ff0000"
-  }
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
    expect(execute).toThrow(`Message to send isn't set`);
@@ -328,7 +319,7 @@ test('Success - no Attachments', () => {
 
 /**
  * チャット投稿成功の場合
- * チャンネル　Attachment 色　Attachment テキスト　以外が未入力
+ * チャンネル　Attachment 色　Attachment テキスト　を入力
  */
 test('Success - channel Attachment-color Attachment-text ', () => {
   prepareConfigs(configs, 'channel9', '', '', '#ff0000', '', '', 'attachText9');
@@ -375,7 +366,7 @@ test('Success - channel Attachment-title Attachment-titlelink Attachment-text ',
 
 /**
  * チャット投稿成功の場合
- * Attachment 色が無効
+ * Attachment 色が無効（無効であるが、チャット投稿は成功する）
  */
 test('Success - Invalid color setting', () => {
   const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'https://titleLink11', 'attachText11');

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -286,13 +286,15 @@ test('Success', () => {
 
 /**
  * チャット投稿成功の場合
- * チャンネル、 テキストを入力　（Attachmentは未入力）
+ * チャンネル、 テキストを入力
  * Message to send isn't set　のエラーにならない条件①
  * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ * ※Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
  */
-test('Success - Channel and Text - no Attachments', () => {
-  prepareConfigs(configs, 'channel4', 'text4', '', '', '', '', '');
+test('Success - Channel,Text and Attachment-titlelink', () => {
+  prepareConfigs(configs, 'channel4', 'text4', '', '', '', 'https://titleLink4', '');
 
+  //Attachmentタイトルが未設定のため、Attachmentタイトルリンクは設定されず、オブジェクトは空
   const attachment = {};
 
   httpClient.setRequestHandler((request) => {
@@ -317,7 +319,7 @@ test('Success - Channel and Attachment-text ', () => {
   
   const attachment = {
     "text": "attachText9"
-  }
+  };
 
   httpClient.setRequestHandler((request) => {
     assertPostRequest(request, 'channel9', '', attachment);
@@ -341,7 +343,7 @@ test('Success - Channel and Attachment-title ', () => {
   
   const attachment = {
     "title": "title10"
-  }
+  };
 
   httpClient.setRequestHandler((request) => {
     assertPostRequest(request, 'channel10', '', attachment);
@@ -357,9 +359,10 @@ test('Success - Channel and Attachment-title ', () => {
 /**
  * チャット投稿成功の場合
  * Attachment色が無効（無効であるが、チャット投稿は成功する）
+ * ※AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
  */
-test('Success - Invalid color setting', () => {
-  const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'https://titleLink11', 'attachText11');
+test('Success - Invalid color setting and Invalid title-link setting', () => {
+  const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'titleLink11', 'attachText11');
 
   httpClient.setRequestHandler((request) => {
     assertPostRequest(request, 'channel11', 'text11', attachment);

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-05-02</last-modified>
+<last-modified>2022-05-09</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
 <label locale="ja">Slack: チャット投稿 (Bots)</label>
-<summary>Sends a message to Slack with Bots.</summary>
-<summary locale="ja">Bots 機能を使って Slack にメッセージを投稿します。</summary>
+<summary>This item sends a message to Slack with Bots.</summary>
+<summary locale="ja">この工程は、Bots 機能を使って Slack にメッセージを投稿します。</summary>
 <configs>
   <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
     <label>C1: OAuth2 Setting</label>

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-04-28</last-modified>
+<last-modified>2022-05-02</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
@@ -215,6 +215,7 @@ const assertPostRequest = ({url, method, contentType, body}, channel, text, atta
 /**
  * チャット投稿失敗の場合
  * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力
+ * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
  */
 test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'channel1', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
@@ -222,20 +223,6 @@ test('Message to send isn\'t set', () => {
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
    expect(execute).toThrow(`Message to send isn\'t set.`);
-});
-
-
-
-/**
- * チャット投稿失敗の場合
- * チャンネル　Attachment 要約　Attachment 色　を入力
- */
-test('Failed - channel Attachment-fallback Attachment-color', () => {
-  prepareConfigs(configs, 'channel8', '', 'fallback8', '#ff0000', '', '', '');
-
-
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Message to send isn't set`);
 });
 
 
@@ -299,9 +286,11 @@ test('Success', () => {
 
 /**
  * チャット投稿成功の場合
- * Attachment 未入力
+ * チャンネル、 テキストを入力　（Attachmentは未入力）
+ * Message to send isn't set　のエラーにならない条件①
+ * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
-test('Success - no Attachments', () => {
+test('Success - Channel and Text - no Attachments', () => {
   prepareConfigs(configs, 'channel4', 'text4', '', '', '', '', '');
 
   const attachment = {};
@@ -319,13 +308,14 @@ test('Success - no Attachments', () => {
 
 /**
  * チャット投稿成功の場合
- * チャンネル　Attachment 色　Attachment テキスト　を入力
+ * チャンネル、Attachmentテキスト を入力  （テキストは空）
+ * Message to send isn't set　のエラーにならない条件②
+ * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
-test('Success - channel Attachment-color Attachment-text ', () => {
-  prepareConfigs(configs, 'channel9', '', '', '#ff0000', '', '', 'attachText9');
+test('Success - Channel and Attachment-text ', () => {
+  prepareConfigs(configs, 'channel9', '', '', '', '', '', 'attachText9');
   
   const attachment = {
-    "color": "#ff0000",
     "text": "attachText9"
   }
 
@@ -342,15 +332,15 @@ test('Success - channel Attachment-color Attachment-text ', () => {
 
 /**
  * チャット投稿成功の場合
- * Cannel Attachment タイトル　Attachment タイトルリンク　Attachment テキスト　を入力
+ * チャンネル、Attachmentタイトルを入力 （テキストは空）
+ * Message to send isn't set　のエラーにならない条件③
+ * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
-test('Success - channel Attachment-title Attachment-titlelink Attachment-text ', () => {
-  prepareConfigs(configs, 'channel10', '', '', '', 'title10', 'https://titleLink10', 'attachText10');
+test('Success - Channel and Attachment-title ', () => {
+  prepareConfigs(configs, 'channel10', '', '', '', 'title10', '', '');
   
   const attachment = {
-    "title": "title10",
-    "title_link": "https://titleLink10",
-    "text": "attachText10"
+    "title": "title10"
   }
 
   httpClient.setRequestHandler((request) => {
@@ -366,7 +356,7 @@ test('Success - channel Attachment-title Attachment-titlelink Attachment-text ',
 
 /**
  * チャット投稿成功の場合
- * Attachment 色が無効（無効であるが、チャット投稿は成功する）
+ * Attachment色が無効（無効であるが、チャット投稿は成功する）
  */
 test('Success - Invalid color setting', () => {
   const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'https://titleLink11', 'attachText11');
@@ -406,7 +396,7 @@ test('Failed - Non-existent channel', () => {
    
 /**
  * チャット投稿失敗の場合
- * Botがjoinしていないチャンネル名
+ * Bot が join していないチャンネル
  */
 test('Failed - Channel that bot is not joining', () => {
   const attachment = prepareConfigs(configs, 'no-join6', 'text6', 'fallback6', '#ff0000', 'title6', 'https://titleLink6', 'attachText6');

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-08-26</last-modified>
+<last-modified>2022-04-25</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
@@ -155,4 +155,205 @@ snKy8OOVGwo3lXdOVCNS24rlAKSz4ObVm7BttiuGQ/IiuhWzF2qG0Z6ju1FpqRT19B/rR421Bto0
 rfAfc/tLBdVJAeKGUbgUk4/j5UXL4bx+UuiOLK6NpRZhMFVUV4iJaq/fnwxAfhwLEOElNOFGwUpu
 U91zuPLlIGYD4c2bTci0dC2uf3MjmXHlhSQiqWYlS25FIfFkltP/31L6X3jivtfyCMSSfpiIEEv5
 aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==</icon>
+
+<test><![CDATA[
+
+
+/**
+ * 設定の準備
+ * @param configs
+ * @param ChannelName
+ * @param Text
+ * @param Fallback
+ * @param Color
+ * @param Title
+ * @param TitleLink
+ * @param AttachText
+ * @return attachment
+ */
+const prepareConfigs = (configs, channelName, text, fallback, color, title, titleLink, attachText) => {
+  configs.put('Token', 'Slack');
+  configs.put('conf_OAuth2', 'Slack');
+  configs.put('ChannelName', channelName);
+  configs.put('Text', text);
+  configs.put('Fallback', fallback);
+  configs.put('Color', color);
+  configs.put('Title', title);
+  configs.put('TitleLink', titleLink);
+  configs.put('AttachText', attachText);
+
+  const attachment = {
+    "fallback": fallback,
+    "color": color,
+    "title": title,
+    "title_link": titleLink,
+    "text": attachText
+  }
+
+  return attachment;
+};
+
+
+/**
+ * リクエストのテスト
+ * @param {Object} request
+ * @param request.url
+ * @param request.method
+ * @param request.contentType
+ * @param request.body
+ * @param channel
+ * @param text
+ * @param attachment
+ */
+const assertPostRequest = ({url, method, contentType, body}, channel, text, attachment) => {
+    expect(url).toEqual('https://slack.com/api/chat.postMessage');	
+    expect(method).toEqual('POST');
+    expect(contentType).toEqual('application/json; charset=UTF-8');
+    const bodyObj = JSON.parse(body);
+    expect(bodyObj.text).toEqual(text);
+    expect(bodyObj.channel).toEqual(channel);
+    expect(bodyObj.as_user).toEqual('true');
+
+    let attachArray = [];
+    if (Object.keys(attachment).length !== 0) {
+      attachArray.push(attachment);
+    }
+
+    expect(bodyObj.attachments).toEqual(attachArray);
+};
+
+
+
+/**
+ * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力でエラーになる場合
+ */
+test('Message to send isn\'t set', () => {
+  prepareConfigs(configs, 'channel1', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
+
+  const attachment = {
+    "fallback": "fallback1",
+    "color": "#ff0000",
+    "title_link": "https://titleLink1"
+  }
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+
+   expect(execute).toThrow(`Message to send isn\'t set.`);
+});
+
+
+/**
+ * GET API リクエストでエラーになる場合
+ */
+test('GET Failed', () => {
+  const attachment = prepareConfigs(configs, 'channel2', 'text2', 'fallback2', '#ff0000', 'title2', 'https://titleLink2', 'attachText2');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel2', 'text2', attachment);
+    return httpClient.createHttpResponse(400,'application/json', '{}');
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);
+});
+
+
+
+/**
+ * POST リクエストのレスポンスを準備
+ * @param channel
+ * @param text
+ * @return responseObj
+ */
+const preparePostResponse = (channel,text) => {
+  return {
+    "ok": true,
+    "channel": `${channel}`,
+    "ts": "1650857142.223299",
+    "message": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": `${text}`,
+        "ts": "1650857142.223299",
+        "bot_id": "B01JPAT1P4J"
+    }
+  };
+};
+
+
+
+/**
+ * チャット投稿成功の場合
+ * oauth2を設定
+ */
+test('Success', () => {
+  const attachment = prepareConfigs(configs, 'channel3', 'text3', 'fallback3', '#ff0000', 'title3', 'https://titleLink3', 'attachText3');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel3', 'text3', attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('channel3', 'text3')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * Token を設定
+ * Attachment 未入力
+ */
+test('Success - set Token and no Attachments', () => {
+  prepareConfigs(configs, 'channel4', 'text4', '', '', '', '', '');
+
+  //conf_OAuth2 を未設定の状態に上書き
+  configs.put('conf_OAuth2', '');
+
+  const attachment = {};
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'channel4', 'text4', attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('channel4', 'text4')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+
+});
+
+
+
+/**
+ * チャット投稿失敗の場合
+ * oauth2を設定
+ * 存在しないチャンネル
+ */
+test('Failed - Non-existent channel', () => {
+  const attachment = prepareConfigs(configs, 'no-channel5', 'text5', 'fallback5', '#ff0000', 'title5', 'https://titleLink5', 'attachText5');
+
+  //Token を未設定の状態に上書き
+  configs.put('Token', '');
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'no-channel5', 'text5', attachment);
+    const responseObj = {
+      "ok": false,
+      "error": "channel_not_found"
+    };
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(responseObj)));
+  });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send`);
+
+
+});
+
+]]></test>
 </service-task-definition>

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -5,7 +5,7 @@
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Bots)</label>
 <label locale="ja">Slack: チャット投稿 (Bots)</label>
-<summary>Send a message to Slack with Bots.</summary>
+<summary>Sends a message to Slack with Bots.</summary>
 <summary locale="ja">Bots 機能を使って Slack にメッセージを投稿します。</summary>
 <configs>
   <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
@@ -215,7 +215,7 @@ const assertPostRequest = ({url, method, contentType, body}, channel, text, atta
 /**
  * チャット投稿失敗の場合
  * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力
- * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
  */
 test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'channel1', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
@@ -288,8 +288,8 @@ test('Success', () => {
  * チャット投稿成功の場合
  * チャンネル、 テキストを入力
  * Message to send isn't set　のエラーにならない条件①
- * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
- * ※Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ * Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
  */
 test('Success - Channel,Text and Attachment-titlelink', () => {
   prepareConfigs(configs, 'channel4', 'text4', '', '', '', 'https://titleLink4', '');
@@ -312,7 +312,7 @@ test('Success - Channel,Text and Attachment-titlelink', () => {
  * チャット投稿成功の場合
  * チャンネル、Attachmentテキスト を入力  （テキストは空）
  * Message to send isn't set　のエラーにならない条件②
- * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
 test('Success - Channel and Attachment-text ', () => {
   prepareConfigs(configs, 'channel9', '', '', '', '', '', 'attachText9');
@@ -336,7 +336,7 @@ test('Success - Channel and Attachment-text ', () => {
  * チャット投稿成功の場合
  * チャンネル、Attachmentタイトルを入力 （テキストは空）
  * Message to send isn't set　のエラーにならない条件③
- * ※「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
 test('Success - Channel and Attachment-title ', () => {
   prepareConfigs(configs, 'channel10', '', '', '', 'title10', '', '');
@@ -359,7 +359,7 @@ test('Success - Channel and Attachment-title ', () => {
 /**
  * チャット投稿成功の場合
  * Attachment色が無効（無効であるが、チャット投稿は成功する）
- * ※AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
+ * AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
  */
 test('Success - Invalid color setting and Invalid title-link setting', () => {
   const attachment = prepareConfigs(configs, 'channel11', 'text11', 'fallback11', '#qqq???', 'title11', 'titleLink11', 'attachText11');


### PR DESCRIPTION
``@hatanaka-akihiro  さん

テストコード　337 行目以降
チャット投稿失敗の場合（存在しないチャンネル）について質問です。

このテストは、エラーですが、ステータスコード200で、レスポンスオブジェクトも返します。

ビルドすると、下記エラーになります。
```
org.graalvm.polyglot.PolyglotException: 

Expected: a string containing "Failed to send"
     but: was "function is expected to be throw error"
```

`expect(execute).toThrow(`Failed to send`);`
と書いてはいけないのでしょうか？