### PR TITLE
t9363 Trello: ラベル ID 取得　英語のラベルを修正

### DIFF
--- a/trello-labelid-get.xml
+++ b/trello-labelid-get.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <label>Trello: Get Label Id</label>
+    <label>Trello: Get Label ID</label>
     <label locale="ja">Trello: ラベル ID 取得</label>
-    <last-modified>2023-09-19</last-modified>
+    <last-modified>2023-09-29</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -91,8 +91,10 @@ function decideLabelNames() {
   */
 function getLabels(apiKey, apiToken, boardId) {
 
-    const url = `https://api.trello.com/1/boards/${boardId}/labels?key=${apiKey}&token=${apiToken}`;
+    const url = `https://api.trello.com/1/boards/${encodeURIComponent(boardId)}/labels`;
     const response = httpClient.begin()
+        .queryParam("key", `${apiKey}`)
+        .queryParam("token", `${apiToken}`)
         .get(url);
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

・英語のラベルを　Trello: Get Label ID　に修正しました。
・ボード ID をパスパラメータに含める部分で encodeURIComponent()　を使用しました。
・クエリパラメータの key と token について、queryParam() を使用しました。