### PR TITLE
t9403 Box: ファイルを PDF/テキスト/画像でダウンロード　engine-type の変更、auth-type の設定

### DIFF
--- a/box-file-representation-download.xml
+++ b/box-file-representation-download.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2023-02-27</last-modified>
+    <last-modified>2024-01-16</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
     <addon-version>2</addon-version>
     <label>Box: Download File as PDF/Text/Image</label>
     <label locale="ja">Box: ファイルを PDF/テキスト/画像でダウンロード</label>
@@ -14,7 +14,7 @@
         https://support.questetra.com/ja/bpmn-icons/service-task-box-file-representation-download/
     </help-page-url>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -72,7 +72,7 @@
 const PATH_VARIABLE = "{+asset_path}";
 
 function main() {
-    const oauth2 = configs.get('conf_OAuth2');
+    const oauth2 = configs.getObject("conf_OAuth2");
     const fileId = decideFileId();
     const representation = configs.get('conf_Representation');
     const fileName = configs.get('conf_FileName');
@@ -95,7 +95,7 @@ function main() {
 }
 
 function proceed() {
-    const oauth2 = configs.get('conf_OAuth2');
+    const oauth2 = configs.getObject("conf_OAuth2");
     const representation = configs.get('conf_Representation');
     const fileName = configs.get('conf_FileName');
     const fileDef = configs.getObject("conf_Files");
@@ -113,7 +113,7 @@ function proceed() {
 /**
  * レプリゼンテーションをダウンロードし、ファイル型データ項目に保存。
  * レプリゼンテーション作成中の場合は、false を返す
- * @param oauth2
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param url
  * @param representation
  * @param fileName
@@ -149,7 +149,7 @@ function decideFileId() {
 
 /**
  * レプリゼンテーションの情報を取得する GET リクエストを送信
- * @param {String} oauth2 OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} fileId ファイル ID
  * @param {String} representation レプリゼンテーション
  * @return {Object} representationInfo
@@ -181,7 +181,7 @@ function getRepresentationInfo(oauth2, fileId, representation) {
 /**
  * レプリゼンテーションをダウンロードする GET リクエストを送信
  * ページ割されていない場合
- * @param {String} oauth2 OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} url URL
  * @param {String} representation レプリゼンテーション
  * @param {String} fileName ファイル名
@@ -215,7 +215,7 @@ function download(oauth2, url, representation, fileName) {
 /**
  * レプリゼンテーションをダウンロードする GET リクエストを送信
  * ページ割されている場合
- * @param {String} oauth2 OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} urlTemplate URL テンプレート
  * @param {String} representation レプリゼンテーション
  * @param {String} fileName ファイル名
@@ -325,7 +325,17 @@ function saveFiles(fileDef, qfiles) {
  * @return {fileDef}
  */
 const prepareConfigs = (fileId, representation, fileName, files) => {
-    configs.put('conf_OAuth2', 'Box');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Box',
+        'https://account.box.com/api/oauth2/authorize',
+        'https://api.box.com/oauth2/token',
+        'root_readwrite',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
 
     // ファイル ID を保存した文字型データ項目（単一行）を準備し、設定
     const fileIdDef = engine.createDataDefinition('ファイル ID', 1, 'q_FileId', 'STRING_TEXTFIELD');


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper? を利用するように修正しました。
engine-type を 3 に変更しました。
