### PR TITLE
T9418

### DIFF
--- a/slack-message-post.xml
+++ b/slack-message-post.xml
@@ -19,7 +19,7 @@
             <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
         </config>
         <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1-b: Authorization Setting (Bot registered by yourself)</label>
+            <label>C1-b: Authorization Setting (Bot registered by you)</label>
             <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Channel" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD"

--- a/slack-message-post.xml
+++ b/slack-message-post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-09-26</last-modified>
+    <last-modified>2023-10-03</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <license>(C) Questetra, Inc. (MIT License)</license>
@@ -15,10 +15,11 @@
     <configs>
         <config name="conf_OAuth2" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
+            <label>C1-a: Authorization Setting (Bot registered by Questetra)</label>
             <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
         </config>
         <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1-b: Authorization Setting ( Using a Bot registered yourself )</label>
+            <label>C1-b: Authorization Setting (Bot registered by yourself)</label>
             <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Channel" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD"

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-09-25</last-modified>
+    <last-modified>2023-10-03</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <label>Slack: Get User ID</label>
@@ -10,10 +10,11 @@
     <configs>
         <config name="conf_OAuth2" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
+            <label>C1-a: Authorization Setting (Bot registered by Questetra)</label>
             <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
         </config>
         <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1-b: Authorization Setting ( Using a Bot registered yourself )</label>
+            <label>C1-b: Authorization Setting (Bot registered by yourself)</label>
             <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Quser" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">

--- a/slack-userid-get.xml
+++ b/slack-userid-get.xml
@@ -14,7 +14,7 @@
             <label locale="ja">C1-a: HTTP 認証設定 (Questetra が登録済みの Bot を使用する場合) </label>
         </config>
         <config name="conf_Token" form-type="OAUTH2" auth-type="TOKEN">
-            <label>C1-b: Authorization Setting (Bot registered by yourself)</label>
+            <label>C1-b: Authorization Setting (Bot registered by you)</label>
             <label locale="ja">C1-b: HTTP 認証設定 (独自に登録した Bot を使用する場合)</label>
         </config>
         <config name="conf_Quser" required="true" form-type="SELECT" select-data-type="STRING_TEXTFIELD|QUSER" editable="true">


### PR DESCRIPTION
@hatanaka-akihiro  さん

すみません、C1-a の英語ラベルの設定ができていませんでした。

C1-b とそろえるような形で、「C1-a: Authorization Setting (Using a Bot registered by Questetra)」とすると、文字数制限にかかりました。
よって、
「C1-a: Authorization Setting (Bot registered by Questetra)」にしました。
こちらにそろえ、C1-b も、以下に変更しました。
「C1-b: Authorization Setting (Bot registered by yourself)」