### PR TITLE
t8319: kintone: レコード追加　単体テストの追加／summary の変更

### DIFF
--- a/kintone-record-add.xml
+++ b/kintone-record-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>kintone: Add New Record</label>
 <label locale="ja">kintone: レコード追加</label>
-<last-modified>2022-06-28</last-modified>
+<last-modified>2022-06-30</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>This item adds a new record to a Kintone App.</summary>
@@ -275,6 +275,11 @@ const prepareConfigs = (configs, basic, domain, guestSpaceId, appId) => {
   configs.put('conf_domain', domain);
   configs.put('conf_guestSpaceId', guestSpaceId);
   configs.put('conf_appId', appId);
+
+  for (let i = 0; i < FIELD_SIZE; i++) {
+    configs.put(`conf_fieldCode${i+1}`, '');
+    configs.put(`conf_fieldValue${i+1}`, '');	
+  }; 
   
   // 文字型データ項目を準備して、config に指定
   const recordIdDef = engine.createDataDefinition('レコードの ID', 1, 'q_record_id', 'STRING_TEXTAREA');
@@ -292,11 +297,10 @@ const prepareConfigs = (configs, basic, domain, guestSpaceId, appId) => {
  * ドメインが不正な文字列でエラーになる場合
  */
 test('Invalid Kintone domain', () => {
-  const data = ['test1', '', '', '', '', '', ''];
   prepareConfigs(configs, '', 'invalidDomain', '', '1' );
 
   configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  configs.put(`conf_fieldValue1`, data[0]);
+  configs.put(`conf_fieldValue1`, 'test1');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid Kintone domain.');
@@ -307,11 +311,10 @@ test('Invalid Kintone domain', () => {
  * ゲストスペース ID が不正な文字列でエラーになる場合
  */
 test('Invalid Guest Space ID', () => {
-  const data = ['test1', '', '', '', '', '', ''];
   prepareConfigs(configs, '', 'test.cybozu.com', '-1', '2');
 
-  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  configs.put(`conf_fieldValue1`, data[0]);
+  configs.put(`conf_fieldCode2`, `フィールドコード_2`);
+  configs.put(`conf_fieldValue2`, 'test2');
   
   // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid Guest Space ID.');
@@ -322,11 +325,10 @@ test('Invalid Guest Space ID', () => {
  * アプリ ID が不正な文字列でエラーになる場合
  */
 test('Invalid App ID', () => {
-  const data = ['test1', '', '', '', '', '', ''];
   prepareConfigs(configs, '', 'test.kintone.com', '1', '2.3');
 
-  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  configs.put(`conf_fieldValue1`, data[0]);
+  configs.put(`conf_fieldCode3`, `フィールドコード_3`);
+  configs.put(`conf_fieldValue3`, 'test3');
   
   // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid App ID.');
@@ -337,12 +339,11 @@ test('Invalid App ID', () => {
  * フィールドコードが重複して指定されていて、エラーになる場合
  */
 test('The same Field Code is set multiple times', () => {
-  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
   prepareConfigs(configs, '', 'test.cybozu.com', '1', '1');
  
   for (let i = 0; i < FIELD_SIZE; i++) {
     configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
-    configs.put(`conf_fieldValue${i+1}`, data[i]);	
+    configs.put(`conf_fieldValue${i+1}`, `test${i+1}`);	
   }; 
 
   // 2 番目のフィールドコードを 1 番目と同様に
@@ -384,16 +385,15 @@ const assertRequest = ({url, method, body}, domain, guestSpaceId, appId, recordO
  * POST リクエスト失敗
  */
 test('POST Failed', () => {
-  const data = ['test1', '', '', '', '', '', ''];
   prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   const recordObj = {};  
   
-  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  configs.put(`conf_fieldValue1`, data[0]);
+  configs.put(`conf_fieldCode4`, `フィールドコード_4`);
+  configs.put(`conf_fieldValue4`, 'test4');
 
-  recordObj[`フィールドコード_1`] = {
-    "value": data[0]
+  recordObj[`フィールドコード_4`] = {
+    "value": 'test4'
   };
 
   httpClient.setRequestHandler((request) => {        
@@ -412,17 +412,16 @@ test('POST Failed', () => {
  * 正しいフィールドコードを７つの項目全てに指定
  */
 test('Sucsess - 7fieldCodes', () => {
-  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
   const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   const recordObj = {};  
   
   for (let i = 0; i < FIELD_SIZE; i++) {
     configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
-    configs.put(`conf_fieldValue${i+1}`, data[i]);
+    configs.put(`conf_fieldValue${i+1}`, `test${i+1}`);
 	
     recordObj[`フィールドコード_${i+1}`] = {
-      "value": data[i]
+      "value":`test${i+1}`
     };
   };
   
@@ -456,7 +455,6 @@ test('Sucsess - fieldValue is empty', () => {
   const recordObj = {};  
   
   configs.put(`conf_fieldCode2`, `フィールドコード_2`);
-  configs.put(`conf_fieldValue2`, '');
 	
   recordObj[`フィールドコード_2`] = {
     "value": null
@@ -484,13 +482,11 @@ test('Sucsess - fieldValue is empty', () => {
  * 全てのフィールドコードが空白（値の設定はするが、対応するフィールドコードの設定が空）
  */
 test('Sucsess - 7fieldCodes are empty', () => {
-  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
   const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   
   for (let i = 0; i < FIELD_SIZE; i++) {
-    configs.put(`conf_fieldCode${i+1}`, ``); //全てのフィールドコードが空白
-    configs.put(`conf_fieldValue${i+1}`, data[i]);	
+    configs.put(`conf_fieldValue${i+1}`, `test${i+1}`);	
   };
   const recordObj = {}; //フィールドコードの設定が空の場合、値の設定が無視される
   

--- a/kintone-record-add.xml
+++ b/kintone-record-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>kintone: Add New Record</label>
 <label locale="ja">kintone: レコード追加</label>
-<last-modified>2022-06-23</last-modified>
+<last-modified>2022-06-27</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>This item adds a new record to a Kintone App.</summary>
@@ -269,7 +269,7 @@ const FIELD_SIZE = 7;
  * @param guestSpaceId
  * @param appId
  */
-const prepareConfigs = (basic, domain, guestSpaceId, appId) => {
+const prepareConfigs = (configs, basic, domain, guestSpaceId, appId) => {
   configs.put('conf_auth', 'kintone');  
   configs.put('conf_basic', basic);
   configs.put('conf_domain', domain);
@@ -293,17 +293,12 @@ const prepareConfigs = (basic, domain, guestSpaceId, appId) => {
  */
 test('Invalid Kintone domain', () => {
   const data = ['test1', '', '', '', '', '', ''];
-  prepareConfigs('', 'invalidDomain', '', '1' );
+  prepareConfigs(configs, '', 'invalidDomain', '', '1' );
 
-  const recordObj = {};
+  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  configs.put(`conf_fieldValue1`, data[0]);
 
-  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
-
-  recordObj[fieldCode] = {
-    "value": fieldValue
-  };
-
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid Kintone domain.');
 });
 
@@ -313,17 +308,12 @@ test('Invalid Kintone domain', () => {
  */
 test('Invalid Guest Space ID', () => {
   const data = ['test1', '', '', '', '', '', ''];
-  prepareConfigs('', 'test.cybozu.com', '-1', '2');
+  prepareConfigs(configs, '', 'test.cybozu.com', '-1', '2');
 
-  const recordObj = {};
-
-  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
-
-  recordObj[fieldCode] = {
-    "value": fieldValue
-  };
+  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  configs.put(`conf_fieldValue1`, data[0]);
   
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid Guest Space ID.');
 });
 
@@ -333,17 +323,12 @@ test('Invalid Guest Space ID', () => {
  */
 test('Invalid App ID', () => {
   const data = ['test1', '', '', '', '', '', ''];
-  prepareConfigs('', 'test.kintone.com', '1', '2.3');
+  prepareConfigs(configs, '', 'test.kintone.com', '1', '2.3');
 
-  const recordObj = {};  
+  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  configs.put(`conf_fieldValue1`, data[0]);
   
-  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
-
-  recordObj[fieldCode] = {
-    "value": fieldValue
-  };
-    
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Invalid App ID.');
 });
 
@@ -353,22 +338,17 @@ test('Invalid App ID', () => {
  */
 test('The same Field Code is set multiple times', () => {
   const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
-  prepareConfigs('', 'test.cybozu.com', '1', '1');
-
-  const recordObj = {};
-
+  prepareConfigs(configs, '', 'test.cybozu.com', '1', '1');
+ 
   for (let i = 0; i < FIELD_SIZE; i++) {
-    let fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
-    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
-	
-	recordObj[fieldCode] = {
-      "value": fieldValue
-    };
+    configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+    configs.put(`conf_fieldValue${i+1}`, data[i]);	
   }; 
 
   // 2 番目のフィールドコードを 1 番目と同様に
   configs.put('conf_fieldCode2', 'フィールドコード_1'); 
 
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('The same Field Code is set multiple times.');
 });
 
@@ -395,7 +375,7 @@ const assertRequest = ({url, method, body}, domain, guestSpaceId, appId, recordO
   
   const bodyObj = JSON.parse(body);
   expect(bodyObj.app).toEqual(appId);
-//  expect(bodyObj.record).toEqual(recordObj);
+  expect(bodyObj.record).toEqual(recordObj);
 
 };
 
@@ -405,21 +385,21 @@ const assertRequest = ({url, method, body}, domain, guestSpaceId, appId, recordO
  */
 test('POST Failed', () => {
   const data = ['test1', '', '', '', '', '', ''];
-  prepareConfigs('', 'test.cybozu.com', '', '1');
+  prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   const recordObj = {};  
   
-  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
-  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
-	
-  recordObj[fieldCode] = {
-    "value": fieldValue
+  configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  configs.put(`conf_fieldValue1`, data[0]);
+
+  recordObj[`フィールドコード_1`] = {
+    "value": data[0]
   };
 
   httpClient.setRequestHandler((request) => {        
     assertRequest(request, 'test.cybozu.com', '', '1', recordObj);       
-        return httpClient.createHttpResponse(400, 'application/json', '{}');
-    });
+    return httpClient.createHttpResponse(400, 'application/json', '{}');
+  });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
   expect(execute).toThrow('Failed to add record. status: 400');
@@ -433,16 +413,16 @@ test('POST Failed', () => {
  */
 test('Sucsess - 7fieldCodes', () => {
   const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
-  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+  const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   const recordObj = {};  
   
   for (let i = 0; i < FIELD_SIZE; i++) {
-    let fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
-    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+    configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+    configs.put(`conf_fieldValue${i+1}`, data[i]);
 	
-	recordObj[fieldCode] = {
-      "value": fieldValue
+	recordObj[`フィールドコード_${i+1}`] = {
+      "value": data[i]
     };
   };
   
@@ -451,14 +431,14 @@ test('Sucsess - 7fieldCodes', () => {
     const responseObj = {
       "id": "2"
     };        
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-    });
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
 
-    // <script> のスクリプトを実行
-    execute();
+  // <script> のスクリプトを実行
+  execute();
 
-    // 文字型データ項目の値をチェック
-    expect(engine.findData(recordIdDef)).toEqual('2');
+  // 文字型データ項目の値をチェック
+  expect(engine.findData(recordIdDef)).toEqual('2');
 });
 
 
@@ -472,15 +452,15 @@ test('Sucsess - 7fieldCodes', () => {
  */
 test('Sucsess - fieldValue is empty', () => {
   const data = ['', '', '', '', '', '', ''];
-  const recordIdDef = prepareConfigs('basic', 'test.cybozu.com', '1', '1');
+  const recordIdDef = prepareConfigs(configs, 'basic', 'test.cybozu.com', '1', '1');
 
   const recordObj = {};  
   
-  let fieldCode = configs.put(`conf_fieldCode2`, `フィールドコード_2`);
-  let fieldValue = configs.put(`conf_fieldValue2`, data[1]);
+  configs.put(`conf_fieldCode2`, `フィールドコード_2`);
+  configs.put(`conf_fieldValue2`, data[1]);
 	
-  recordObj[fieldCode] = {
-    "value": fieldValue
+  recordObj[`フィールドコード_2`] = {
+    "value": null
   };
   
   httpClient.setRequestHandler((request) => {        
@@ -488,14 +468,14 @@ test('Sucsess - fieldValue is empty', () => {
     const responseObj = {
       "id": "3"
     };        
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-    });
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
 
-    // <script> のスクリプトを実行
-    execute();
+  // <script> のスクリプトを実行
+  execute();
 
-    // 文字型データ項目の値をチェック
-    expect(engine.findData(recordIdDef)).toEqual('3');
+  // 文字型データ項目の値をチェック
+  expect(engine.findData(recordIdDef)).toEqual('3');
 });
 
 
@@ -506,32 +486,28 @@ test('Sucsess - fieldValue is empty', () => {
  */
 test('Sucsess - 7fieldCodes are empty', () => {
   const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
-  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+  const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
-  const recordObj = {};  
   
   for (let i = 0; i < FIELD_SIZE; i++) {
-    let fieldCode = configs.put(`conf_fieldCode${i+1}`, ``); //全てのフィールドコードが空白
-    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
-	
-	recordObj[fieldCode] = {
-      "value": fieldValue
-    };
+    configs.put(`conf_fieldCode${i+1}`, ``); //全てのフィールドコードが空白
+    configs.put(`conf_fieldValue${i+1}`, data[i]);	
   };
+  const recordObj = {};
   
   httpClient.setRequestHandler((request) => {        
     assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
     const responseObj = {
       "id": "4"
     };        
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-    });
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
 
-    // <script> のスクリプトを実行
-    execute();
+  // <script> のスクリプトを実行
+  execute();
 
-    // 文字型データ項目の値をチェック
-    expect(engine.findData(recordIdDef)).toEqual('4');
+  // 文字型データ項目の値をチェック
+  expect(engine.findData(recordIdDef)).toEqual('4');
 });
 
 
@@ -542,22 +518,28 @@ test('Sucsess - 7fieldCodes are empty', () => {
  */
 test('Sucsess - Non-existent fieldcode', () => {
   const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
-  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+  const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
 
   const recordObj = {};  
   let fieldCode;
 
   for (let i = 0; i < FIELD_SIZE; i++) {
     if (i === 2) { // 3 番目を存在しないフィールドコードに 
-      fieldCode = configs.put(`conf_fieldCode${i+1}`, `存在しないフィールドコード`);
+      configs.put(`conf_fieldCode${i+1}`, `存在しないフィールドコード`);
 	}else{
-      fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+      configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
     }
-    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+    configs.put(`conf_fieldValue${i+1}`, data[i]);
 
-	recordObj[fieldCode] = {
-      "value": fieldValue
-    };
+    if (i === 2) {
+	  recordObj[`存在しないフィールドコード`] = {
+        "value": data[i]
+      };
+    }else{
+      recordObj[`フィールドコード_${i+1}`] = {
+        "value": data[i]
+      };
+    }
   };
   
   httpClient.setRequestHandler((request) => {        
@@ -565,14 +547,14 @@ test('Sucsess - Non-existent fieldcode', () => {
     const responseObj = {
       "id": "5"
     };        
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-    });
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+  });
 
-    // <script> のスクリプトを実行
-    execute();
+  // <script> のスクリプトを実行
+  execute();
 
-    // 文字型データ項目の値をチェック
-    expect(engine.findData(recordIdDef)).toEqual('5');
+  // 文字型データ項目の値をチェック
+  expect(engine.findData(recordIdDef)).toEqual('5');
 });
 ]]></test>
 

--- a/kintone-record-add.xml
+++ b/kintone-record-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>kintone: Add New Record</label>
 <label locale="ja">kintone: レコード追加</label>
-<last-modified>2022-06-27</last-modified>
+<last-modified>2022-06-28</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <summary>This item adds a new record to a Kintone App.</summary>
@@ -421,7 +421,7 @@ test('Sucsess - 7fieldCodes', () => {
     configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
     configs.put(`conf_fieldValue${i+1}`, data[i]);
 	
-	recordObj[`フィールドコード_${i+1}`] = {
+    recordObj[`フィールドコード_${i+1}`] = {
       "value": data[i]
     };
   };
@@ -451,13 +451,12 @@ test('Sucsess - 7fieldCodes', () => {
  * C8V: 値_2 が空白
  */
 test('Sucsess - fieldValue is empty', () => {
-  const data = ['', '', '', '', '', '', ''];
   const recordIdDef = prepareConfigs(configs, 'basic', 'test.cybozu.com', '1', '1');
 
   const recordObj = {};  
   
   configs.put(`conf_fieldCode2`, `フィールドコード_2`);
-  configs.put(`conf_fieldValue2`, data[1]);
+  configs.put(`conf_fieldValue2`, '');
 	
   recordObj[`フィールドコード_2`] = {
     "value": null
@@ -481,8 +480,8 @@ test('Sucsess - fieldValue is empty', () => {
 
 
 /**
- * レコード追加成功（全てのフィールドコードに初期値のレコードが登録される）
- * 全てのフィールドコードが空白
+ * レコード追加成功
+ * 全てのフィールドコードが空白（値の設定はするが、対応するフィールドコードの設定が空）
  */
 test('Sucsess - 7fieldCodes are empty', () => {
   const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
@@ -493,7 +492,7 @@ test('Sucsess - 7fieldCodes are empty', () => {
     configs.put(`conf_fieldCode${i+1}`, ``); //全てのフィールドコードが空白
     configs.put(`conf_fieldValue${i+1}`, data[i]);	
   };
-  const recordObj = {};
+  const recordObj = {}; //フィールドコードの設定が空の場合、値の設定が無視される
   
   httpClient.setRequestHandler((request) => {        
     assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
@@ -511,51 +510,6 @@ test('Sucsess - 7fieldCodes are empty', () => {
 });
 
 
-
-/**
- * レコード追加成功
- * C9F: フィールドコード_3 に存在しないフィールドコードを指定
- */
-test('Sucsess - Non-existent fieldcode', () => {
-  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
-  const recordIdDef = prepareConfigs(configs, '', 'test.cybozu.com', '', '1');
-
-  const recordObj = {};  
-  let fieldCode;
-
-  for (let i = 0; i < FIELD_SIZE; i++) {
-    if (i === 2) { // 3 番目を存在しないフィールドコードに 
-      configs.put(`conf_fieldCode${i+1}`, `存在しないフィールドコード`);
-	}else{
-      configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
-    }
-    configs.put(`conf_fieldValue${i+1}`, data[i]);
-
-    if (i === 2) {
-	  recordObj[`存在しないフィールドコード`] = {
-        "value": data[i]
-      };
-    }else{
-      recordObj[`フィールドコード_${i+1}`] = {
-        "value": data[i]
-      };
-    }
-  };
-  
-  httpClient.setRequestHandler((request) => {        
-    assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
-    const responseObj = {
-      "id": "5"
-    };        
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
-  });
-
-  // <script> のスクリプトを実行
-  execute();
-
-  // 文字型データ項目の値をチェック
-  expect(engine.findData(recordIdDef)).toEqual('5');
-});
 ]]></test>
 
 

--- a/kintone-record-add.xml
+++ b/kintone-record-add.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>kintone: Add New Record</label>
 <label locale="ja">kintone: レコード追加</label>
-<last-modified>2021-08-17</last-modified>
+<last-modified>2022-06-23</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
-<summary>Add a new record to a Kintone App.</summary>
-<summary locale="ja">kintone アプリにレコードを１件追加します。</summary>
+<summary>This item adds a new record to a Kintone App.</summary>
+<summary locale="ja">この工程は、kintone アプリにレコードを１件追加します。</summary>
 <configs>
   <config name="conf_auth" required="true" form-type="OAUTH2">
     <label>C1: Authorization Setting in which API Token is set</label>
@@ -257,5 +257,324 @@ uQU29yfbsNIgqmTNB45y6GdrLtgA8E68+jvUA2LCTrlsg8htFFf0InkQ2HMQvtVroQ8PQWqZK7qB
 j9ziv7enDCwy6xzFfNP1MHJxyScgnxPM60X+8rmaAptKZYcRF0x1HL9QhCrKrscxt6nrhcQEXdcr
 mQmirpfS/4OJF76WW0zU82Figqjr06y0m+r2OJ2u/nfz8xwerN4wOc7tdwAAAABJRU5ErkJggg==
 </icon>
+
+<test><![CDATA[
+
+const FIELD_SIZE = 7;
+
+/**
+ * 設定の準備
+ * @param basic
+ * @param domain
+ * @param guestSpaceId
+ * @param appId
+ */
+const prepareConfigs = (basic, domain, guestSpaceId, appId) => {
+  configs.put('conf_auth', 'kintone');  
+  configs.put('conf_basic', basic);
+  configs.put('conf_domain', domain);
+  configs.put('conf_guestSpaceId', guestSpaceId);
+  configs.put('conf_appId', appId);
+  
+  // 文字型データ項目を準備して、config に指定
+  const recordIdDef = engine.createDataDefinition('レコードの ID', 1, 'q_record_id', 'STRING_TEXTAREA');
+  configs.putObject('conf_recordId', recordIdDef);
+  // 文字型データ項目の値（レコード ID を保存するデータ項目）を指定
+  engine.setData(recordIdDef, '事前文字列');
+
+  
+  return recordIdDef;
+};
+
+
+
+/**
+ * ドメインが不正な文字列でエラーになる場合
+ */
+test('Invalid Kintone domain', () => {
+  const data = ['test1', '', '', '', '', '', ''];
+  prepareConfigs('', 'invalidDomain', '', '1' );
+
+  const recordObj = {};
+
+  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
+
+  recordObj[fieldCode] = {
+    "value": fieldValue
+  };
+
+  expect(execute).toThrow('Invalid Kintone domain.');
+});
+
+
+/**
+ * ゲストスペース ID が不正な文字列でエラーになる場合
+ */
+test('Invalid Guest Space ID', () => {
+  const data = ['test1', '', '', '', '', '', ''];
+  prepareConfigs('', 'test.cybozu.com', '-1', '2');
+
+  const recordObj = {};
+
+  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
+
+  recordObj[fieldCode] = {
+    "value": fieldValue
+  };
+  
+  expect(execute).toThrow('Invalid Guest Space ID.');
+});
+
+
+/**
+ * アプリ ID が不正な文字列でエラーになる場合
+ */
+test('Invalid App ID', () => {
+  const data = ['test1', '', '', '', '', '', ''];
+  prepareConfigs('', 'test.kintone.com', '1', '2.3');
+
+  const recordObj = {};  
+  
+  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
+
+  recordObj[fieldCode] = {
+    "value": fieldValue
+  };
+    
+  expect(execute).toThrow('Invalid App ID.');
+});
+
+
+/**
+ * フィールドコードが重複して指定されていて、エラーになる場合
+ */
+test('The same Field Code is set multiple times', () => {
+  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
+  prepareConfigs('', 'test.cybozu.com', '1', '1');
+
+  const recordObj = {};
+
+  for (let i = 0; i < FIELD_SIZE; i++) {
+    let fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+	
+	recordObj[fieldCode] = {
+      "value": fieldValue
+    };
+  }; 
+
+  // 2 番目のフィールドコードを 1 番目と同様に
+  configs.put('conf_fieldCode2', 'フィールドコード_1'); 
+
+  expect(execute).toThrow('The same Field Code is set multiple times.');
+});
+
+
+
+/**
+ * リクエストのテスト
+ * @param {Object} request
+ * @param request.url
+ * @param request.method
+ * @param domain
+ * @param guestSpaceId
+ * @param appId
+ * @param recordIdsParameter
+ */
+const assertRequest = ({url, method, body}, domain, guestSpaceId, appId, recordObj) => {
+  expect(method).toEqual('POST');
+
+  if ( guestSpaceId === "" || guestSpaceId === null ) {
+    expect(url).toEqual(`https://${domain}/k/v1/record.json`);
+  } else {
+    expect(url).toEqual(`https://${domain}/k/guest/${guestSpaceId}/v1/record.json`);
+  }
+  
+  const bodyObj = JSON.parse(body);
+  expect(bodyObj.app).toEqual(appId);
+//  expect(bodyObj.record).toEqual(recordObj);
+
+};
+
+
+/**
+ * POST リクエスト失敗
+ */
+test('POST Failed', () => {
+  const data = ['test1', '', '', '', '', '', ''];
+  prepareConfigs('', 'test.cybozu.com', '', '1');
+
+  const recordObj = {};  
+  
+  let fieldCode = configs.put(`conf_fieldCode1`, `フィールドコード_1`);
+  let fieldValue = configs.put(`conf_fieldValue1`, data[0]);
+	
+  recordObj[fieldCode] = {
+    "value": fieldValue
+  };
+
+  httpClient.setRequestHandler((request) => {        
+    assertRequest(request, 'test.cybozu.com', '', '1', recordObj);       
+        return httpClient.createHttpResponse(400, 'application/json', '{}');
+    });
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+  expect(execute).toThrow('Failed to add record. status: 400');
+});
+
+
+
+/**
+ * レコード追加成功
+ * 正しいフィールドコードを７つの項目全てに指定
+ */
+test('Sucsess - 7fieldCodes', () => {
+  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
+  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+
+  const recordObj = {};  
+  
+  for (let i = 0; i < FIELD_SIZE; i++) {
+    let fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+	
+	recordObj[fieldCode] = {
+      "value": fieldValue
+    };
+  };
+  
+  httpClient.setRequestHandler((request) => {        
+    assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
+    const responseObj = {
+      "id": "2"
+    };        
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(recordIdDef)).toEqual('2');
+});
+
+
+
+/**
+ * レコード追加成功（指定したフィールドコードに空値のレコードが設定される）
+ * 正しいフィールドコードを１つ指定
+ * ゲストスペースのアプリ
+ * basic 認証設定
+ * C8V: 値_2 が空白
+ */
+test('Sucsess - fieldValue is empty', () => {
+  const data = ['', '', '', '', '', '', ''];
+  const recordIdDef = prepareConfigs('basic', 'test.cybozu.com', '1', '1');
+
+  const recordObj = {};  
+  
+  let fieldCode = configs.put(`conf_fieldCode2`, `フィールドコード_2`);
+  let fieldValue = configs.put(`conf_fieldValue2`, data[1]);
+	
+  recordObj[fieldCode] = {
+    "value": fieldValue
+  };
+  
+  httpClient.setRequestHandler((request) => {        
+    assertRequest(request, 'test.cybozu.com', '1', '1', recordObj);
+    const responseObj = {
+      "id": "3"
+    };        
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(recordIdDef)).toEqual('3');
+});
+
+
+
+/**
+ * レコード追加成功（全てのフィールドコードに初期値のレコードが登録される）
+ * 全てのフィールドコードが空白
+ */
+test('Sucsess - 7fieldCodes are empty', () => {
+  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
+  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+
+  const recordObj = {};  
+  
+  for (let i = 0; i < FIELD_SIZE; i++) {
+    let fieldCode = configs.put(`conf_fieldCode${i+1}`, ``); //全てのフィールドコードが空白
+    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+	
+	recordObj[fieldCode] = {
+      "value": fieldValue
+    };
+  };
+  
+  httpClient.setRequestHandler((request) => {        
+    assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
+    const responseObj = {
+      "id": "4"
+    };        
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(recordIdDef)).toEqual('4');
+});
+
+
+
+/**
+ * レコード追加成功
+ * C9F: フィールドコード_3 に存在しないフィールドコードを指定
+ */
+test('Sucsess - Non-existent fieldcode', () => {
+  const data = ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7'];
+  const recordIdDef = prepareConfigs('', 'test.cybozu.com', '', '1');
+
+  const recordObj = {};  
+  let fieldCode;
+
+  for (let i = 0; i < FIELD_SIZE; i++) {
+    if (i === 2) { // 3 番目を存在しないフィールドコードに 
+      fieldCode = configs.put(`conf_fieldCode${i+1}`, `存在しないフィールドコード`);
+	}else{
+      fieldCode = configs.put(`conf_fieldCode${i+1}`, `フィールドコード_${i+1}`);
+    }
+    let fieldValue = configs.put(`conf_fieldValue${i+1}`, data[i]);
+
+	recordObj[fieldCode] = {
+      "value": fieldValue
+    };
+  };
+  
+  httpClient.setRequestHandler((request) => {        
+    assertRequest(request, 'test.cybozu.com', '', '1', recordObj);
+    const responseObj = {
+      "id": "5"
+    };        
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(recordIdDef)).toEqual('5');
+});
+]]></test>
+
 
 </service-task-definition>


### PR DESCRIPTION
@hatanaka-akihiro さん

教えてください。
リクエストのテストを検証するコードで、398 行目
`expect(bodyObj.record).toEqual(recordObj);`
でビルドが失敗します。オブジェクトの検証が間違っているのでしょうか

（テストコードは、この処理をコメントアウトして、ビルドを通して作成しています。）