### PR TITLE
t9341 Slack: ユーザ ID 取得　の作成

### DIFF
--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-21</last-modified>
+    <last-modified>2023-08-24</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -32,9 +32,9 @@ function main() {
     const mailAddress = getmailAddress();
     const slackUserId = usersLookupByEmail(auth, mailAddress).id;
 	
-    const sUserId = configs.get("conf_SlackUserId");
+    const resultDataDefNum = configs.get("conf_SlackUserId");
 
-    engine.setDataByNumber(sUserId, slackUserId);
+    engine.setDataByNumber(resultDataDefNum, slackUserId);
 }
 
 /**
@@ -161,7 +161,7 @@ const prepareConfigs = (configs, user) => {
  * @param request.method
  * @param email
  */
-const assertPostGetIdRequest = ({ url, method }, email) => {
+const assertGetRequest = ({ url, method }, email) => {
 
     let newEmail = email.replace("@", "%40");
 
@@ -197,12 +197,12 @@ test('No Questetra User or Email address.- User is a user-type data items', () =
 
 
 /**
- * POST リクエストのレスポンスを準備（Slack ID 取得）
+ * GET リクエストのレスポンスを準備（Slack ID 取得）
  * @param channel
  * @param text
  * @return responseObj
  */
-const preparePostGetIdResponse = (id) => {
+const prepareGetIdResponse = (id) => {
     return {
         "ok": true,
         "user": {
@@ -213,13 +213,13 @@ const preparePostGetIdResponse = (id) => {
 
 
 /**
- * POST API リクエストでエラーになる場合（Slack ID 取得）
+ * GET API リクエストでエラーになる場合（Slack ID 取得）
  */
-test('POST GetId Failed', () => {
+test('GET Failed', () => {
     prepareConfigs(configs, 'SouthPole@questetra.com');
 
     httpClient.setRequestHandler((request) => {
-        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
+        assertGetRequest(request, 'SouthPole@questetra.com');
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
 
@@ -235,8 +235,8 @@ test('POST GetId Failed', () => {
 test('Success - User is a string data item', () => {
     const idDef = prepareConfigs(configs, 'SouthPole@questetra.com');
     httpClient.setRequestHandler((request) => {
-        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('56789FGHIJ')));
+        assertGetRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetIdResponse('56789FGHIJ')));
     });
 
     // <script> のスクリプトを実行
@@ -255,8 +255,8 @@ test('Success - User is a fixed value', () => {
     configs.put('conf_Quser', 'SouthPole@questetra.com');
 
     httpClient.setRequestHandler((request) => {
-        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('43210ABCDE')));
+        assertGetRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetIdResponse('43210ABCDE')));
     });
 
     // <script> のスクリプトを実行
@@ -283,8 +283,8 @@ test('Success - User is a user-type data items', () => {
     engine.setData(userDef, quser);
 
     httpClient.setRequestHandler((request) => {
-        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
-        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('AAAAA00000')));
+        assertGetRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetIdResponse('AAAAA00000')));
 
     });
 

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service-task-definition>
+    <last-modified>2023-08-17</last-modified>
+    <license>(C) Questetra, Inc. (MIT License)</license>
+    <engine-type>3</engine-type>
+    <label>Slack: Get User ID</label>
+    <label locale="ja">Slack: ユーザ ID 取得</label>
+    <summary>This item gets a user ID on Slack.</summary>
+    <summary locale="ja">この工程は、Slack のユーザ ID を取得します。</summary>
+    <configs>
+        <config name="conf_Token" required="true" form-type="OAUTH2" auth-type="TOKEN">
+            <label>C1: Authorization Setting in which Bot Token is set</label>
+            <label locale="ja">C1: Bot トークンを設定した認証設定</label>
+        </config>
+        <config name="conf_User" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">
+            <label>C2: User or Email address)</label>
+            <label locale="ja">C2: ユーザ もしくは メールアドレス</label>
+        </config>
+        <config name="conf_UserId" form-type="SELECT" select-data-type="STRING">
+            <label>C3: Data Item that will save User ID</label>
+            <label locale="ja">C3: ユーザ ID を保存するデータ項目</label>
+        </config>
+    </configs>
+    <help-page-url>https://support.questetra.com/bpmn-icons/slack-userid-get/</help-page-url>
+    <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/slack-userid-get/</help-page-url>
+    <script><![CDATA[
+main();
+
+function main() {
+    const auth = configs.getObject("conf_Token");
+
+    const slackIdNum = decideSlackIdNum(auth);
+
+    const userID = configs.get("conf_UserId");
+
+    if (userID !== null && userID !== "") {
+        engine.setDataByNumber(userID, slackIdNum);
+    }
+}
+
+/**
+ * ユーザのメールアドレス（Slack アカウント）をconfigから読み出す
+ * メールアドレスから Slack ID を取得する関数を呼ぶ
+ * @return {String} slackIdNum  Slack ID
+ */
+function decideSlackIdNum(auth) {
+    let mailAddress = "";
+    let slackIdNum = "";
+    mailAddressDef = configs.getObject("conf_User");
+
+    if (mailAddressDef === null) { //固定値
+        mailAddress = configs.get("conf_User");
+    } else {
+        const user = engine.findData(mailAddressDef);
+        if (mailAddressDef.matchDataType("QUSER")) { //ユーザ型
+            if (user !== null) {
+                mailAddress = user.getEmail();
+            }
+        } else { //文字型
+            mailAddress = user;
+        }
+    }
+
+    if (mailAddress !== "" && mailAddress !== null) {
+        engine.log("email: " + mailAddress);
+        slackIdNum = usersLookupByEmail(auth, mailAddress);
+    } else {
+        throw `User or Email address is brank.`;
+    }
+
+    return slackIdNum;
+}
+
+
+/**
+ * メールアドレスから Slack ID を取得する
+ * users.lookupByEmail https://api.slack.com/methods/users.lookupByEmail
+ * @param {String} auth
+ * @param {String} email
+ * @return {String} responseJson.user.id  Slack ID
+ */
+function usersLookupByEmail(auth, email) {
+
+    const url = 'https://slack.com/api/users.lookupByEmail';
+    const response = httpClient.begin()
+        .authSetting(auth)
+        .queryParam("email", email)
+        .post(url);
+    const status = response.getStatusCode();
+    const responseTxt = response.getResponseAsString();
+
+    let responseJson;
+    try {
+        responseJson = JSON.parse(responseTxt);
+    } catch (e) {
+        engine.log("failed to parse as json");
+        engine.log(`status: ${status}`);
+        engine.log(responseTxt);
+        throw `Failed to users lookup By email. status: ${status}`;
+    }
+
+    if (responseJson.ok !== true) {
+        const error = `Failed to get`;
+        engine.log(`status: ${status}`);
+        engine.log(responseTxt);
+        throw error;
+    }
+    return responseJson.user.id;
+}
+]]></script>
+    <icon>iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAABFBJREFUWEfN
+        l39ME2cYx79vofwSEljXirCwLWOSYJRotjgnJDPZWNKjg4BYpDgnCCuYKCxmxLUu7pcJZupitmqY
+        XTfFLRnaqeXqYibbXExIdNQ/tj+WLMvCEjPoGGABxULf5b3Sy7W9a0+zhd0f/aP3Ps/zeZ/fR7DE
+        D1Fr31RgygrNh2pBsYmCrAXoYwDyFuUnAPI7AfWB4FtNqsbtueWZVaM7KYBRb8wnIN0UsALIUKMU
+        wF0CnKCgPV6/989EMgkBjIYqKyh9H8AylYZjj82AkL3esYETSvKKANzDnIMStD+g4SgxQnGc/4vv
+        kNMlC2A0cJ+DYuu/YVzUQfCFd4xvjNUZB6Dm5kUlRRj5ZUTUlZOXA41Gg6nxqYTMcp6IAliM+XEl
+        LcyQa9iFzGUZmJ6cxrbVL6PhNTO2dG4BIQS8i4ejW1E8rJaQdmlOiAAs2wHya6KEaznQjNqOWpHv
+        1MFTgvGMrHBxzAfnUV1YkyxyMwAtjlSHCMDpuaMU6EwkXVZRhoPn3hOPeD+7hBctlUhJTRH/4wxV
+        yQBAgA94P98lOIT9sCazEAyNq6lzBtHR0460jDSc+9CNtndb7xuA9YkUrUbHmpUAwBm4JkpxOha9
+        4PEVaHmrBfmP5ke9unc3CM9JDwb7B3Hx1oU4gFXrS9HU3YShr4dwofeirEcIwTZ+jO8LA+g5JwWa
+        Y0/2/XQaeYZIt43Xs+eFThy5dDgKwLyyAWd+7kOqNlUQ6GnrwdXzP8QJE+AT3s+3CABGfdUwQNfG
+        nhoY9QjZrfSwJDR3mZGemS4cCd4Lwv2RW/gv8jAvHd51REYF8Xn9A+sWAbi/JYNFPGz71IZnjRtk
+        7c/dmYOl1ILttu0w7TQJZxyvO6B/RI/63fViVbRteBWjI6NyOia8fv6hCABVumVxWTHWbFyNhfkF
+        TI3fDt90LohrA9dEEZYrLFSjf4xBl6/DqmdKMTt9B5fPXEZoIaToQa+fD/vXqOdkAXbsfwV1u+pA
+        NERwr/nJBnw81AvdCp1wq53rW4XbN7+5Q4y51NqkfxLW8nYEJgKyEFIA2RBIM1wuvr32XjTubUR2
+        brbiLRN0R2kI5JPw7G/9yMzOFJT7vvdh5vYsyk0bRWOsEZWVr0HhE4WKAM4DTrgdXyVOQqUyfPr5
+        p9D6TisCkwHYN9vReawrDsD1tgs21xsoWVcSZYTlzPB3PhyyHgINxUc4qgyVGlEs9j7nvjiAXH0u
+        snKy8OOVGwo3lXdOVCNS24rlAKSz4ObVm7BttiuGQ/IiuhWzF2qG0Z6ju1FpqRT19B/rR421Bto0
+        rfAfc/tLBdVJAeKGUbgUk4/j5UXL4bx+UuiOLK6NpRZhMFVUV4iJaq/fnwxAfhwLEOElNOFGwUpu
+        U91zuPLlIGYD4c2bTci0dC2uf3MjmXHlhSQiqWYlS25FIfFkltP/31L6X3jivtfyCMSSfpiIEEv5
+        aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==
+    </icon>
+
+    <test><![CDATA[
+
+
+/**
+ * 設定の準備
+ * @param configs
+ * @param user
+ */
+const prepareConfigs = (configs, user) => {
+    const auth = httpClient.createAuthSettingToken('Slack', 'Slack');
+    configs.putObject('conf_Token', auth);
+
+    // 文字型データ項目を準備して、config に指定
+    const userDef = engine.createDataDefinition('ユーザ', 2, 'q_user', 'STRING_TEXTFIELD');
+    configs.putObject('conf_User', userDef);
+
+    engine.setData(userDef, user);
+
+    // 文字型データ項目を準備して、config に指定
+    const idDef = engine.createDataDefinition('ユーザID', 3, 'q_ids', 'STRING_TEXTFIELD');
+    configs.putObject('conf_UserId', idDef);
+    // 文字型データ項目の値（ユーザ ID を保存するデータ項目）を指定
+    engine.setData(idDef, '事前文字列');
+
+    return idDef;
+
+};
+
+
+/**
+ * POSTリクエストのテスト（Slack ID 取得）
+ * @param {Object} request
+ * @param request.url
+ * @param request.method
+ * @param email
+ */
+const assertPostGetIdRequest = ({ url, method }, email) => {
+
+    let newEmail = email.replace("@", "%40");
+
+    expect(url).toEqual(`https://slack.com/api/users.lookupByEmail?email=${newEmail}`);
+    expect(method).toEqual('POST');
+};
+
+
+/**
+ * ユーザ ID 取得失敗の場合
+ * ユーザは文字型データ項目を選択していて空
+ */
+test('User or Email address is brank.- User is a string data item', () => {
+    prepareConfigs(configs, null,);
+    expect(execute).toThrow('User or Email address is brank.');
+});
+
+
+/**
+ * ユーザ ID 取得失敗の場合
+ * ユーザはユーザ型データ項目で空
+ */
+test('User or Email address is brank.- User is a user-type data items', () => {
+    prepareConfigs(configs, null);
+
+    // ユーザ型データ項目を準備して、config に指定
+    const userDef = engine.createDataDefinition('ユーザ', 5, 'q_user', 'QUSER');
+    //conf_User の設定値を上書き
+    configs.putObject('conf_User', userDef);
+    engine.setData(userDef, null);
+    expect(execute).toThrow('User or Email address is brank.');
+});
+
+
+/**
+ * POST リクエストのレスポンスを準備（Slack ID 取得）
+ * @param channel
+ * @param text
+ * @return responseObj
+ */
+const preparePostGetIdResponse = (id) => {
+    return {
+        "ok": true,
+        "user": {
+            "id": `${id}`
+        }
+    };
+};
+
+
+/**
+ * POST API リクエストでエラーになる場合（Slack ID 取得）
+ */
+test('POST GetId Failed', () => {
+    prepareConfigs(configs, 'SouthPole@questetra.com');
+
+    httpClient.setRequestHandler((request) => {
+        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(400, 'application/json', '{}');
+    });
+
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    expect(execute).toThrow(`Failed to get`);
+});
+
+
+/**
+ * ユーザ ID 取得成功の場合
+ * ユーザは文字型データ項目
+ */
+test('Success - User is a string data item', () => {
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com');
+    httpClient.setRequestHandler((request) => {
+        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('56789FGHIJ')));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+    expect(engine.findData(idDef)).toEqual('56789FGHIJ');
+});
+
+
+/**
+ * ユーザ ID 取得成功の場合
+ * ユーザは固定値
+ */
+test('Success - User is a fixed value', () => {
+    const idDef = prepareConfigs(configs, '');
+    //conf_User の設定値を固定値で上書き
+    configs.put('conf_User', 'SouthPole@questetra.com');
+
+    httpClient.setRequestHandler((request) => {
+        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('43210ABCDE')));
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+    expect(engine.findData(idDef)).toEqual('43210ABCDE');
+});
+
+
+/**
+ * ユーザ ID 取得成功の場合
+ * ユーザはユーザ型データ項目を選択
+ */
+test('Success - User is a user-type data items', () => {
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com');
+
+    // ユーザ型データ項目を準備して、config に指定
+    const userDef = engine.createDataDefinition('ユーザ', 4, 'q_user', 'QUSER');
+    //conf_User の設定値を上書き
+    configs.putObject('conf_User', userDef);
+
+    const quser = engine.createQuser(5, 'サウスポール', 'SouthPole@questetra.com');
+
+    // ユーザ型データ項目の値を指定
+    engine.setData(userDef, quser);
+
+    httpClient.setRequestHandler((request) => {
+        assertPostGetIdRequest(request, 'SouthPole@questetra.com');
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(preparePostGetIdResponse('AAAAA00000')));
+
+    });
+
+    // <script> のスクリプトを実行
+    execute();
+    expect(engine.findData(idDef)).toEqual('AAAAA00000');
+});
+
+]]></test>
+</service-task-definition>

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-18</last-modified>
+    <last-modified>2023-08-21</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -12,13 +12,13 @@
             <label>C1: Authorization Setting in which Bot Token is set</label>
             <label locale="ja">C1: Bot トークンを設定した認証設定</label>
         </config>
-        <config name="conf_User" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">
-            <label>C2: User or Email address)</label>
-            <label locale="ja">C2: ユーザ もしくは メールアドレス</label>
+        <config name="conf_Quser" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">
+            <label>C2: Questetra User or Email address)</label>
+            <label locale="ja">C2: Questetra ユーザ もしくは メールアドレス</label>
         </config>
-        <config name="conf_UserId" form-type="SELECT" select-data-type="STRING">
-            <label>C3: Data Item that will save User ID</label>
-            <label locale="ja">C3: ユーザ ID を保存するデータ項目</label>
+        <config name="conf_SlackUserId" required="true" form-type="SELECT" select-data-type="STRING">
+            <label>C3: Data Item that will save Slack User ID</label>
+            <label locale="ja">C3: Slack ユーザ ID を保存するデータ項目</label>
         </config>
     </configs>
     <help-page-url>https://support.questetra.com/bpmn-icons/slack-userid-get/</help-page-url>
@@ -32,11 +32,9 @@ function main() {
     const mailAddress = getmailAddress();
     const slackUserId = usersLookupByEmail(auth, mailAddress).id;
 	
-    const userId = configs.get("conf_UserId");
+    const sUserId = configs.get("conf_SlackUserId");
 
-    if (userId !== null && userId !== "") {
-        engine.setDataByNumber(userId, slackUserId);
-    }
+    engine.setDataByNumber(sUserId, slackUserId);
 }
 
 /**
@@ -45,10 +43,10 @@ function main() {
  */
 function getmailAddress(){
     let mailAddress = "";
-    const mailAddressDef = configs.getObject("conf_User");
+    const mailAddressDef = configs.getObject("conf_Quser");
 
     if (mailAddressDef === null) { //固定値
-        mailAddress = configs.get("conf_User");
+        mailAddress = configs.get("conf_Quser");
     } else {
         const user = engine.findData(mailAddressDef);
         if (mailAddressDef.matchDataType("QUSER")) { //ユーザ型
@@ -62,7 +60,7 @@ function getmailAddress(){
     if (mailAddress !== "" && mailAddress !== null) {
         engine.log("email: " + mailAddress);        
     } else {
-        throw `No User or Email address.`;
+        throw `No Questetra User or Email address.`;
     }
     return mailAddress;
 }
@@ -141,13 +139,13 @@ const prepareConfigs = (configs, user) => {
 
     // 文字型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 2, 'q_user', 'STRING_TEXTFIELD');
-    configs.putObject('conf_User', userDef);
+    configs.putObject('conf_Quser', userDef);
 
     engine.setData(userDef, user);
 
     // 文字型データ項目を準備して、config に指定
     const idDef = engine.createDataDefinition('ユーザID', 3, 'q_ids', 'STRING_TEXTFIELD');
-    configs.putObject('conf_UserId', idDef);
+    configs.putObject('conf_SlackUserId', idDef);
     // 文字型データ項目の値（ユーザ ID を保存するデータ項目）を指定
     engine.setData(idDef, '事前文字列');
 
@@ -176,9 +174,9 @@ const assertPostGetIdRequest = ({ url, method }, email) => {
  * ユーザ ID 取得失敗の場合
  * ユーザは文字型データ項目を選択していて空
  */
-test('No User or Email address.- User is a string data item', () => {
+test('No Questetra User or Email address.- User is a string data item', () => {
     prepareConfigs(configs, null,);
-    expect(execute).toThrow('No User or Email address.');
+    expect(execute).toThrow('No Questetra User or Email address.');
 });
 
 
@@ -186,15 +184,15 @@ test('No User or Email address.- User is a string data item', () => {
  * ユーザ ID 取得失敗の場合
  * ユーザはユーザ型データ項目で空
  */
-test('No User or Email address.- User is a user-type data items', () => {
+test('No Questetra User or Email address.- User is a user-type data items', () => {
     prepareConfigs(configs, null);
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 5, 'q_user', 'QUSER');
-    //conf_User の設定値を上書き
-    configs.putObject('conf_User', userDef);
+    //conf_Quser の設定値を上書き
+    configs.putObject('conf_Quser', userDef);
     engine.setData(userDef, null);
-    expect(execute).toThrow('No User or Email address.');
+    expect(execute).toThrow('No Questetra User or Email address.');
 });
 
 
@@ -253,8 +251,8 @@ test('Success - User is a string data item', () => {
  */
 test('Success - User is a fixed value', () => {
     const idDef = prepareConfigs(configs, '');
-    //conf_User の設定値を固定値で上書き
-    configs.put('conf_User', 'SouthPole@questetra.com');
+    //conf_Quser の設定値を固定値で上書き
+    configs.put('conf_Quser', 'SouthPole@questetra.com');
 
     httpClient.setRequestHandler((request) => {
         assertPostGetIdRequest(request, 'SouthPole@questetra.com');
@@ -276,8 +274,8 @@ test('Success - User is a user-type data items', () => {
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 4, 'q_user', 'QUSER');
-    //conf_User の設定値を上書き
-    configs.putObject('conf_User', userDef);
+    //conf_Quser の設定値を上書き
+    configs.putObject('conf_Quser', userDef);
 
     const quser = engine.createQuser(5, 'サウスポール', 'SouthPole@questetra.com');
 

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-17</last-modified>
+    <last-modified>2023-08-18</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -29,24 +29,23 @@ main();
 function main() {
     const auth = configs.getObject("conf_Token");
 
-    const slackIdNum = decideSlackIdNum(auth);
+    const mailAddress = getmailAddress();
+    const slackUserId = usersLookupByEmail(auth, mailAddress).id;
+	
+    const userId = configs.get("conf_UserId");
 
-    const userID = configs.get("conf_UserId");
-
-    if (userID !== null && userID !== "") {
-        engine.setDataByNumber(userID, slackIdNum);
+    if (userId !== null && userId !== "") {
+        engine.setDataByNumber(userId, slackUserId);
     }
 }
 
 /**
  * ユーザのメールアドレス（Slack アカウント）をconfigから読み出す
- * メールアドレスから Slack ID を取得する関数を呼ぶ
- * @return {String} slackIdNum  Slack ID
+ * @return {String} mailAddress  mail address
  */
-function decideSlackIdNum(auth) {
+function getmailAddress(){
     let mailAddress = "";
-    let slackIdNum = "";
-    mailAddressDef = configs.getObject("conf_User");
+    const mailAddressDef = configs.getObject("conf_User");
 
     if (mailAddressDef === null) { //固定値
         mailAddress = configs.get("conf_User");
@@ -60,24 +59,21 @@ function decideSlackIdNum(auth) {
             mailAddress = user;
         }
     }
-
     if (mailAddress !== "" && mailAddress !== null) {
-        engine.log("email: " + mailAddress);
-        slackIdNum = usersLookupByEmail(auth, mailAddress);
+        engine.log("email: " + mailAddress);        
     } else {
-        throw `User or Email address is brank.`;
+        throw `No User or Email address.`;
     }
-
-    return slackIdNum;
+    return mailAddress;
 }
 
 
 /**
- * メールアドレスから Slack ID を取得する
+ * メールアドレスから Slack User オブジェクト を取得する
  * users.lookupByEmail https://api.slack.com/methods/users.lookupByEmail
  * @param {String} auth
  * @param {String} email
- * @return {String} responseJson.user.id  Slack ID
+ * @return {String} responseBody  User オブジェクト
  */
 function usersLookupByEmail(auth, email) {
 
@@ -85,27 +81,27 @@ function usersLookupByEmail(auth, email) {
     const response = httpClient.begin()
         .authSetting(auth)
         .queryParam("email", email)
-        .post(url);
+        .get(url);
     const status = response.getStatusCode();
-    const responseTxt = response.getResponseAsString();
+    const responseJson = response.getResponseAsString();
 
-    let responseJson;
+    let responseBody;
     try {
-        responseJson = JSON.parse(responseTxt);
+        responseBody = JSON.parse(responseJson);
     } catch (e) {
         engine.log("failed to parse as json");
         engine.log(`status: ${status}`);
-        engine.log(responseTxt);
+        engine.log(responseJson);
         throw `Failed to users lookup By email. status: ${status}`;
     }
 
-    if (responseJson.ok !== true) {
+    if (responseBody.ok !== true) {
         const error = `Failed to get`;
         engine.log(`status: ${status}`);
-        engine.log(responseTxt);
+        engine.log(responseJson);
         throw error;
     }
-    return responseJson.user.id;
+    return responseBody.user;
 }
 ]]></script>
     <icon>iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAABFBJREFUWEfN
@@ -172,7 +168,7 @@ const assertPostGetIdRequest = ({ url, method }, email) => {
     let newEmail = email.replace("@", "%40");
 
     expect(url).toEqual(`https://slack.com/api/users.lookupByEmail?email=${newEmail}`);
-    expect(method).toEqual('POST');
+    expect(method).toEqual('GET');
 };
 
 
@@ -180,9 +176,9 @@ const assertPostGetIdRequest = ({ url, method }, email) => {
  * ユーザ ID 取得失敗の場合
  * ユーザは文字型データ項目を選択していて空
  */
-test('User or Email address is brank.- User is a string data item', () => {
+test('No User or Email address.- User is a string data item', () => {
     prepareConfigs(configs, null,);
-    expect(execute).toThrow('User or Email address is brank.');
+    expect(execute).toThrow('No User or Email address.');
 });
 
 
@@ -190,7 +186,7 @@ test('User or Email address is brank.- User is a string data item', () => {
  * ユーザ ID 取得失敗の場合
  * ユーザはユーザ型データ項目で空
  */
-test('User or Email address is brank.- User is a user-type data items', () => {
+test('No User or Email address.- User is a user-type data items', () => {
     prepareConfigs(configs, null);
 
     // ユーザ型データ項目を準備して、config に指定
@@ -198,7 +194,7 @@ test('User or Email address is brank.- User is a user-type data items', () => {
     //conf_User の設定値を上書き
     configs.putObject('conf_User', userDef);
     engine.setData(userDef, null);
-    expect(execute).toThrow('User or Email address is brank.');
+    expect(execute).toThrow('No User or Email address.');
 });
 
 


### PR DESCRIPTION
@yehara さん

レビューをお願いします。

ファイル名は、slack-userid-get　としました。

コンフィグは、以下にしました。
C1: 認証設定（必須）
C2: ユーザもしくはメールアドレス（必須）
C3: ユーザ ID を保存する文字型データ項目