### PR TITLE
Slack: チャット投稿 (Incoming Webhook)単体テスト追加／summaryの変更

### DIFF
--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-08-09</last-modified>
+<last-modified>2022-08-15</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Incoming Webhook)</label>
@@ -196,10 +196,18 @@ const preparePostResponse = (text) => {
  * POST API リクエストでエラーになる場合
  */
 test('POST Failed', () => {
-    const attachment = prepareConfigs(configs, 'https://hooks.slack.com/services/ZZZZZ', 'text2', 'fallback2', '#ff0000', 'title2', 'https://titleLink2', 'attachText2');
+  const WebhookUrl = 'https://hooks.slack.com/services/ZZZZZ';
+  const mainText = "text2";
+  const fallback = "fallback2";
+  const color = "#ff0000";
+  const title = "title2";
+  const title_link = "https://titleLink2";
+  const text = "attachText2";
+
+    const attachment = prepareConfigs(configs, WebhookUrl, mainText, fallback, color, title, title_link, text);
 
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'https://hooks.slack.com/services/ZZZZZ', 'text2', attachment);
+        assertPostRequest(request, WebhookUrl, mainText, attachment);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
 
@@ -214,11 +222,19 @@ test('POST Failed', () => {
  * 全てを設定
  */
 test('Success', () => {
-  const attachment = prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', 'text3','fallback3', '#ff0000', 'title3', 'https://titleLink3', 'attachText3');
+  const WebhookUrl = 'https://hooks.slack.com/services/ABCDE';
+  const mainText = "text3";
+  const fallback = "fallback3";
+  const color = "#ff0000";
+  const title = "title3";
+  const title_link = "https://titleLink3";
+  const text = "attachText3";
+
+  const attachment = prepareConfigs(configs, WebhookUrl, mainText,fallback, color, title, title_link, text);
 
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', 'text3', attachment);
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('text3')));
+        assertPostRequest(request, WebhookUrl, mainText, attachment);
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
     });
 
   // <script> のスクリプトを実行
@@ -235,14 +251,19 @@ test('Success', () => {
  * Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
  */
 test('Success - text', () => {
-  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', 'text4', '', '', '', 'https://titleLink4', '');
+  const WebhookUrl = 'https://hooks.slack.com/services/12345';
+  const mainText = "text4";
+  const title_link = "https://titleLink4";
 
-  //Attachmentタイトルが未設定のため、Attachmentタイトルリンクは設定されず、オブジェクトは空
+  prepareConfigs(configs, WebhookUrl, mainText, '', '', '', title_link, '');
+
+  //Attachment タイトルが未設定のため、Attachment タイトルリンクは設定されない。
+  //その他の Attachment も未設定なので、オブジェクトは空
   const attachment = {};
 
     httpClient.setRequestHandler((request) => {
-       assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', 'text4', attachment);
-       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('text4')));
+       assertPostRequest(request, WebhookUrl, mainText, attachment);
+       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
     });
 
   // <script> のスクリプトを実行
@@ -257,15 +278,19 @@ test('Success - text', () => {
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
 test('Success - Attachment-text ', () => {
-  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', '', '', '', 'attachText5');
+  const WebhookUrl = 'https://hooks.slack.com/services/FGHIJ';
+  const mainText = null;
+  const text = "attachText5";
+
+  prepareConfigs(configs, WebhookUrl, mainText, '', '', '', '', text);
   
   const attachment = {
-    "text": "attachText5"
+    text
   };
 
   httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', null, attachment);
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('')));
+    assertPostRequest(request, WebhookUrl, mainText, attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
   });
 
   // <script> のスクリプトを実行
@@ -280,23 +305,26 @@ test('Success - Attachment-text ', () => {
  * Message to send isn't set　のエラーにならない条件③
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  * Attachment色が無効（無効であるが、チャット投稿は成功する）
- * AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
+ * AttachmentタイトルリンクがURLの形式でないため、Slack WebUI 上では Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
  */
 test('Success - Attachment-title ', () => {
-  const color = "#ZZZZZZ"
-  const title = "title6"
+  const WebhookUrl = 'https://hooks.slack.com/services/67890';
+  const mainText = null;
+  const title_link = "12345";
+  const color = "#ZZZZZZ";
+  const title = "title6";
   
-  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', color, title, '12345', '');
+  prepareConfigs(configs, WebhookUrl, mainText, '', color, title, title_link, '');
 
   const attachment = {
-    "title_link": "12345",
+    title_link,
     color,
     title
   };
 
   httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', null, attachment);
-    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('')));
+    assertPostRequest(request, WebhookUrl, mainText, attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
   });
 
   // <script> のスクリプトを実行

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -126,9 +126,9 @@ const prepareConfigs = (configs, WebhookUrl, text, fallback, color, title, title
   configs.put('AttachText', attachText);
 
   const attachment = {
-    "fallback": fallback,
-    "color": color,
-    "title": title,
+    fallback,
+    color,
+    title,
     "title_link": titleLink,
     "text": attachText
   }
@@ -183,7 +183,7 @@ const preparePostResponse = (text) => {
     "message": {
         "type": "message",
         "subtype": "bot_message",
-        "text": text,
+        text,
         "ts": "1650857142.223299",
         "bot_id": "B01JPAT1P4J"
     }

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -183,7 +183,7 @@ const preparePostResponse = (text) => {
     "message": {
         "type": "message",
         "subtype": "bot_message",
-        "text": `${text}`,
+        "text": text,
         "ts": "1650857142.223299",
         "bot_id": "B01JPAT1P4J"
     }

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-08-26</last-modified>
+<last-modified>2022-08-08</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Incoming Webhook)</label>
 <label locale="ja">Slack: チャット投稿 (Incoming Webhook)</label>
-<summary>Send a message to Slack with Incoming Webhook.</summary>
-<summary locale="ja">Incoming Webhook を使って Slack にメッセージを投稿します。</summary>
+<summary>This item sends a message to Slack with Incoming Webhook.</summary>
+<summary locale="ja">この工程は、Incoming Webhook を使って Slack にメッセージを投稿します。</summary>
 <configs>
   <config name="Url" required="true">
     <label>C1: Incoming Webhook URL</label>
@@ -102,4 +102,204 @@ snKy8OOVGwo3lXdOVCNS24rlAKSz4ObVm7BttiuGQ/IiuhWzF2qG0Z6ju1FpqRT19B/rR421Bto0
 rfAfc/tLBdVJAeKGUbgUk4/j5UXL4bx+UuiOLK6NpRZhMFVUV4iJaq/fnwxAfhwLEOElNOFGwUpu
 U91zuPLlIGYD4c2bTci0dC2uf3MjmXHlhSQiqWYlS25FIfFkltP/31L6X3jivtfyCMSSfpiIEEv5
 aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==</icon>
+    
+<test><![CDATA[
+
+/**
+ * 設定の準備
+ * @param configs
+ * @param Text
+ * @param Fallback
+ * @param Color
+ * @param Title
+ * @param TitleLink
+ * @param AttachText
+ * @return attachment
+ */
+const prepareConfigs = (configs, WebhookUrl, text, fallback, color, title, titleLink, attachText) => {
+  configs.put('Url', WebhookUrl);
+  configs.put('Text', text);
+  configs.put('Fallback', fallback);
+  configs.put('Color', color);
+  configs.put('Title', title);
+  configs.put('TitleLink', titleLink);
+  configs.put('AttachText', attachText);
+
+  const attachment = {
+    "fallback": fallback,
+    "color": color,
+    "title": title,
+    "title_link": titleLink,
+    "text": attachText
+  }
+
+  return attachment;
+};
+
+
+/**
+ * POSTリクエストのテスト（チャット投稿）
+ * @param {Object} request
+ * @param request.url
+ * @param request.method
+ * @param request.contentType
+ * @param request.body
+ * @param text
+ * @param attachment
+ */
+const assertPostRequest = ({url, method, contentType, body}, WebhookUrl, text, attachment) => {
+    expect(url).toEqual(WebhookUrl);	
+    expect(method).toEqual('POST');
+    expect(contentType).toEqual('application/json; charset=UTF-8');
+    const bodyObj = JSON.parse(body);
+    expect(bodyObj.text).toEqual(text);
+    expect(bodyObj.attachments).toEqual([attachment]);
+};
+
+
+/**
+ * チャット投稿失敗の場合
+ * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
+ */
+test('Message to send isn\'t set', () => {
+  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
+
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Message to send isn\'t set.`);
+});
+
+
+/**
+ * POST リクエストのレスポンスを準備
+ * @param text
+ * @return responseObj
+ */
+const preparePostResponse = (text) => {
+  return {
+    "ok": true,
+    "channel": `channel`,
+    "ts": "1650857142.223299",
+    "message": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": `${text}`,
+        "ts": "1650857142.223299",
+        "bot_id": "B01JPAT1P4J"
+    }
+  };
+};
+
+
+
+/**
+ * POST API リクエストでエラーになる場合
+ */
+test('POST Failed', () => {
+    const attachment = prepareConfigs(configs, 'https://hooks.slack.com/services/ZZZZZ', 'text2', 'fallback2', '#ff0000', 'title2', 'https://titleLink2', 'attachText2');
+
+    httpClient.setRequestHandler((request) => {
+        assertPostRequest(request, 'https://hooks.slack.com/services/ZZZZZ', 'text2', attachment);
+        return httpClient.createHttpResponse(400, 'application/json', '{}');
+    });
+
+   // <script> のスクリプトを実行し、エラーがスローされることを確認
+   expect(execute).toThrow(`Failed to send. status: 400`);
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * 全てを設定
+ */
+test('Success', () => {
+  const attachment = prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', 'text3','fallback3', '#ff0000', 'title3', 'https://titleLink3', 'attachText3');
+
+    httpClient.setRequestHandler((request) => {
+        assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', 'text3', attachment);
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('text3')));
+    });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * テキストを入力
+ * Message to send isn't set　のエラーにならない条件①
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ * Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
+ */
+test('Success - text', () => {
+  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', 'text4', '', '', '', 'https://titleLink4', '');
+
+  //Attachmentタイトルが未設定のため、Attachmentタイトルリンクは設定されず、オブジェクトは空
+  const attachment = {};
+
+    httpClient.setRequestHandler((request) => {
+       assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', 'text4', attachment);
+       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('text4')));
+    });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+/**
+ * チャット投稿成功の場合
+ * Attachmentテキスト を入力  （テキストは空）
+ * Message to send isn't set　のエラーにならない条件②
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ */
+test('Success - Attachment-text ', () => {
+  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', '', '', '', 'attachText5');
+  
+  const attachment = {
+    "text": "attachText5"
+  };
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', null, attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+
+/**
+ * チャット投稿成功の場合
+ * チャンネル、Attachmentタイトルを入力 （テキストは空）
+ * Message to send isn't set　のエラーにならない条件③
+ *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
+ * Attachment色が無効（無効であるが、チャット投稿は成功する）
+ * AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
+ */
+test('Success - Attachment-title ', () => {
+  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', '#ZZZZZZ', 'title6', '12345', '');
+
+  const attachment = {
+    "title_link": "12345",
+    "color": "#ZZZZZZ",
+    "title": "title6"
+  };
+
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, 'https://hooks.slack.com/services/ABCDE', null, attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse('')));
+  });
+
+  // <script> のスクリプトを実行
+  execute();
+});
+
+
+]]></test>
 </service-task-definition>

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-08-15</last-modified>
+<last-modified>2022-08-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Incoming Webhook)</label>
@@ -108,16 +108,17 @@ aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==</icon>
 /**
  * 設定の準備
  * @param configs
- * @param Text
- * @param Fallback
- * @param Color
- * @param Title
- * @param TitleLink
- * @param AttachText
+ * @param webhookUrl
+ * @param text
+ * @param fallback
+ * @param color
+ * @param title
+ * @param titleLink
+ * @param attachText
  * @return attachment
  */
-const prepareConfigs = (configs, WebhookUrl, text, fallback, color, title, titleLink, attachText) => {
-  configs.put('Url', WebhookUrl);
+const prepareConfigs = (configs, webhookUrl, text, fallback, color, title, titleLink, attachText) => {
+  configs.put('Url', webhookUrl);
   configs.put('Text', text);
   configs.put('Fallback', fallback);
   configs.put('Color', color);
@@ -138,17 +139,18 @@ const prepareConfigs = (configs, WebhookUrl, text, fallback, color, title, title
 
 
 /**
- * POSTリクエストのテスト（チャット投稿）
+ * POST リクエストのテスト（チャット投稿）
  * @param {Object} request
  * @param request.url
  * @param request.method
  * @param request.contentType
  * @param request.body
+ * @param webhookUrl
  * @param text
  * @param attachment
  */
-const assertPostRequest = ({url, method, contentType, body}, WebhookUrl, text, attachment) => {
-    expect(url).toEqual(WebhookUrl);	
+const assertPostRequest = ({url, method, contentType, body}, webhookUrl, text, attachment) => {
+    expect(url).toEqual(webhookUrl);	
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json; charset=UTF-8');
     const bodyObj = JSON.parse(body);
@@ -159,14 +161,14 @@ const assertPostRequest = ({url, method, contentType, body}, WebhookUrl, text, a
 
 /**
  * チャット投稿失敗の場合
- * テキストが空、attachmentタイトル未入力、attachmentテキスト未入力
+ * テキストが空、attachment タイトル未入力、attachment テキスト未入力
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
  */
 test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Message to send isn\'t set.`);
+  expect(execute).toThrow(`Message to send isn\'t set.`);
 });
 
 
@@ -196,7 +198,7 @@ const preparePostResponse = (text) => {
  * POST API リクエストでエラーになる場合
  */
 test('POST Failed', () => {
-  const WebhookUrl = 'https://hooks.slack.com/services/ZZZZZ';
+  const webhookUrl = 'https://hooks.slack.com/services/ZZZZZ';
   const mainText = "text2";
   const fallback = "fallback2";
   const color = "#ff0000";
@@ -204,15 +206,15 @@ test('POST Failed', () => {
   const title_link = "https://titleLink2";
   const text = "attachText2";
 
-    const attachment = prepareConfigs(configs, WebhookUrl, mainText, fallback, color, title, title_link, text);
+  const attachment = prepareConfigs(configs, webhookUrl, mainText, fallback, color, title, title_link, text);
 
-    httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, WebhookUrl, mainText, attachment);
-        return httpClient.createHttpResponse(400, 'application/json', '{}');
-    });
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, webhookUrl, mainText, attachment);
+    return httpClient.createHttpResponse(400, 'application/json', '{}');
+  });
 
-   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send. status: 400`);
+  // <script> のスクリプトを実行し、エラーがスローされることを確認
+  expect(execute).toThrow(`Failed to send. status: 400`);
 });
 
 
@@ -222,7 +224,7 @@ test('POST Failed', () => {
  * 全てを設定
  */
 test('Success', () => {
-  const WebhookUrl = 'https://hooks.slack.com/services/ABCDE';
+  const webhookUrl = 'https://hooks.slack.com/services/ABCDE';
   const mainText = "text3";
   const fallback = "fallback3";
   const color = "#ff0000";
@@ -230,11 +232,11 @@ test('Success', () => {
   const title_link = "https://titleLink3";
   const text = "attachText3";
 
-  const attachment = prepareConfigs(configs, WebhookUrl, mainText,fallback, color, title, title_link, text);
+  const attachment = prepareConfigs(configs, webhookUrl, mainText,fallback, color, title, title_link, text);
 
     httpClient.setRequestHandler((request) => {
-        assertPostRequest(request, WebhookUrl, mainText, attachment);
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
+      assertPostRequest(request, webhookUrl, mainText, attachment);
+      return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
     });
 
   // <script> のスクリプトを実行
@@ -248,23 +250,23 @@ test('Success', () => {
  * テキストを入力
  * Message to send isn't set　のエラーにならない条件①
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
- * Attachmentタイトルリンクが設定されているが、Attachmentタイトルが未設定のため無視されるケース（チャット投稿は成功する）
+ * Attachment タイトルリンクが設定されているが、Attachment タイトルが未設定のため無視されるケース（チャット投稿は成功する）
  */
 test('Success - text', () => {
-  const WebhookUrl = 'https://hooks.slack.com/services/12345';
+  const webhookUrl = 'https://hooks.slack.com/services/12345';
   const mainText = "text4";
   const title_link = "https://titleLink4";
 
-  prepareConfigs(configs, WebhookUrl, mainText, '', '', '', title_link, '');
+  prepareConfigs(configs, webhookUrl, mainText, '', '', '', title_link, '');
 
   //Attachment タイトルが未設定のため、Attachment タイトルリンクは設定されない。
   //その他の Attachment も未設定なので、オブジェクトは空
   const attachment = {};
 
-    httpClient.setRequestHandler((request) => {
-       assertPostRequest(request, WebhookUrl, mainText, attachment);
-       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
-    });
+  httpClient.setRequestHandler((request) => {
+    assertPostRequest(request, webhookUrl, mainText, attachment);
+    return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
+  });
 
   // <script> のスクリプトを実行
   execute();
@@ -273,23 +275,23 @@ test('Success - text', () => {
 
 /**
  * チャット投稿成功の場合
- * Attachmentテキスト を入力  （テキストは空）
+ * Attachment テキスト を入力  （テキストは空）
  * Message to send isn't set　のエラーにならない条件②
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
  */
 test('Success - Attachment-text ', () => {
-  const WebhookUrl = 'https://hooks.slack.com/services/FGHIJ';
+  const webhookUrl = 'https://hooks.slack.com/services/FGHIJ';
   const mainText = null;
   const text = "attachText5";
 
-  prepareConfigs(configs, WebhookUrl, mainText, '', '', '', '', text);
+  prepareConfigs(configs, webhookUrl, mainText, '', '', '', '', text);
   
   const attachment = {
     text
   };
 
   httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, WebhookUrl, mainText, attachment);
+    assertPostRequest(request, webhookUrl, mainText, attachment);
     return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
   });
 
@@ -301,20 +303,20 @@ test('Success - Attachment-text ', () => {
 
 /**
  * チャット投稿成功の場合
- * チャンネル、Attachmentタイトルを入力 （テキストは空）
+ * チャンネル、Attachment タイトルを入力 （テキストは空）
  * Message to send isn't set　のエラーにならない条件③
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていると、投稿成功する
- * Attachment色が無効（無効であるが、チャット投稿は成功する）
- * AttachmentタイトルリンクがURLの形式でないため、Slack WebUI 上では Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
+ * Attachment 色が無効（無効であるが、チャット投稿は成功する）
+ * Attachment タイトルリンクが URL の形式でないが、チャット投稿は成功する（Slack WebUI 上では、無視されてリンクにならない)
  */
 test('Success - Attachment-title ', () => {
-  const WebhookUrl = 'https://hooks.slack.com/services/67890';
+  const webhookUrl = 'https://hooks.slack.com/services/67890';
   const mainText = null;
   const title_link = "12345";
   const color = "#ZZZZZZ";
   const title = "title6";
   
-  prepareConfigs(configs, WebhookUrl, mainText, '', color, title, title_link, '');
+  prepareConfigs(configs, webhookUrl, mainText, '', color, title, title_link, '');
 
   const attachment = {
     title_link,
@@ -323,7 +325,7 @@ test('Success - Attachment-title ', () => {
   };
 
   httpClient.setRequestHandler((request) => {
-    assertPostRequest(request, WebhookUrl, mainText, attachment);
+    assertPostRequest(request, webhookUrl, mainText, attachment);
     return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostResponse(mainText)));
   });
 

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-08-08</last-modified>
+<last-modified>2022-08-09</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Slack: Post Chat (Incoming Webhook)</label>
@@ -283,12 +283,15 @@ test('Success - Attachment-text ', () => {
  * AttachmentタイトルリンクがURLの形式でないため、Attachmentタイトルにリンクが無いケース（チャット投稿は成功する）
  */
 test('Success - Attachment-title ', () => {
-  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', '#ZZZZZZ', 'title6', '12345', '');
+  const color = "#ZZZZZZ"
+  const title = "title6"
+  
+  prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', null, '', color, title, '12345', '');
 
   const attachment = {
     "title_link": "12345",
-    "color": "#ZZZZZZ",
-    "title": "title6"
+    color,
+    title
   };
 
   httpClient.setRequestHandler((request) => {


### PR DESCRIPTION
@hatanaka-akihiro  さん

単体テストコードを追加しました。
summary の変更をしました。

ご確認をお願いいたします。

変更元のコードは、以下のものを流用しました。
https://raw.githubusercontent.com/Questetra/Addon-XML/release-2021-08-26/slack-chat-post-webhook.xml

アイコンの色がグリーンで、標準アイテムの紫と異なります。
こちらのファイルで、どこか設定する箇所があれば教えてください。