### PR TITLE
t9362 Trello: リスト ID 取得　の作成

### DIFF
--- a/trello-listid-get.xml
+++ b/trello-listid-get.xml
@@ -2,7 +2,7 @@
 <service-task-definition>
     <label>Trello: Get List Id</label>
     <label locale="ja">Trello: リスト ID 取得</label>
-    <last-modified>2023-09-08</last-modified>
+    <last-modified>2023-09-12</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -26,7 +26,7 @@
             <label locale="ja">C4: リストの名前</label>
         </config>
         <config name="conf_ListId" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-            <label>C5: Data item to save ID of the list</label>
+            <label>C5: Data item to save List ID</label>
             <label locale="ja">C5: リスト ID を保存するデータ項目</label>
         </config>
     </configs>


### PR DESCRIPTION
@hatanaka-akihiro さん

英語の表記を修正しました。ご確認をお願いします。

C5 
Data item to save ID of the list
を
Data item to save List ID
に修正しました。
list を List にしましたが、他のアイテムに習い、summary の list は小文字のままにしています。