### PR TITLE
t9418 Slack: ユーザ ID 取得　Questetra が登録済みの Bot でも使用できるように

### DIFF
--- a/slack-message-post.xml
+++ b/slack-message-post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-04</last-modified>
+    <last-modified>2023-09-25</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <license>(C) Questetra, Inc. (MIT License)</license>
@@ -13,9 +13,13 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-slack-message-post/
     </help-page-url>
     <configs>
-        <config name="conf_Token" required="true" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1: Authorization Setting in which Bot Token is set</label>
-            <label locale="ja">C1: Bot トークンを設定した認証設定</label>
+        <config name="conf_OAuth2" form-type="OAUTH2" auth-type="OAUTH2"
+                oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
+            <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
+        </config>
+        <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
+            <label>C1-b: Authorization Setting ( Using a Bot registered yourself )</label>
+            <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Channel" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD"
                 editable="true">
@@ -41,7 +45,7 @@
     </configs>
     <script><![CDATA[
 function main() {
-    const auth = configs.getObject("conf_Token");
+    const auth = decideAuth();
     const channel = readStringData('conf_Channel');
     if (channel === null) {
         throw new Error('Channel must not be blank.');
@@ -52,6 +56,25 @@ function main() {
     const blocks = readBlocks();
 
     sendMessage(auth, channel, thread, replyBroadcast, blocks, text);
+}
+
+/** 
+  * config から認証設定値を読み出す
+  * 両方とも設定されていれば、auth-type="OAUTH2" の方を優先
+  * 両方とも設定されていなければ、スクリプトエラー
+  * @return auth
+  */
+function decideAuth() {
+    const auth_OAuth2 = configs.getObject("conf_OAuth2");
+    const auth_Token = configs.getObject("conf_Token")
+
+    if (auth_OAuth2 !== null ){
+        return auth_OAuth2;
+    } else if (auth_Token !== null){
+        return auth_Token;
+    } else {
+        throw `No Authorization Setting.`;
+    }
 }
 
 function readStringData(configName) {
@@ -166,9 +189,31 @@ function sendMessage(auth, channel, thread, replyBroadcast, blocks, text) {
  * @param blocks
  * @param text
  */
-const prepareConfigs = (channel, thread, replyBroadcast, blocks, text) => {
-    const auth = httpClient.createAuthSettingToken('Slack', 'Slack');
-    configs.putObject('conf_Token', auth);
+const prepareConfigs = (channel, thread, replyBroadcast, blocks, text, oauth2, token) => {
+    if (oauth2){
+        const auth_OAuth2 = httpClient.createAuthSettingOAuth2(
+            'Slack',
+            'https://slack.com/oauth/v2/authorize',
+            'https://slack.com/api/oauth.v2.access',
+            'chat:write,users:read,users:read.email',
+            'consumer_key',
+            'consumer_secret',
+            'access_token'
+        );
+        configs.putObject('conf_OAuth2', auth_OAuth2);
+    } else {
+        configs.put('conf_OAuth2', '');
+    }
+
+    if (token){
+        const auth_Token = httpClient.createAuthSettingToken(
+            'Slack Bot Token',
+            'slack-bot-token'
+        );
+        configs.putObject('conf_Token', auth_Token);
+    } else {
+        configs.put('conf_Token', '');
+    }
 
     const channelDef = engine.createDataDefinition('チャンネル', 1, 'q_channel', 'STRING_TEXTFIELD');
     engine.setData(channelDef, channel);
@@ -183,6 +228,8 @@ const prepareConfigs = (channel, thread, replyBroadcast, blocks, text) => {
     configs.put('conf_Blocks', blocks === null ? '' : JSON.stringify(blocks));
     configs.put('conf_Text', text);
 };
+
+
 
 /**
  * POSTリクエストのテスト（チャット投稿）
@@ -238,11 +285,27 @@ const preparePostResponse = (channel, text) => {
     };
 };
 
+
+/**
+ * 認証設定が両方されていない場合
+ */
+test('No Authorization Setting', () => {
+    prepareConfigs('channel1', null, false, null, 'text1', false, false);
+
+    try {
+        main();
+    } catch (e) {
+        const errorMsg = 'No Authorization Setting.';
+        expect(e.message).toEqual(errorMsg);
+    }
+});
+
+
 /**
  * POST API リクエストでエラーになる場合（チャット投稿）
  */
 test('POST Failed', () => {
-    prepareConfigs('channel1', null, false, null, 'text1');
+    prepareConfigs('channel1', null, false, null, 'text1', true, false);
 
     httpClient.setRequestHandler((request) => {
         assertPostRequest(request, 'channel1', null, false, null, 'text1');
@@ -263,9 +326,11 @@ test('POST Failed', () => {
  * チャット投稿成功の場合
  * スレッド指定なし
  * Blocks 指定なし
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - no thread, no blocks', () => {
-    prepareConfigs('channel2', null, false, null, 'text2');
+    prepareConfigs('channel2', null, false, null, 'text2', true , true);
 
     httpClient.setRequestHandler((request) => {
         assertPostRequest(request, 'channel2', null, false, null, 'text2');
@@ -279,6 +344,8 @@ test('Success - no thread, no blocks', () => {
  * チャット投稿成功の場合
  * スレッド指定あり
  * Blocks 指定あり
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 未設定
  */
 test('Success - with thread, with blocks', () => {
     const blocks = {
@@ -301,7 +368,7 @@ test('Success - with thread, with blocks', () => {
             }
         ]
     };
-    prepareConfigs('channel3', 'thread3', false, blocks, 'text3');
+    prepareConfigs('channel3', 'thread3', false, blocks, 'text3', true , false);
 
     httpClient.setRequestHandler((request) => {
         assertPostRequest(request, 'channel3', 'thread3', false, blocks, 'text3');
@@ -316,9 +383,11 @@ test('Success - with thread, with blocks', () => {
  * スレッド指定あり
  * reply_broadcast
  * Blocks 指定なし
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 未設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - with thread, reply_broadcast, no blocks', () => {
-    prepareConfigs('channel4', 'thread4', true, null, 'text4');
+    prepareConfigs('channel4', 'thread4', true, null, 'text4, false , true);
 
     httpClient.setRequestHandler((request) => {
         assertPostRequest(request, 'channel4', 'thread4', true, null, 'text4');

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-08-29</last-modified>
+    <last-modified>2023-09-22</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -8,9 +8,13 @@
     <summary>This item gets a user ID on Slack.</summary>
     <summary locale="ja">この工程は、Slack のユーザ ID を取得します。</summary>
     <configs>
-        <config name="conf_Token" required="true" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1: Authorization Setting in which Bot Token is set</label>
-            <label locale="ja">C1: Bot トークンを設定した認証設定</label>
+        <config name="conf_OAuth2_V2" form-type="OAUTH2" auth-type="OAUTH2"
+                oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
+            <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
+        </config>
+        <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
+            <label>C1-b: Authorization Setting ( Using a Bot registered yourself )</label>
+            <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Quser" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">
             <label>C2: Questetra User or Email Address</label>
@@ -27,15 +31,39 @@
 main();
 
 function main() {
-    const auth = configs.getObject("conf_Token");
+
+    const auth = decideAuth();
 
     const mailAddress = getmailAddress();
     const slackUserId = usersLookupByEmail(auth, mailAddress).id;
 	
-    const resultDataDefNum = configs.get("conf_SlackUserId");
+    const resultDataDefNum = configs.getObject("conf_SlackUserId");
 
-    engine.setDataByNumber(resultDataDefNum, slackUserId);
+    engine.setData(resultDataDefNum, slackUserId);
 }
+
+
+/** 
+  * config から認証設定値を読み出す
+  * 両方とも設定されていれば、auth-type="OAUTH2" の方を優先
+  * 両方とも設定されていなければ、スクリプトエラー
+  * @return auth
+  */
+function decideAuth() {
+    let auth;
+    const auth_OAuth2_V2 = configs.getObject("conf_OAuth2_V2");
+    const auth_Token = configs.getObject("conf_Token")
+
+    if (auth_OAuth2_V2 !== "" && auth_OAuth2_V2 !== null ){
+        auth = auth_OAuth2_V2;
+    }else if (auth_OAuth2_V2 === "" || auth_OAuth2_V2 === null && auth_Token !== "" && auth_Token !== null){
+        auth = auth_Token;
+    } else {
+        throw `No Authorization Setting.`;
+    }
+    return auth;
+}
+
 
 /**
  * ユーザのメールアドレス（Slack アカウント）をconfigから読み出す
@@ -69,7 +97,7 @@ function getmailAddress(){
 /**
  * メールアドレスから Slack User オブジェクト を取得する
  * users.lookupByEmail https://api.slack.com/methods/users.lookupByEmail
- * @param {String} auth
+ * @@param {AuthSettingWrapper} or {String} auth
  * @param {String} email
  * @return {String} responseBody  User オブジェクト
  */
@@ -129,13 +157,36 @@ function usersLookupByEmail(auth, email) {
 
 
 /**
- * 設定の準備
+ * 設定の準備 auth_OAuth2_V2 conf_OAuth2_V2
  * @param configs
  * @param user
  */
-const prepareConfigs = (configs, user) => {
-    const auth = httpClient.createAuthSettingToken('Slack', 'Slack');
-    configs.putObject('conf_Token', auth);
+const prepareConfigs = (configs, user, oauth2, token) => {
+    if (oauth2 === "yes"){
+        const auth_OAuth2_V2 = httpClient.createAuthSettingOAuth2(
+            'Slack',
+            'https://slack.com/oauth/v2/authorize',
+            'https://slack.com/api/oauth.v2.access',
+            'chat:write,users:read,users:read.email',
+            'consumer_key',
+            'consumer_secret',
+            'access_token'
+        );
+        configs.putObject('conf_OAuth2_V2', auth_OAuth2_V2);
+    } else {
+        configs.putObject('conf_OAuth2_V2', '');
+    }
+
+    if (token === "yes"){
+        const auth_Token = httpClient.createAuthSettingToken(
+            'Slack Bot Token',
+            'slack-bot-token'
+        );
+        configs.putObject('conf_Token', auth_Token);
+    } else {
+        configs.putObject('conf_Token', '');
+    }
+
 
     // 文字型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 2, 'q_user', 'STRING_TEXTFIELD');
@@ -171,11 +222,21 @@ const assertGetRequest = ({ url, method }, email) => {
 
 
 /**
+ * 認証設定が両方されていない場合
+ */
+test('No Authorization Setting', () => {
+    prepareConfigs(configs, null, 'no', 'no');
+    expect(execute).toThrow('No Authorization Setting.');
+});
+
+
+
+/**
  * ユーザ ID 取得失敗の場合
  * ユーザは文字型データ項目を選択していて空
  */
 test('No Questetra User or Email address.- User is a string data item', () => {
-    prepareConfigs(configs, null,);
+    prepareConfigs(configs, null, "yes", "no");
     expect(execute).toThrow('No Questetra User or Email address.');
 });
 
@@ -185,7 +246,7 @@ test('No Questetra User or Email address.- User is a string data item', () => {
  * ユーザはユーザ型データ項目で空
  */
 test('No Questetra User or Email address.- User is a user-type data items', () => {
-    prepareConfigs(configs, null);
+    prepareConfigs(configs, null, "no", "yes");
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 5, 'q_user', 'QUSER');
@@ -233,7 +294,7 @@ test('GET Failed', () => {
  * ユーザは文字型データ項目
  */
 test('Success - User is a string data item', () => {
-    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com');
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "yes" , "yes");
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetIdResponse('56789FGHIJ')));
@@ -252,7 +313,7 @@ test('Success - User is a string data item', () => {
 test('Success - User is a fixed value', () => {
     const idDef = prepareConfigs(configs, '');
     //conf_Quser の設定値を固定値で上書き
-    configs.put('conf_Quser', 'SouthPole@questetra.com');
+    configs.put('conf_Quser', 'SouthPole@questetra.com', "yes" , "no");
 
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
@@ -270,7 +331,7 @@ test('Success - User is a fixed value', () => {
  * ユーザはユーザ型データ項目を選択
  */
 test('Success - User is a user-type data items', () => {
-    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com');
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "no" , "yes");
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 4, 'q_user', 'QUSER');

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-09-22</last-modified>
+    <last-modified>2023-09-25</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -8,7 +8,7 @@
     <summary>This item gets a user ID on Slack.</summary>
     <summary locale="ja">この工程は、Slack のユーザ ID を取得します。</summary>
     <configs>
-        <config name="conf_OAuth2_V2" form-type="OAUTH2" auth-type="OAUTH2"
+        <config name="conf_OAuth2" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
             <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
         </config>
@@ -50,18 +50,16 @@ function main() {
   * @return auth
   */
 function decideAuth() {
-    let auth;
-    const auth_OAuth2_V2 = configs.getObject("conf_OAuth2_V2");
+    const auth_OAuth2 = configs.getObject("conf_OAuth2");
     const auth_Token = configs.getObject("conf_Token")
 
-    if (auth_OAuth2_V2 !== "" && auth_OAuth2_V2 !== null ){
-        auth = auth_OAuth2_V2;
-    }else if (auth_OAuth2_V2 === "" || auth_OAuth2_V2 === null && auth_Token !== "" && auth_Token !== null){
-        auth = auth_Token;
+    if (auth_OAuth2 !== null ){
+        return auth_OAuth2;
+    }else if (auth_OAuth2 === null &&  auth_Token !== null){
+        return auth_Token;
     } else {
         throw `No Authorization Setting.`;
     }
-    return auth;
 }
 
 
@@ -97,7 +95,7 @@ function getmailAddress(){
 /**
  * メールアドレスから Slack User オブジェクト を取得する
  * users.lookupByEmail https://api.slack.com/methods/users.lookupByEmail
- * @@param {AuthSettingWrapper} or {String} auth
+ * @@param {AuthSettingWrapper}
  * @param {String} email
  * @return {String} responseBody  User オブジェクト
  */
@@ -157,13 +155,13 @@ function usersLookupByEmail(auth, email) {
 
 
 /**
- * 設定の準備 auth_OAuth2_V2 conf_OAuth2_V2
+ * 設定の準備
  * @param configs
  * @param user
  */
 const prepareConfigs = (configs, user, oauth2, token) => {
-    if (oauth2 === "yes"){
-        const auth_OAuth2_V2 = httpClient.createAuthSettingOAuth2(
+    if (oauth2){
+        const auth_OAuth2 = httpClient.createAuthSettingOAuth2(
             'Slack',
             'https://slack.com/oauth/v2/authorize',
             'https://slack.com/api/oauth.v2.access',
@@ -172,12 +170,12 @@ const prepareConfigs = (configs, user, oauth2, token) => {
             'consumer_secret',
             'access_token'
         );
-        configs.putObject('conf_OAuth2_V2', auth_OAuth2_V2);
+        configs.putObject('conf_OAuth2', auth_OAuth2);
     } else {
-        configs.put('conf_OAuth2_V2', '');
+        configs.put('conf_OAuth2', '');
     }
 
-    if (token === "yes"){
+    if (token){
         const auth_Token = httpClient.createAuthSettingToken(
             'Slack Bot Token',
             'slack-bot-token'
@@ -225,7 +223,7 @@ const assertGetRequest = ({ url, method }, email) => {
  * 認証設定が両方されていない場合
  */
 test('No Authorization Setting', () => {
-    prepareConfigs(configs, null, 'no', 'no');
+    prepareConfigs(configs, null, false, false);
     expect(execute).toThrow('No Authorization Setting.');
 });
 
@@ -236,7 +234,7 @@ test('No Authorization Setting', () => {
  * ユーザは文字型データ項目を選択していて空
  */
 test('No Questetra User or Email address.- User is a string data item', () => {
-    prepareConfigs(configs, null, "yes", "no");
+    prepareConfigs(configs, null, true, false);
     expect(execute).toThrow('No Questetra User or Email address.');
 });
 
@@ -246,7 +244,7 @@ test('No Questetra User or Email address.- User is a string data item', () => {
  * ユーザはユーザ型データ項目で空
  */
 test('No Questetra User or Email address.- User is a user-type data items', () => {
-    prepareConfigs(configs, null, "no", "yes");
+    prepareConfigs(configs, null, false, true);
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 5, 'q_user', 'QUSER');
@@ -277,7 +275,7 @@ const prepareGetIdResponse = (id) => {
  * GET API リクエストでエラーになる場合（Slack ID 取得）
  */
 test('GET Failed', () => {
-    prepareConfigs(configs, 'SouthPole@questetra.com', "yes" , "yes");
+    prepareConfigs(configs, 'SouthPole@questetra.com', true , true);
 
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
@@ -296,7 +294,7 @@ test('GET Failed', () => {
  * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - User is a string data item', () => {
-    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "yes" , "yes");
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', true , true);
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetIdResponse('56789FGHIJ')));
@@ -315,7 +313,7 @@ test('Success - User is a string data item', () => {
  * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 未設定
  */
 test('Success - User is a fixed value', () => {
-    const idDef = prepareConfigs(configs, '', "yes" , "no");
+    const idDef = prepareConfigs(configs, '', true , false);
     //conf_Quser の設定値を固定値で上書き
     configs.put('conf_Quser', 'SouthPole@questetra.com');
 
@@ -337,7 +335,7 @@ test('Success - User is a fixed value', () => {
  * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - User is a user-type data items', () => {
-    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "no" , "yes");
+    const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', false , true);
 
     // ユーザ型データ項目を準備して、config に指定
     const userDef = engine.createDataDefinition('ユーザ', 4, 'q_user', 'QUSER');

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -174,7 +174,7 @@ const prepareConfigs = (configs, user, oauth2, token) => {
         );
         configs.putObject('conf_OAuth2_V2', auth_OAuth2_V2);
     } else {
-        configs.putObject('conf_OAuth2_V2', '');
+        configs.put('conf_OAuth2_V2', '');
     }
 
     if (token === "yes"){
@@ -184,7 +184,7 @@ const prepareConfigs = (configs, user, oauth2, token) => {
         );
         configs.putObject('conf_Token', auth_Token);
     } else {
-        configs.putObject('conf_Token', '');
+        configs.put('conf_Token', '');
     }
 
 
@@ -277,7 +277,7 @@ const prepareGetIdResponse = (id) => {
  * GET API リクエストでエラーになる場合（Slack ID 取得）
  */
 test('GET Failed', () => {
-    prepareConfigs(configs, 'SouthPole@questetra.com');
+    prepareConfigs(configs, 'SouthPole@questetra.com', "yes" , "yes");
 
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
@@ -292,6 +292,8 @@ test('GET Failed', () => {
 /**
  * ユーザ ID 取得成功の場合
  * ユーザは文字型データ項目
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - User is a string data item', () => {
     const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "yes" , "yes");
@@ -309,11 +311,13 @@ test('Success - User is a string data item', () => {
 /**
  * ユーザ ID 取得成功の場合
  * ユーザは固定値
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 未設定
  */
 test('Success - User is a fixed value', () => {
-    const idDef = prepareConfigs(configs, '');
+    const idDef = prepareConfigs(configs, '', "yes" , "no");
     //conf_Quser の設定値を固定値で上書き
-    configs.put('conf_Quser', 'SouthPole@questetra.com', "yes" , "no");
+    configs.put('conf_Quser', 'SouthPole@questetra.com');
 
     httpClient.setRequestHandler((request) => {
         assertGetRequest(request, 'SouthPole@questetra.com');
@@ -329,6 +333,8 @@ test('Success - User is a fixed value', () => {
 /**
  * ユーザ ID 取得成功の場合
  * ユーザはユーザ型データ項目を選択
+ * C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) 未設定
+ * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - User is a user-type data items', () => {
     const idDef = prepareConfigs(configs, 'SouthPole@questetra.com', "no" , "yes");

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -55,7 +55,7 @@ function decideAuth() {
 
     if (auth_OAuth2 !== null ){
         return auth_OAuth2;
-    }else if (auth_OAuth2 === null &&  auth_Token !== null){
+    } else if (auth_Token !== null){
         return auth_Token;
     } else {
         throw `No Authorization Setting.`;


### PR DESCRIPTION
@hatanaka-akihiro  さん

Questetra が登録済みの Bot でも使用できるよう対応しました。
QBPMS 上では動作確認できたのですが、テストコードで失敗します。

https://sanjo.questetra.net/jenkins/job/userweb_test_addon/3580/com.questetra$bpms/console
このエラーはどういう意味か教えてください。

設定の準備で、認証設定の以下の箇所が間違えているのでしょうか？

```
const auth_OAuth2_V2 = httpClient.createAuthSettingOAuth2(
            'Slack',
            'https://slack.com/oauth/v2/authorize',
            'https://slack.com/api/oauth.v2.access',
            'chat:write,users:read,users:read.email',
            'consumer_key',
            'consumer_secret',
            'access_token'
        );
configs.putObject('conf_OAuth2_V2', auth_OAuth2_V2);
```
