### PR TITLE
t9400 Box: ファイル共有リンク削除　engine-type の変更、auth-type の設定

### DIFF
--- a/box-file-link-delete.xml
+++ b/box-file-link-delete.xml
@@ -14,7 +14,7 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-box-file-link-delete/
     </help-page-url>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>

--- a/box-file-link-delete.xml
+++ b/box-file-link-delete.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2022-11-28</last-modified>
+    <last-modified>2023-12-29</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
     <label>Box: Delete Shared Link of File</label>
     <label locale="ja">Box: ファイル共有リンク削除</label>
     <summary>This item deletes a Shared Link URL of the specified file on Box. An error will occur if there is no shared
@@ -26,9 +27,8 @@
     </configs>
 
     <script><![CDATA[
-main();
 function main() {
-  const oauth2 = configs.get("conf_OAuth2");
+  const oauth2 = configs.getObject("conf_OAuth2");
   const fileId = decideFileId();
   checkExistingSharedLink(oauth2, fileId);
   deleteSharedLink(oauth2, fileId);
@@ -54,7 +54,7 @@ function decideFileId() {
 
 /**
  * ファイルに共有リンクが作成されているか調べ、無い場合はエラーにする
- * @param {String} oauth OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} fileId ファイルの ID
  */
 function checkExistingSharedLink(oauth2, fileId) {
@@ -77,7 +77,7 @@ function checkExistingSharedLink(oauth2, fileId) {
 
 /**
  * Delete Shared Link to File on Box 共有リンク削除
- * @param {String} oauth2 OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} fileId 共有リンクを削除したいファイルのID
  */
 function deleteSharedLink(oauth2, fileId) {
@@ -171,7 +171,17 @@ const NO_SHARED_LINK = {
  * @return {Object}
  */
 const prepareConfigs = (fileId) => {
-  configs.put("conf_OAuth2", "Box");
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Box',
+    'https://account.box.com/api/oauth2/authorize',
+    'https://api.box.com/oauth2/token',
+    'root_readwrite',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_OAuth2', auth);
   const fileIdDef = engine.createDataDefinition(
     "ファイル ID",
     3,
@@ -216,6 +226,20 @@ const assertPutRequest = ({ url, method, contentType, body }, fileId) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  try {
+    func();
+    fail();
+  } catch (e) {
+    expect(e.toString()).toEqual(errorMsg);
+  }
+};
+
+/**
  * 正常系 / 文字型データ項目で指定されたファイル ID
  */
 test("Success / fileId specified by String Data", () => {
@@ -240,7 +264,8 @@ test("Success / fileId specified by String Data", () => {
     );
   });
 
-  execute();
+  //execute();
+  main();
 
   expect(engine.findData(fileIdDef)).toEqual("12345");
 });
@@ -249,7 +274,16 @@ test("Success / fileId specified by String Data", () => {
  * 正常系 / 固定値で指定されたファイル ID
  */
 test("Success / fileID specified with fixed value", () => {
-  configs.put("conf_OAuth2", "Box");
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Box',
+    'https://account.box.com/api/oauth2/authorize',
+    'https://api.box.com/oauth2/token',
+    'root_readwrite',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+  configs.putObject('conf_OAuth2', auth);
   configs.put("conf_FileId", "98765");
 
   let reqCount = 0;
@@ -271,7 +305,8 @@ test("Success / fileID specified with fixed value", () => {
     );
   });
 
-  execute();
+  //execute();
+  main();
 });
 
 /**
@@ -279,7 +314,8 @@ test("Success / fileID specified with fixed value", () => {
  */
 test("FileID is null", () => {
   prepareConfigs(null);
-  expect(execute).toThrow("File ID is blank");
+  //expect(execute).toThrow("File / Folder URLs aren\'t set.");
+  assertError(main, 'File ID is blank');
 });
 
 /**
@@ -293,7 +329,8 @@ test("GET Failed", () => {
     return httpClient.createHttpResponse(400, "application/json", "{}");
   });
 
-  expect(execute).toThrow("Failed to get file information. status:400");
+  //expect(execute).toThrow("Failed to get file information. status:400");
+  assertError(main, 'Failed to get file information. status:400');
 });
 
 /**
@@ -311,7 +348,8 @@ test("No shared link", () => {
     );
   });
 
-  expect(execute).toThrow("Failed to Delete Shared Link. \n The file(ID:12345) doesn't have a Shared link.");
+  //expect(execute).toThrow("Failed to Delete Shared Link. \n The file(ID:12345) doesn't have a Shared link.");
+  assertError(main, 'Failed to Delete Shared Link. \n The file(ID:12345) doesn\'t have a Shared link.');
 });
 
 /**
@@ -335,7 +373,8 @@ test("PUT Failed", () => {
     return httpClient.createHttpResponse(400, "application/json", "{}");
   });
 
-  expect(execute).toThrow("Failed to delete. status:400");
+  //expect(execute).toThrow("Failed to delete. status:400");
+  assertError(main, 'Failed to delete. status:400');
 });
 ]]></test>
 


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。