### PR TITLE
T9611: Twilio SendGrid: メール一斉送信　C7 の設定を C6-B の設定と同一タブにする

### DIFF
--- a/sendgrid-email-send-bulk.xml
+++ b/sendgrid-email-send-bulk.xml
@@ -82,12 +82,12 @@
             <label locale="ja">追加設定</label>
             <configs>
                 <config name="conf_SingleSendId" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-                    <label>C8: Data item to save ID of the email sending</label>
-                    <label locale="ja">C8: メール送信 ID を保存するデータ項目</label>
+                    <label>C7: Data item to save ID of the email sending</label>
+                    <label locale="ja">C7: メール送信 ID を保存するデータ項目</label>
                 </config>
                 <config name="conf_SingleSendUrl" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
-                    <label>C9: Data item to save URL of the email sending status page</label>
-                    <label locale="ja">C9: メール送信ステータス確認ページの URL を保存するデータ項目</label>
+                    <label>C8: Data item to save URL of the email sending status page</label>
+                    <label locale="ja">C8: メール送信ステータス確認ページの URL を保存するデータ項目</label>
                 </config>
             </configs>
         </tab>

--- a/sendgrid-email-send-bulk.xml
+++ b/sendgrid-email-send-bulk.xml
@@ -2,7 +2,7 @@
 <service-task-definition>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
-    <last-modified>2023-10-20</last-modified>
+    <last-modified>2023-12-14</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <label>Twilio SendGrid: Send Bulk Email</label>
     <label locale="ja">Twilio SendGrid: メール一斉送信</label>
@@ -71,16 +71,16 @@
                     <label>C6-B3: Plain Text Content (if blank, auto-generated from HTML)</label>
                     <label locale="ja">C6-B3: プレーンテキストメールの本文（指定しない場合、HTML メールの本文から自動生成されます）</label>
                 </config>
+                <config name="conf_Categories" depends-on="conf_HasUniqueContent" form-type="SELECT" select-data-type="STRING|SELECT">
+                    <label>C6-B4: Categories for filtering logs (write one per line)</label>
+                    <label locale="ja">C6-B4: メール送信ログ検索用カテゴリ（文字型データ項目の場合、1 行に 1 つ）</label>
+                </config>
             </configs>
         </tab>
         <tab>
             <label>Additional Settings</label>
             <label locale="ja">追加設定</label>
             <configs>
-                <config name="conf_Categories" depends-on="conf_HasUniqueContent" form-type="SELECT" select-data-type="STRING|SELECT">
-                    <label>C7: Categories for filtering logs (write one per line)</label>
-                    <label locale="ja">C7: メール送信ログ検索用カテゴリ（文字型データ項目の場合、1 行に 1 つ）</label>
-                </config>
                 <config name="conf_SingleSendId" form-type="SELECT" select-data-type="STRING_TEXTFIELD">
                     <label>C8: Data item to save ID of the email sending</label>
                     <label locale="ja">C8: メール送信 ID を保存するデータ項目</label>


### PR DESCRIPTION
* カテゴリを C6-B の設定と同一タブの末尾に移動させ、連番を C7 から C6-B4 に変更しました
* タブ名「メール本文」を変更するか迷いましたが、そのままにしました