### PR TITLE
T8625: Stripe: 商品を作成

### DIFF
--- a/stripe-product-create.xml
+++ b/stripe-product-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2022-09-16</last-modified>
+    <last-modified>2022-10-03</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>2</engine-type>
     <label>Stripe: Create Product</label>
@@ -353,9 +353,11 @@ function createProduct(auth, name, description, currency, unitAmount, currencyOp
         .authSetting(auth) // with "Authorization: Bearer XX"
         .header('Stripe-Version', STRIPE_API_VERSION)
         .formParam('name', name)
-        .formParam('description', description)
         .formParam('default_price_data[currency]', currency)
         .formParam('default_price_data[unit_amount]', unitAmount);
+    if (description !== '') {
+        request = request.formParam('description', description);
+    }
     currencyOptions.forEach((subUnitAmount, subCurrency) => {
         request = request.formParam(`default_price_data[currency_options][${subCurrency}][unit_amount]`, subUnitAmount);
     });
@@ -613,9 +615,11 @@ const assertRequest = ({url, method, headers, contentType, body}, name, descript
     expect(headers.get('Stripe-Version')).toEqual(STRIPE_VERSION);
     expect(contentType).startsWith('application/x-www-form-urlencoded');
     let expectedBody = `name=${encodeURIComponent(name)}`
-        + `&description=${encodeURIComponent(description)}`
         + `&${encodeURIComponent('default_price_data[currency]')}=${currency}`
         + `&${encodeURIComponent('default_price_data[unit_amount]')}=${unitAmount}`;
+    if (description !== '') {
+        expectedBody += `&description=${encodeURIComponent(description)}`;
+    }
     currencyOptions.forEach((subUnitAmount, subCurrency) => {
         const encodedParamName = encodeURIComponent(`default_price_data[currency_options][${subCurrency}][unit_amount]`);
         expectedBody += `&${encodedParamName}=${subUnitAmount}`;


### PR DESCRIPTION
商品説明が空の場合、パラメータにセットしないように変更しました。
（パラメータにセットしてしまうと、API リクエストでエラーになるため）