### PR TITLE
t9348 Box Sign: 署名リクエストキャンセル　の作成

### DIFF
--- a/box-sign-request-cancel.xml
+++ b/box-sign-request-cancel.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-09-07</last-modified>
+    <last-modified>2023-09-12</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <label>Box: Cancel Sign Request</label>
     <label locale="ja">Box Sign: 署名リクエストキャンセル</label>
-    <summary>This item cancels a specified sign request on Box.
+    <summary>This item cancels the specified sign request on Box.
     </summary>
     <summary locale="ja">この工程は、Box 上の指定の署名リクエストをキャンセルします。</summary>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-box-sign-request-cancel/</help-page-url>
@@ -64,7 +64,7 @@ function cancelRequest(oauth2, requestId) {
         return;
     } else if (status === 400) {
         engine.log(responseTxt);
-        engine.log('The status can be "Signed", "Canceled","Declined", or "Converting".');
+        engine.log('The status can be "Signed", "Canceled", "Declined", or "Converting".');
         return;
     } else {
         const error = `Failed to cancel. status: ${status}`;


### PR DESCRIPTION
@hatanaka-akihiro さん

英文の指摘を修正しました。ご確認をお願いします。

summary について 
This item cancels a specified sign request on Box.
を以下に修正しました。
This item cancels the specified sign request on Box.

400　エラー時のログ出力について
The status can be "Signed", "Canceled","Declined", or "Converting".
を以下に修正しました。"Canceled"と"Declined"の間にスペースを加えました。
The status can be "Signed", "Canceled", "Declined", or "Converting".
