### PR TITLE
t9364 Trello: メンバ ID 取得  英語のラベルを修正

### DIFF
--- a/trello-memberid-get.xml
+++ b/trello-memberid-get.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <label>Trello: Get Member Id</label>
+    <label>Trello: Get Member ID</label>
     <label locale="ja">Trello: メンバ ID 取得</label>
-    <last-modified>2023-09-25</last-modified>
+    <last-modified>2023-09-29</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -22,7 +22,7 @@
             <label locale="ja">C3: ボード ID</label>
         </config>
         <config name="conf_Names" required="true" form-type="TEXTAREA">
-            <label>C4: Member Name(Full Name or User Name, Write one per line)</label>
+            <label>C4: Member Name (Full Name or User Name; write one per line)</label>
             <label locale="ja">C4: メンバの名前（フルネームもしくはユーザネーム 複数設定する場合、1件ごとに改行してください）</label>
         </config>
         <config name="conf_MemberId" required="true" form-type="SELECT" select-data-type="STRING_TEXTAREA">
@@ -91,8 +91,10 @@ function decideMemberNames() {
   */
 function getMembers(apiKey, apiToken, boardId) {
 
-    const url = `https://api.trello.com/1/boards/${boardId}/members?key=${apiKey}&token=${apiToken}`;
+    const url = `https://api.trello.com/1/boards/${encodeURIComponent(boardId)}/members`;
     const response = httpClient.begin()
+        .queryParam("key", `${apiKey}`)
+        .queryParam("token", `${apiToken}`)
         .get(url);
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

・英語のラベルを　Trello: Trello: Get Member ID　に修正しました。
・英語のラベル（C4）を　( の前に半角スペースを追加し、Full Name or User Name; write one per line とし、区切り文字をセミコロンにして、write の語頭を小文字にしました。
・ボード ID をパスパラメータに含める部分で encodeURIComponent()　を使用しました。
・クエリパラメータの key と token について、queryParam() を使用しました。