### PR TITLE
t9419 Trello: リスト ID 取得 　ラベルの修正等

### DIFF
--- a/trello-listid-get.xml
+++ b/trello-listid-get.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <label>Trello: Get List Id</label>
+    <label>Trello: Get List ID</label>
     <label locale="ja">Trello: リスト ID 取得</label>
-    <last-modified>2023-09-12</last-modified>
+    <last-modified>2023-09-28</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -63,8 +63,10 @@ function main() {
   */
 function getListInformation(apiKey, apiToken, boardId) {
 
-    const url = `https://api.trello.com/1/boards/${boardId}/lists?key=${apiKey}&token=${apiToken}`;
+    const url = `https://api.trello.com/1/boards/${encodeURIComponent(boardId)}/lists`;
     const response = httpClient.begin()
+        .queryParam("key", `${apiKey}`)
+        .queryParam("token", `${apiToken}`)
         .get(url);
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();
@@ -172,7 +174,7 @@ const assertError = (func, errorMsg) => {
  * @param boardId
  */
 const assertRequest = ({ url, method }, boardId) => {
-    expect(url).toEqual(`https://api.trello.com/1/boards/${boardId}/lists?key=TrelloApiKey&token=TrelloApiToken`); // 認証設定のトークンのテスト時の値は token
+    expect(url).toEqual(`https://api.trello.com/1/boards/${encodeURIComponent(boardId)}/lists?key=TrelloApiKey&token=TrelloApiToken`); // 認証設定のトークンのテスト時の値は token
     expect(method).toEqual('GET');
 };
 


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

英語のラベルを　Trello: Get List ID　に修正しました。

他、別のアイテムで指摘があったので、こちらのアイテムでも修正しました。
・ボード ID をパスパラメータに含める部分で encodeURIComponent()　を使用しました。
・クエリパラメータの key と token について、queryParam() を使用しました。