### PR TITLE
8854: Box: フォルダ削除　Summary の変更／単体テストの改良

### DIFF
--- a/box-folder-delete.xml
+++ b/box-folder-delete.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2021-11-25</last-modified>
+<last-modified>2022-12-06</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Box: Delete Folder</label>
 <label locale="ja">Box: フォルダ削除</label>
-<summary>Delete folders on Box. You can delete multiple folders at once. When you delete multiple ones, you should write one folder ID on each line.</summary>
-<summary locale="ja">Box 上のフォルダを削除します。一度に複数の削除が可能です。複数削除する場合、データ項目では1行につき1つずつIDを書くようにしてください。</summary>
+<summary>This item deletes folders on Box. You can delete multiple folders at once. When you delete multiple ones, you should write one folder ID on each line.</summary>
+<summary locale="ja">この工程は、Box 上のフォルダを削除します。一度に複数の削除が可能です。複数削除する場合、データ項目では1行につき1つずつIDを書くようにしてください。</summary>
 <help-page-url>https://support.questetra.com/bpmn-icons/box-folder-delete/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/box-folder-delete/</help-page-url>
 <configs>
@@ -23,44 +23,43 @@
 
 <script><![CDATA[
 main();
-function main(){
-  const folderIds = engine.findDataByNumber(configs.get("FolderIdsItem"));
-  if (folderIds === "" ||folderIds === null){
-    throw "Folder IDs aren't set.";
-  }
+function main() {
+    const folderIds = engine.findDataByNumber(configs.get("FolderIdsItem"));
+    if (folderIds === "" || folderIds === null) {
+        throw "Folder IDs aren't set.";
+    }
 
-  let linesArray = folderIds.split("\n");
-  linesArray = linesArray.filter(lines => lines !== ""); // 空文字列を削除
-  if (linesArray.length === 0) {
-    throw "Folder IDs aren't set.";
-  }
+    let linesArray = folderIds.split("\n");
+    linesArray = linesArray.filter(lines => lines !== ""); // 空文字列を削除
+    if (linesArray.length === 0) {
+        throw "Folder IDs aren't set.";
+    }
 
-  const numOfLines = linesArray.length;
-  if (numOfLines > httpClient.getRequestingLimit()){
-  	throw "Number of Folder IDs is over the limit."
-  }
-  const oauth2 = configs.get("OAuth2");
-  for (let i = 0; i < numOfLines; i++){
-    deleteFolder(oauth2, linesArray[i])
-  }
+    const numOfLines = linesArray.length;
+    if (numOfLines > httpClient.getRequestingLimit()) {
+        throw "Number of Folder IDs is over the limit."
+    }
+    const oauth2 = configs.get("OAuth2");
+    for (let i = 0; i < numOfLines; i++) {
+        deleteFolder(oauth2, linesArray[i])
+    }
 }
 
 function deleteFolder(oauth2, folderId) {
-  const url = `https://api.box.com/2.0/folders/${folderId}`;
+    const url = `https://api.box.com/2.0/folders/${folderId}`;
 
-  let response = httpClient.begin()
-    .authSetting(oauth2)
-    .queryParam("recursive","true")
-    .delete(url);
-  const status = response.getStatusCode();
-  const responseTxt = response.getResponseAsString();
-  engine.log(`status: ${status}`);
-  if (status >= 300) {
-    engine.log(responseTxt)
-    throw `Failed to delete Folder ID:${folderId}`;
-  }else{
-    engine.log(`Succeeded to delete Folder ID:${folderId}`);
-  }
+    let response = httpClient.begin()
+        .authSetting(oauth2)
+        .queryParam("recursive", "true")
+        .delete(url);
+    const status = response.getStatusCode();
+    const responseTxt = response.getResponseAsString();
+    if (status >= 300) {
+        engine.log(responseTxt);
+        throw `Failed to delete. Folder ID:${folderId}, status: ${status}`;
+    } else {
+        engine.log(`Succeeded to delete. Folder ID:${folderId}`);
+    }
 }
 
 ]]></script>
@@ -94,12 +93,12 @@ l9NGhGgA6QZxR8pEngExipTdYHTNt+LiNbBCTSDf7X8FbX8wYecpbwAAAABJRU5ErkJggg==</icon>
  * @return {Object}
  */
 const prepareConfigs = (configs, folderId) => {
-  configs.put('OAuth2', 'Box');
-  const folderIdDef = engine.createDataDefinition('フォルダ ID', 3, 'q_folderId', 'STRING_TEXTAREA');
-  configs.putObject('FolderIdsItem', folderIdDef);
-  engine.setData(folderIdDef, folderId);
+    configs.put('OAuth2', 'Box');
+    const folderIdDef = engine.createDataDefinition('フォルダ ID', 3, 'q_folderId', 'STRING_TEXTAREA');
+    configs.putObject('FolderIdsItem', folderIdDef);
+    engine.setData(folderIdDef, folderId);
 
-  return folderIdDef;
+    return folderIdDef;
 };
 
 /**
@@ -108,55 +107,37 @@ const prepareConfigs = (configs, folderId) => {
  * @param method
  * @param id
  */
-const assertRequest = ({url, method}, folderId) => {
-  expect(url).toEqual(`https://api.box.com/2.0/folders/${folderId}?recursive=true`);
-  expect(method).toEqual('DELETE');
+const assertRequest = ({ url, method }, folderId) => {
+    expect(url).toEqual(`https://api.box.com/2.0/folders/${folderId}?recursive=true`);
+    expect(method).toEqual('DELETE');
 };
 
 /**
  * フォルダ ID が null の場合
  */
 test('IDs is null', () => {
-  prepareConfigs(configs, null);
-
-  try {
-      execute();
-      fail('not come here');
-  } catch (e) {
-      expect(e.message).endsWith("Folder IDs aren't set.");
-  }
+    prepareConfigs(configs, null);
+    expect(execute).toThrow("Folder IDs aren't set.");
 });
 
 /**
  * フォルダ ID が空白の場合
  */
 test('IDs is blank', () => {
-  prepareConfigs(configs, '\n\n\n'); //空行が複数行あるだけ
-
-  try {
-      execute();
-      fail('not come here');
-  } catch (e) {
-      expect(e.message).endsWith("Folder IDs aren't set.");
-  }
+    prepareConfigs(configs, '\n\n\n'); //空行が複数行あるだけ
+    expect(execute).toThrow("Folder IDs aren't set.");
 });
 
 /**
  * フォルダ ID の数が最大リクエスト数を超えた場合
  */
 test('Number of Folder IDs is over the limit', () => {
-  let ids = '';
-  for (let i = 0; i <= httpClient.getRequestingLimit(); i++) {
-      ids += `f${i}\n`;
-  }
-  prepareConfigs(configs, ids);
-
-  try {
-      execute();
-      fail('not come here');
-  } catch (e) {
-      expect(e.message).endsWith('Number of Folder IDs is over the limit.');
-  }
+    let ids = '';
+    for (let i = 0; i <= httpClient.getRequestingLimit(); i++) {
+        ids += `f${i}\n`;
+    }
+    prepareConfigs(configs, ids);
+    expect(execute).toThrow('Number of Folder IDs is over the limit.');
 });
 
 
@@ -164,26 +145,26 @@ test('Number of Folder IDs is over the limit', () => {
  * 削除するフォルダが複数の場合（この場合、最大リクエスト数）
  */
 test('Succeed to delete multiple folders', () => {
-  let ids = '';
-  for (let i = 0; i < httpClient.getRequestingLimit(); i++) {
-      ids += `f${i}\n`;
-  }
-  const folderIdDef = prepareConfigs(configs, ids);
+    let ids = '';
+    for (let i = 0; i < httpClient.getRequestingLimit(); i++) {
+        ids += `f${i}\n`;
+    }
+    const folderIdDef = prepareConfigs(configs, ids);
 
-  let requestCount = 0;
-  httpClient.setRequestHandler((request) => {
-      assertRequest(request, `f${requestCount++}`);
-      return httpClient.createHttpResponse(204, 'application/json', '{}');
-  });
+    let requestCount = 0;
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, `f${requestCount++}`);
+        return httpClient.createHttpResponse(204, 'application/json', '{}');
+    });
 
-  // <script> のスクリプトを実行
-  execute();
+    // <script> のスクリプトを実行
+    execute();
 
-  // 文字型データ項目の値をチェック
-  expect(engine.findData(folderIdDef)).toEqual(ids);
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(folderIdDef)).toEqual(ids);
 
-  // リクエスト数をチェック
-  expect(requestCount).toEqual(httpClient.getRequestingLimit());
+    // リクエスト数をチェック
+    expect(requestCount).toEqual(httpClient.getRequestingLimit());
 });
 
 
@@ -191,18 +172,18 @@ test('Succeed to delete multiple folders', () => {
  * 削除するフォルダが1つの場合
  */
 test('Succeed to delete 1 folder', () => {
-  const folderIdDef = prepareConfigs(configs, '12345');
+    const folderIdDef = prepareConfigs(configs, '12345');
 
-  httpClient.setRequestHandler((request) => {
-      assertRequest(request, '12345');
-      return httpClient.createHttpResponse(204, 'application/json', '{}');
-  });
+    httpClient.setRequestHandler((request) => {
+        assertRequest(request, '12345');
+        return httpClient.createHttpResponse(204, 'application/json', '{}');
+    });
 
-  // <script> のスクリプトを実行
-  execute();
+    // <script> のスクリプトを実行
+    execute();
 
-  // 文字型データ項目の値をチェック
-  expect(engine.findData(folderIdDef)).toEqual('12345');
+    // 文字型データ項目の値をチェック
+    expect(engine.findData(folderIdDef)).toEqual('12345');
 });
 
 
@@ -210,33 +191,27 @@ test('Succeed to delete 1 folder', () => {
  * フォルダ削除失敗の場合（400レスポンスが返ってくる）
  */
 test('Failed to delete folder', () => {
-  let ids = '';
-  for (let i = 0; i < 2; i++) {
-      ids += `000${i}\n`;
-  }
-  prepareConfigs(configs, ids);
+    let ids = '';
+    for (let i = 0; i < 2; i++) {
+        ids += `000${i}\n`;
+    }
+    prepareConfigs(configs, ids);
 
-  let requestCount = 0;
-  httpClient.setRequestHandler((request) => {
-      try {
-          assertRequest(request, `000${requestCount}`);
-          if (requestCount === 1) {
-              return httpClient.createHttpResponse(400, 'application/json', '{}');
-          } else {
-              return httpClient.createHttpResponse(204, 'application/json', '{}');
-          }
-      } finally {
-          requestCount++;
-      }
-  });
+    let requestCount = 0;
+    httpClient.setRequestHandler((request) => {
+        try {
+            assertRequest(request, `000${requestCount}`);
+            if (requestCount === 1) {
+                return httpClient.createHttpResponse(400, 'application/json', '{}');
+            } else {
+                return httpClient.createHttpResponse(204, 'application/json', '{}');
+            }
+        } finally {
+            requestCount++;
+        }
+    });
 
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-      execute();
-      fail('not come here');
-  } catch (e) {
-      expect(e.message).endsWith('Failed to delete Folder ID:0001');
-  }
+    expect(execute).toThrow('Failed to delete. Folder ID:0001, status: 400');
 });
 ]]></test>
 


### PR DESCRIPTION
@hatanaka-akihiro  さん

スクリプト部分、テストコード部分にフォーマットをかけました。
8752 Box: ファイル削除　Summary の変更／Nashorn Compatible モード取りやめを見越した単体テストの改良
を参考にして、Summary の変更、単体テストの改良のほか、ログ出力を整形してステータスコードをエラーメッセージに含めるようにしました。

ご確認をお願いします。