### PR TITLE
t9418 Slack: メッセージ送信 (Block Kit 対応) Questetra が登録済みの Bot でも使用できるように

### DIFF
--- a/slack-message-post.xml
+++ b/slack-message-post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-09-25</last-modified>
+    <last-modified>2023-09-26</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <license>(C) Questetra, Inc. (MIT License)</license>
@@ -73,7 +73,7 @@ function decideAuth() {
     } else if (auth_Token !== null){
         return auth_Token;
     } else {
-        throw `No Authorization Setting.`;
+        throw new Error('No Authorization Setting.');
     }
 }
 
@@ -387,7 +387,7 @@ test('Success - with thread, with blocks', () => {
  * C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合) 設定
  */
 test('Success - with thread, reply_broadcast, no blocks', () => {
-    prepareConfigs('channel4', 'thread4', true, null, 'text4, false , true);
+    prepareConfigs('channel4', 'thread4', true, null, 'text4', false , true);
 
     httpClient.setRequestHandler((request) => {
         assertPostRequest(request, 'channel4', 'thread4', true, null, 'text4');
@@ -401,7 +401,7 @@ test('Success - with thread, reply_broadcast, no blocks', () => {
  * Block Kit が不正な場合
  */
 test('Invalid Blocks - not JSON', () => {
-    prepareConfigs('channel4', null, false, 'text', 'text4');
+    prepareConfigs('channel4', null, false, 'text', 'text4', true , true);
 
     try {
         main();
@@ -415,7 +415,7 @@ test('Invalid Blocks - not JSON', () => {
  * Block Kit が不正な場合
  */
 test('Invalid Blocks - root it not blocks', () => {
-    prepareConfigs('channel5', null, false, {type: 'text'}, 'text5');
+    prepareConfigs('channel5', null, false, {type: 'text'}, 'text5', true , true);
 
     try {
         main();
@@ -431,7 +431,7 @@ test('Invalid Blocks - root it not blocks', () => {
 test('Invalid Text - empty', () => {
     prepareConfigs('channel6', null, false, {
         'blocks': []
-    }, '');
+    }, '', true , true);
 
     try {
         main();
@@ -445,7 +445,7 @@ test('Invalid Text - empty', () => {
  * Channel が不正な場合
  */
 test('Invalid Channel - empty', () => {
-    prepareConfigs(null, null, false, null, 'text7');
+    prepareConfigs(null, null, false, null, 'text7', true , true);
 
     try {
         main();


### PR DESCRIPTION
@hatanaka-akihiro さん

修正しました。ご確認をお願いします。