### PR TITLE
t9408 Box: フォルダ共有リンク作成　engine-type の変更、auth-type の設定

### DIFF
--- a/box-folder-link-create.xml
+++ b/box-folder-link-create.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-10-13</last-modified>
+<last-modified>2024-01-12</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Box: Create Shared Link to Folder</label>
 <label locale="ja">Box: フォルダ共有リンク作成</label>
 <summary>This item creates a URL to access the specified folder on Box. If no expiration date is specified, the URL will be created indefinitely. 
@@ -11,7 +12,7 @@
 <help-page-url>https://support.questetra.com/bpmn-icons/box-folder-link-create</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/box-folder-link-create</help-page-url>
 <configs>
-  <config name="OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
+  <config name="OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -38,7 +39,6 @@
 </configs>
 
 <script><![CDATA[
-main();
 function main(){
   const folderId = retrieveFolderId();
   const dateItem = configs.get("unsharedAt");
@@ -55,7 +55,7 @@ function main(){
   }
 
   // get OAuth2 Setting
-  const oauth2 = configs.get("OAuth2");
+  const oauth2 = configs.getObject("OAuth2");
 
   // フォルダが既に共有リンク作成されているか調べる
   const existingUrl = getFolderInformation(oauth2, folderId);
@@ -188,7 +188,17 @@ YII=</icon>
  * }}
  */
 const prepareConfigs = (configs,folderId, unsharedDate, password) => {
-  configs.put("OAuth2", "Box");
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Box',
+    'https://account.box.com/api/oauth2/authorize',
+    'https://api.box.com/oauth2/token',
+    'root_readwrite',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('OAuth2', auth);
 
   // 文字型データ項目を準備して、config に指定
   const folderIdDef = engine.createDataDefinition(
@@ -300,11 +310,25 @@ const assertPutRequest = (
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  try {
+    func();
+    fail();
+  } catch (e) {
+    expect(e.toString()).toEqual(errorMsg);
+  }
+};
+
+/**
  * folderId が空の場合
  */
 test("folder ID is blank", () => {
   prepareConfigs(configs, null, "2021-04-15 10:00:00", "word2");
-  expect(execute).toThrow("Folder ID is blank");
+  assertError(main, 'Folder ID is blank');
 });
 
 /**
@@ -319,7 +343,7 @@ test("GET Failed", () => {
     return httpClient.createHttpResponse(400, "application/json", "{}");
   });
 
-  expect(execute).toThrow("Failed to get folder information");
+  assertError(main, 'Failed to get folder information');
 });
 
 /**
@@ -367,7 +391,7 @@ test("Shared link was already created.", () => {
     }
   });
 
-  expect(execute).toThrow("Shared link(https://www.box.com/s/vspke7y05sb214wjokpk) was already created.");
+  assertError(main, 'Shared link(https://www.box.com/s/vspke7y05sb214wjokpk) was already created.');
 });
 
 /**
@@ -404,7 +428,7 @@ test("PUT Failed", () => {
 
   engine.setTimeZoneOffsetInMinutes(0); // テストスクリプトではタイムゾーンの値をコントロール可能。timezone = 'GMT'に設定する
 
-  expect(execute).toThrow("Failed to create Shared Link");
+  assertError(main, 'Failed to create Shared Link');
 });
 
 /**
@@ -479,7 +503,7 @@ test("200 Success", () => {
   engine.setTimeZoneOffsetInMinutes(540); // テストスクリプトではタイムゾーンの値をコントロール可能 timezone = 'GMT+09:00' に設定する
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 文字型データ項目の値をチェック
   expect(engine.findData(unsharedDateDef).toString()).toEqual(
@@ -559,7 +583,7 @@ test("200 Success - Folder ID set as fixed value, no unsharedDate and no passwor
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 文字型データ項目の値をチェック
   expect(engine.findData(unsharedDateDef)).toEqual(null);
@@ -634,7 +658,7 @@ test("200 Success - Folder ID set by deprecated config, neither unsharedDate nor
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 文字型データ項目の値をチェック
   expect(engine.findData(urlDef)).toEqual(


### PR DESCRIPTION
@hatanaka-akihiro  さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。

