### PR TITLE
t9341 Slack: ユーザ ID 取得　の作成

### DIFF
--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-24</last-modified>
+    <last-modified>2023-08-29</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -13,16 +13,16 @@
             <label locale="ja">C1: Bot トークンを設定した認証設定</label>
         </config>
         <config name="conf_Quser" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">
-            <label>C2: Questetra User or Email address)</label>
+            <label>C2: Questetra User or Email Address</label>
             <label locale="ja">C2: Questetra ユーザ もしくは メールアドレス</label>
         </config>
         <config name="conf_SlackUserId" required="true" form-type="SELECT" select-data-type="STRING">
-            <label>C3: Data Item that will save Slack User ID</label>
+            <label>C3: Data item to save Slack User ID</label>
             <label locale="ja">C3: Slack ユーザ ID を保存するデータ項目</label>
         </config>
     </configs>
-    <help-page-url>https://support.questetra.com/bpmn-icons/slack-userid-get/</help-page-url>
-    <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/slack-userid-get/</help-page-url>
+    <help-page-url>https://support.questetra.com/bpmn-icons/service-task-slack-userid-get/</help-page-url>
+    <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-slack-userid-get/</help-page-url>
     <script><![CDATA[
 main();
 


### PR DESCRIPTION
@yehara  さん

定義ファイルを修正しました。ご確認をお願いします。

ヘルプページ URL に service-task- が抜けていたので追加しました。
C2 の英語ラベルに不要な ) を削除しました。　Email Address　の表記に修正しました。
C3 の英語ラベルを Data item to save Slack User ID　に修正しました。