### PR TITLE
t9446: Microsoft 365 OneDrive for Business: ファイルアップロード　engine-type の変更、auth-type の設定

### DIFF
--- a/onedrive-file-upload.xml
+++ b/onedrive-file-upload.xml
@@ -2,13 +2,13 @@
 <service-task-definition>
     <label>Microsoft 365 OneDrive for Business: Upload File</label>
     <label locale="ja">Microsoft 365 OneDrive for Business: ファイルアップロード</label>
-    <last-modified>2023-03-06</last-modified>
+    <last-modified>2023-12-18</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
     <summary>This item uploads files to the specified folder on OneDrive.</summary>
     <summary locale="ja">この工程は、OneDrive の指定フォルダにファイルをアップロードします。</summary>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -50,7 +50,7 @@ const GRAPH_URI = "https://graph.microsoft.com/v1.0/";
 main();
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const folderUrl = retrieveFolderUrl();
     const urlDataDef = configs.getObject("conf_fileUrl");
     const shouldReplace = configs.getObject("conf_shouldReplace");
@@ -158,7 +158,7 @@ function checkFileNameOverlap(files) {
   * フォルダのURLからフォルダ情報（ドライブIDとフォルダID）を取得し、
   * オブジェクトで返す（URLが空の場合はドライブIDをme/drive、フォルダIDをrootにする）
   * @param {String} folderUrl  フォルダのURL
-  * @param {String} oauth2  OAuth2 設定情報
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} folderInfo  フォルダ情報 {driveId, folderId}
   */
 function getFolderInfoByUrl(folderUrl, oauth2) {
@@ -180,7 +180,7 @@ function getFolderInfoByUrl(folderUrl, oauth2) {
   * OneDriveのドライブアイテム（ファイル、フォルダ）のメタデータを取得し、JSONオブジェクトを返す
   * APIの仕様: https://docs.microsoft.com/ja-jp/onedrive/developer/rest-api/api/shares_get?view=odsp-graph-online
   * @param {String} sharingUrl  ファイルの共有URL
-  * @param {String} oauth2  OAuth2 設定情報
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} responseObj  ドライブアイテムのメタデータのJSONオブジェクト
   */
 function getObjBySharingUrl(sharingUrl, oauth2) {
@@ -220,7 +220,7 @@ function encodeSharingUrl(sharingUrl) {
 
 /**
   * ファイルをアップロードする。一回につき一つのみ。
-  * @param {String} oauth2  OAuth2 設定情報
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {File} file  アップロードするファイル
   * @param {String,String} driveId,folderId  アップロード先ドライブ、フォルダのID
   * @param {boolean} shouldReplace  上書きするかどうか
@@ -254,7 +254,7 @@ function upload(oauth2, file, {
 
 /**
   * 4MBを超えるファイルのアップロード処理を行う
-  * @param {String} oauth2  OAuth2 設定情報
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {File} file  アップロードするファイル
   * @param {String,String} driveId,folderId  アップロード先ドライブ、フォルダのID
   * @param {boolean} shouldReplace  上書きするかどうか
@@ -279,7 +279,7 @@ function processLargeFile(oauth2, file, {
 
 /**
   * アップロード用のセッションを作成する
-  * @param {String} oauth2  OAuth2 設定情報
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {String} fileName  アップロードするファイルのファイル名
   * @param {String,String} driveId,folderId  アップロード先ドライブ、フォルダのID
   * @param {boolean} shouldReplace  上書きするかどうか
@@ -405,7 +405,16 @@ const PACKET_SIZE_LIMIT = 10485760;
  * @return fileUrlDef
  */
 const prepareConfigs = (files, folderUrl, shouldReplace) => {
-    configs.put('conf_OAuth2', 'OneDrive');
+    const oauth2 = httpClient.createAuthSettingOAuth2(
+        'OneDrive',
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+        'https://graph.microsoft.com/Files.ReadWrite.All offline_access',
+        'client_id',
+        'client_secret',
+        'access_token'
+    );
+    configs.putObject('conf_OAuth2', oauth2);
 
     const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
     configs.putObject('conf_uploadedFile', fileDef);


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。
engine-type を 3 に変更しました。
auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。