### PR TITLE
t9445 Microsoft 365 OneDrive for Business: ファイル / フォルダ削除　engine-typeの変更、auth-type の設定

### DIFF
--- a/onedrive-file-delete.xml
+++ b/onedrive-file-delete.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Microsoft 365 OneDrive for Business: Delete File / Folder</label>
 <label locale="ja">Microsoft 365 OneDrive for Business: ファイル / フォルダ削除</label>
-<last-modified>2022-05-17</last-modified>
+<last-modified>2023-12-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
 <summary>This item deletes files and folders on OneDrive. It can delete multiple ones at once. It must contain one URL per line. </summary>
 <summary locale="ja">この工程は、OneDrive 上のファイル / フォルダを削除します。一度に複数の削除が可能です。1行につき1つのURLが含まれている必要があります。</summary>
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -32,7 +32,7 @@ const GRAPH_URI = "https://graph.microsoft.com/v1.0/";
 main();
 function main(){
   //// == 工程コンフィグの参照 / Config Retrieving ==
-  const oauth2 = configs.get("conf_OAuth2");
+  const oauth2 = configs.getObject("conf_OAuth2");
   const urlsDef = configs.getObject("conf_urls");
 
   //// == ワークフローデータの参照 / Data Retrieving ==
@@ -74,7 +74,7 @@ function checkHttpRequestingLimit( urlArray ) {
 /**
   * ドライブアイテム（ファイル/フォルダ）を削除する。
   * @param {Array<String>} urlArray  ドライブアイテムの URL の配列
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   */
 function deleteItems( urlArray, oauth2 ) {
   const itemNum = urlArray.length;
@@ -88,7 +88,7 @@ function deleteItems( urlArray, oauth2 ) {
   * ドライブアイテム（ファイル/フォルダ）の URL からアイテム情報（ドライブIDとアイテムID）を取得し、
   * オブジェクトで返す
   * @param {String} driveItemUrl  ドライブアイテムの URL
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} itemInfo  ドライブアイテム情報 {driveId, id}
   */
 function getItemInfoByUrl( driveItemUrl, oauth2 ) {
@@ -107,7 +107,7 @@ function getItemInfoByUrl( driveItemUrl, oauth2 ) {
   * OneDriveのドライブアイテム（ファイル/フォルダ）のメタデータを取得し、JSONオブジェクトを返す
   * APIの仕様：https://docs.microsoft.com/ja-jp/onedrive/developer/rest-api/api/shares_get?view=odsp-graph-online
   * @param {String} sharingUrl  ファイルの共有URL
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} responseObj  ドライブアイテムのメタデータのJSONオブジェクト
   */
 function getObjBySharingUrl( sharingUrl, oauth2 ) {
@@ -148,7 +148,7 @@ function encodeSharingUrl( sharingUrl ) {
 /**
   * ドライブアイテム（ファイル/フォルダ）を削除する。
   * @param {String,String} driveId,id  ドライブアイテムのドライブID、アイテムID
-  * @param {String} oauth2  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {String} driveItemUrl  ドライブアイテムの URL
   */
 function deleteItem( {
@@ -201,7 +201,16 @@ TkSuQmCC
  * @return folderUrlDef
  */
 const prepareConfigs = (urls) => {
-  configs.put('conf_OAuth2', 'Microsoft');
+  const oauth2 = httpClient.createAuthSettingOAuth2(
+    'OneDrive',
+    'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
+    'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+    'https://graph.microsoft.com/Files.ReadWrite.All offline_access',
+    'client_id',
+    'client_secret',
+    'access_token'
+  );
+  configs.putObject('conf_OAuth2', oauth2);
   
   // 削除するファイル / フォルダの URL が保存されている文字型データ項目（複数行）を準備
   const urlsDef = engine.createDataDefinition('削除するファイル / フォルダの URL', 1, 'q_urls', 'STRING_TEXTAREA');
@@ -223,7 +232,7 @@ test('urls is null.', () => {
  */
 test('urls is blank lines.', () => {
   prepareConfigs('\n\n\n');
-  
+
   expect(execute).toThrow('File / Folder URLs aren\'t set.');
 });
 
@@ -236,7 +245,7 @@ test('Number of urls is over the limit', () => {
     urls += `https://test-my.sharepoint.com/personal/staff_questetra365_onmicrosoft_com/Documents/f${i}\n`;
   }
   prepareConfigs(urls);
-  
+
   expect(execute).toThrow('Necessary HTTP requests exceeds the limit.');
 });
 
@@ -263,7 +272,7 @@ test('GET Failed', () => {
     assertGetRequest(request, 'https://test-my.sharepoint.com/personal/aaa/Documents/f1');
     return httpClient.createHttpResponse(400, 'application/json', '{}');
   });
-  
+
   expect(execute).toThrow('Failed to get drive item. status: 400');
 });
 
@@ -302,7 +311,7 @@ test('DELETE Failed', () => {
     assertDeleteRequest(request, 'Drive001', 'Id001');
     return httpClient.createHttpResponse(400, 'application/json', '{}');
   });
-  
+
   expect(execute).toThrow('Failed to delete. status: 400');
 });
 


### PR DESCRIPTION
@hatanaka-akihiro  さん

レビューをお願いします。

engine-type を 3 に変更しました。
auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。