### PR TITLE
t8880: Google カレンダー: 予定削除　Summary の変更／単体テストの改良

### DIFF
--- a/google-calendar-event-delete.xml
+++ b/google-calendar-event-delete.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
-<last-modified>2022-03-23</last-modified>
+<last-modified>2022-12-19</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>2</engine-type>
 <label>Google Calendar: Delete Event</label>
 <label locale="ja">Google カレンダー: 予定削除</label>
-<summary>Delete an event on Google Calendar.</summary>
-<summary locale="ja">Google カレンダーの予定を削除します。</summary>
+<summary>This item deletes an event on Google Calendar.</summary>
+<summary locale="ja">この工程は、Google カレンダーの予定を削除します。</summary>
 <help-page-url>https://support.questetra.com/bpmn-icons/service-task-google-calendar-event-delete/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-calendar-event-delete/</help-page-url>
  
@@ -28,25 +28,25 @@
 <script><![CDATA[
 main();
 function main() {
-  //// == 工程コンフィグの参照 / Config Retrieving ==
-  const quser = configs.getObject("conf_User");
-  if (quser === null) {
-    throw `User not found.`;
-  }
-  let calendarId = configs.get("conf_CalendarId");
-  if (calendarId === "" || calendarId === null) {
-    calendarId = "primary";
-  }
-  const eventId = engine.findData(configs.getObject("conf_EventId"));
-  if (eventId === "" || eventId === null) {
-    throw "Event ID isn't set";
-  }
+    //// == 工程コンフィグの参照 / Config Retrieving ==
+    const quser = configs.getObject("conf_User");
+    if (quser === null) {
+        throw `User not found.`;
+    }
+    let calendarId = configs.get("conf_CalendarId");
+    if (calendarId === "" || calendarId === null) {
+        calendarId = "primary";
+    }
+    const eventId = engine.findData(configs.getObject("conf_EventId"));
+    if (eventId === "" || eventId === null) {
+        throw "Event ID isn't set.";
+    }
 
-  //// == 演算 / Calculating ==
-  if (calendarId.search(/^[\w\-_.!*'@]+$/) === -1) {
-    throw "Invalid Calendar ID";
-  }
-  deleteEvent(quser,calendarId,eventId);
+    //// == 演算 / Calculating ==
+    if (calendarId.search(/^[\w\-_.!*'@]+$/) === -1) {
+        throw "Invalid Calendar ID.";
+    }
+    deleteEvent(quser, calendarId, eventId);
 }
 /**
  * Google カレンダーの予定を削除する
@@ -54,22 +54,23 @@ function main() {
  * @param {String} calendarId カレンダーID
  * @param {String} eventId 予定ID
  */
-function deleteEvent(quser,calendarId,eventId) {
-  const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`;
+function deleteEvent(quser, calendarId, eventId) {
+    const uri = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`;
 
-  const response = httpClient.begin()
-    .googleOAuth2(quser, "Calendar")
-    .delete(uri);
+    const response = httpClient.begin()
+        .googleOAuth2(quser, "Calendar")
+        .delete(uri);
 
-  const status = response.getStatusCode();
-  const responseStr = response.getResponseAsString();
-  engine.log(`Event ID: ${eventId}`);
-  engine.log(`Status: ${status}`);
-  if (status >= 300) {
-    engine.log(responseStr);
-    throw `Failed to delete.`;
-  }
-  engine.log("Succeeded to delete");
+    const status = response.getStatusCode();
+    const responseStr = response.getResponseAsString();
+    engine.log(`Event ID: ${eventId}`);
+
+    if (status >= 300) {
+        engine.log(responseStr);
+        throw `Failed to delete. status:${status}`;
+    }
+
+    engine.log("Succeeded to delete.");
 }
 ]]></script>
  
@@ -110,93 +111,68 @@ AABJRU5ErkJggg==
  * @param eventId
  */
 const prepareConfigs = (configs, calenderId, eventId) => {
-  const quser = engine.createQuser(3, 'サウスポール', 'SouthPole@questetra.com');
-  configs.putObject('conf_User', quser);
-  
-  configs.put('conf_CalendarId', calenderId,);
-  
-  // 文字型データ項目を準備して、config に指定
-  const idDef = engine.createDataDefinition('予定 ID', 1, 'q_eventId', 'STRING_TEXTAREA');
-  configs.putObject('conf_EventId', idDef);
-  // 文字型データ項目の値（予定 ID を保存するデータ項目）を指定
-  engine.setData(idDef, eventId);
+    const quser = engine.createQuser(3, 'サウスポール', 'SouthPole@questetra.com');
+    configs.putObject('conf_User', quser);
+
+    configs.put('conf_CalendarId', calenderId,);
+
+    // 文字型データ項目を準備して、config に指定
+    const idDef = engine.createDataDefinition('予定 ID', 1, 'q_eventId', 'STRING_TEXTAREA');
+    configs.putObject('conf_EventId', idDef);
+    // 文字型データ項目の値（予定 ID を保存するデータ項目）を指定
+    engine.setData(idDef, eventId);
 };
 
 /**
  * Google ドライブに接続する UserID に対応する QuserView がなくエラーになる場合
  */
 test('User not found', () => {
-  prepareConfigs(configs, 'test1@a.com', 'event1');
-  // 設定されたユーザが削除された場合、未設定と同じ状態に上書きする
-  configs.put('conf_User', '');
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('User not found.');
-  }
+    prepareConfigs(configs, 'test1@a.com', 'event1');
+    // 設定されたユーザが削除された場合、未設定と同じ状態に上書きする
+    configs.put('conf_User', '');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('User not found.');
 });
 
 /**
  * 予定 IDが空でエラーになる場合
  */
 test('Event ID is blank', () => {
-  prepareConfigs(configs, 'test2@a.com', '');
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('Event ID isn\'t set');
-  }
+    prepareConfigs(configs, 'test2@a.com', '');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('Event ID isn\'t set.');
 });
 
 /**
  * カレンダー IDに不正な文字(半角スペース)が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID - Half-width space', () => {
-  prepareConfigs(configs, 'test 3@a.com', 'event3');
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('Invalid Calendar ID');
-  }
+    prepareConfigs(configs, 'test 3@a.com', 'event3');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('Invalid Calendar ID.');
 });
 
 /**
  * カレンダー IDに不正な文字(許可してない記号()が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID - Not allowed symbols(', () => {
-  prepareConfigs(configs, 'test(3@a.com', 'event3');
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('Invalid Calendar ID');
-  }
+    prepareConfigs(configs, 'test(3@a.com', 'event3');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('Invalid Calendar ID.');
 });
 
 /**
  * カレンダー IDに不正な文字(許可してない記号#)が含まれていてエラーになる場合
  */
 test('Invalid Calendar ID - Not allowed symbols#', () => {
-  prepareConfigs(configs, 'test#3@a.com', 'event3');
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('Invalid Calendar ID');
-  }
+    prepareConfigs(configs, 'test#3@a.com', 'event3');
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('Invalid Calendar ID.');
 });
 
 /**
@@ -207,53 +183,48 @@ test('Invalid Calendar ID - Not allowed symbols#', () => {
  * @param calendarId
  * @param eventId
  */
-const assertDeleteRequest = ({url, method}, calendarId, eventId) => {
-  expect(url).toEqual(`https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`);
-  expect(method).toEqual('DELETE');
+const assertDeleteRequest = ({ url, method }, calendarId, eventId) => {
+    expect(url).toEqual(`https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`);
+    expect(method).toEqual('DELETE');
 };
 
 /**
  * ファイル削除失敗の場合（400レスポンスが返ってくる）
  */
 test('Failed to delete Event', () => {
-  prepareConfigs(configs, 'test4@a.com', 'event4');
-  
-  httpClient.setRequestHandler((request) => {
-    assertDeleteRequest(request, 'test4@a.com', 'event4', );
-    return httpClient.createHttpResponse(400, 'application/json', '{}');
-  });
-  
-  // <script> のスクリプトを実行し、エラーがスローされることを確認
-  try {
-    execute();
-    fail('not come here');
-  } catch (e) {
-    expect(e.message).endsWith('Failed to delete.');
-  }
+    prepareConfigs(configs, 'test4@a.com', 'event4');
+
+    httpClient.setRequestHandler((request) => {
+        assertDeleteRequest(request, 'test4@a.com', 'event4',);
+        return httpClient.createHttpResponse(400, 'application/json', '{}');
+    });
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow('Failed to delete. status:400');
 });
 
 /**
  * 予定削除成功(カレンダーID にurlで使える全ての記号を含む)
  */
 test('Succeed to Delete Event', () => {
-  prepareConfigs(configs, 'test5-_.!*\'@a.com', 'event5');
-  
-  httpClient.setRequestHandler((request) => {
-    assertDeleteRequest(request, 'test5-_.!*\'@a.com', 'event5', );
-    return httpClient.createHttpResponse(200, 'application/json', '{}');
-  });
+    prepareConfigs(configs, 'test5-_.!*\'@a.com', 'event5');
+
+    httpClient.setRequestHandler((request) => {
+        assertDeleteRequest(request, 'test5-_.!*\'@a.com', 'event5',);
+        return httpClient.createHttpResponse(200, 'application/json', '{}');
+    });
 });
 
 /**
  * 予定削除成功 - カレンダーID 指定なし
  */
 test('Succeed to Delete Event - No calender ID', () => {
-  prepareConfigs(configs, '', 'event6');
-  
-  httpClient.setRequestHandler((request) => {
-    assertDeleteRequest(request, 'primary', 'event6');
-    return httpClient.createHttpResponse(200, 'application/json', '{}');
-  });
+    prepareConfigs(configs, '', 'event6');
+
+    httpClient.setRequestHandler((request) => {
+        assertDeleteRequest(request, 'primary', 'event6');
+        return httpClient.createHttpResponse(200, 'application/json', '{}');
+    });
 });
 
 ]]></test>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

スクリプト：
ログ出力を統一しました。（ピリオドの追加）
エラーメッセージにステータスコードを含むようにしました。（処理成功の場合は、ステータスコードを出力しないようにしました）
フォーマットをかけました。

テストコード：
異常系テストケースを改修しました。
フォーマットをかけました。