### PR TITLE
t9447: Microsoft 365 OneDrive for Business: フォルダ作成　engine-type の変更、auth-type の設定

### DIFF
--- a/onedrive-folder-create.xml
+++ b/onedrive-folder-create.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Microsoft 365 OneDrive for Business: Create Folder</label>
 <label locale="ja">Microsoft 365 OneDrive for Business: フォルダ作成</label>
-<last-modified>2022-05-10</last-modified>
+<last-modified>2023-12-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
 <summary>This item creates a folder in the specified folder on OneDrive.</summary>
 <summary locale="ja">この工程は、OneDrive の指定フォルダ内にフォルダを作成します。</summary>
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://graph.microsoft.com/Files.ReadWrite.All">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -41,7 +41,7 @@ const GRAPH_URI = "https://graph.microsoft.com/v1.0/";
 main();
 function main(){
   //// == 工程コンフィグの参照 / Config Retrieving ==
-  const oauth2 = configs.get("conf_OAuth2");
+  const oauth2 = configs.getObject("conf_OAuth2");
   const parentFolderUrl = retrieveParentFolderUrl();
   const folderName = retrieveFolderName();
   const urlDataDef = configs.getObject("conf_folderUrl");
@@ -79,7 +79,7 @@ function retrieveFolderName() {
   * フォルダのURLからフォルダ情報（ドライブIDとフォルダID）を取得し、
   * オブジェクトで返す（URLが空の場合はドライブIDをme/drive、フォルダIDをrootにする）
   * @param {String} folderUrl  フォルダのURL
-  * @param {String} oauth2  OAuth2 設定名
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} folderInfo  フォルダ情報 {driveId, folderId}
   */
 function getFolderInfoByUrl( folderUrl, oauth2 ) {
@@ -101,7 +101,7 @@ function getFolderInfoByUrl( folderUrl, oauth2 ) {
   * OneDriveのドライブアイテム（ファイル、フォルダ）のメタデータを取得し、JSONオブジェクトを返す
   * APIの仕様：https://docs.microsoft.com/ja-jp/onedrive/developer/rest-api/api/shares_get?view=odsp-graph-online
   * @param {String} sharingUrl  ファイルの共有URL
-  * @param {String} oauth2  OAuth2 設定名
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {Object} responseObj  ドライブアイテムのメタデータのJSONオブジェクト
   */
 function getObjBySharingUrl( sharingUrl, oauth2 ) {
@@ -142,7 +142,7 @@ function encodeSharingUrl( sharingUrl ) {
   * フォルダを作成する
   * @param {String,String} driveId,folderId  親フォルダのドライブID、フォルダID
   * @param {String} folderName  作成するフォルダの名前
-  * @param {String} oauth2  OAuth2 設定名
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @return {String}  作成したフォルダの URL
   */
 function createFolder( {
@@ -213,7 +213,16 @@ TkSuQmCC
  * @return folderUrlDef
  */
 const prepareConfigs = (parentFolderUrl, folderName) => {
-  configs.put('conf_OAuth2', 'Microsoft');
+  const oauth2 = httpClient.createAuthSettingOAuth2(
+    'OneDrive',
+    'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
+    'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+    'https://graph.microsoft.com/Files.ReadWrite.All offline_access',
+    'client_id',
+    'client_secret',
+    'access_token'
+  );
+  configs.putObject('conf_OAuth2', oauth2);
   configs.put('conf_folderName', folderName);
   
   // 作成するフォルダの親フォルダの URL を保存する文字型データ項目（単数行）を準備


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。
engine-type を 3 に変更しました。
auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。