### PR TITLE
T8601: Stripe: 請求書ドラフト作成　通貨を指定できるように

### DIFF
--- a/stripe-invoice-create.xml
+++ b/stripe-invoice-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2022-08-09</last-modified>
+    <last-modified>2022-08-12</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>2</engine-type>
     <label>Stripe: Create Draft Invoice</label>
@@ -30,8 +30,8 @@
             <label locale="ja">C3: 説明（請求書に「メモ」として表示されます）</label>
         </config>
         <config name="conf_Currency" required="false" form-type="SELECT_ITEM">
-            <label>C4: Currency</label>
-            <label locale="ja">C4: 通貨</label>
+            <label>C4: Currency (If not selected, defaults to that of the customer)</label>
+            <label locale="ja">C4: 通貨（未選択の場合、顧客の通貨設定に従います）</label>
             <item value="AUD">
                 <label>AUD</label>
             </item>


### PR DESCRIPTION
config のラベルに通貨が未選択の場合の説明を追記