### PR TITLE
t9444 Microsoft 365 OneDrive for Business: ファイル / フォルダコピー　auth-type の設定

### DIFF
--- a/onedrive-file-copy.xml
+++ b/onedrive-file-copy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2023-03-16</last-modified>
+    <last-modified>2023-11-30</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <label>Microsoft 365 OneDrive for Business: Copy File / Folder</label>
@@ -48,7 +48,7 @@ const GRAPH_URI = "https://graph.microsoft.com/v1.0/";
 
 function main() {
     //// == Config Retrieving / 工程コンフィグの参照 ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const sourceUrl = retrieveSourceUrl();
     const destUrl = retrieveDestUrl();
     const newName = retrieveNewName();
@@ -73,7 +73,7 @@ function main() {
 
 function proceed() {
     //// == Config Retrieving / 工程コンフィグの参照 ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const saveUrlDataDef = configs.getObject("conf_dataForUrl");
 
     //// == Restoring Temporary Data / 一時データの読み出し ==
@@ -134,7 +134,7 @@ function retrieveNewName() {
   * ドライブアイテムのURLからアイテム情報（ドライブIDとアイテムID）を取得し、
   * オブジェクトで返す（URLが空の場合はドライブIDもアイテムIDも空文字列）
   * @param {String} driveItemUrl  ドライブアイテム（ファイル、フォルダ）のURL
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} itemInfo  ドライブアイテム情報 {driveId, id}
   */
 function getItemInfoByUrl(driveItemUrl, oauth2) {
@@ -156,7 +156,7 @@ function getItemInfoByUrl(driveItemUrl, oauth2) {
   * OneDriveのドライブアイテム（ファイル、フォルダ）のメタデータを取得し、JSONオブジェクトを返す
   * APIの仕様: https://docs.microsoft.com/ja-jp/onedrive/developer/rest-api/api/shares_get?view=odsp-graph-online
   * @param {String} sharingUrl  ドライブアイテムの共有URL
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} responseObj  ドライブアイテムのメタデータのJSONオブジェクト
   */
 function getObjBySharingUrl(sharingUrl, oauth2) {
@@ -199,7 +199,7 @@ function encodeSharingUrl(sharingUrl) {
   * @param {Object} sourceInfo  コピー元アイテム情報 {driveId, id}
   * @param {Object} destInfo  コピー先フォルダ情報 {driveId, id}
   * @param {String} newName  新しいファイル / フォルダの名前
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {String} location  コピーステータス確認先 URL
   */
 function sendCopyRequest(sourceInfo, destInfo, newName, oauth2) {
@@ -243,7 +243,7 @@ function generateCopyRequestBody(destInfo, newName) {
   * コピー未完了の場合は false を返す
   * @param {String} location  コピーステータス確認用 URL
   * @param {String} driveId  新しいアイテムのドライブ ID
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {DataDefinitionView} saveUrlDataDef  URL を保存するデータ項目
   * @return {boolean}
   */
@@ -305,7 +305,7 @@ function getMonitorResponseObj(location) {
   * OneDriveのドライブアイテムのメタデータを取得し、URLを返す
   * @param {String} driveId  ドライブID
   * @param {String} itemId  アイテムID
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {String} webUrl  ドライブアイテムのURL
   */
 function getItemUrlById(driveId, itemId, oauth2) {
@@ -356,7 +356,16 @@ function getItemUrlById(driveId, itemId, oauth2) {
  * @return dataForUrlDef
  */
 const prepareConfigs = (sourceUrl, destUrl, newName) => {
-    configs.put('conf_OAuth2', 'Microsoft');
+    const oauth2 = httpClient.createAuthSettingOAuth2(
+        'OneDrive',
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+        'https://graph.microsoft.com/Files.ReadWrite.All offline_access',
+        'client_id',
+        'client_secret',
+        'access_token'
+    );
+    configs.putObject('conf_OAuth2', oauth2);
     configs.put('conf_newName', newName);
 
     // コピー元ファイル / フォルダの URL を保存する文字型データ項目（単数行）を準備

--- a/onedrive-file-copy.xml
+++ b/onedrive-file-copy.xml
@@ -12,7 +12,7 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/onedrive-file-copy/</help-page-url>
 
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
         </config>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。
 auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。