### PR TITLE
t9404 Box: ファイルアップロード　engine-type の変更、auth-type の設定

### DIFF
--- a/box-file-upload.xml
+++ b/box-file-upload.xml
@@ -2,13 +2,14 @@
 <service-task-definition>
     <label>Box: Upload File</label>
     <label locale="ja">Box: ファイルアップロード</label>
-    <last-modified>2022-11-21</last-modified>
+    <last-modified>2024-01-19</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
     <summary>This item uploads files to the specified folder on Box.</summary>
     <summary locale="ja">この工程は、Box の指定フォルダにファイルをアップロードします。</summary>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -45,11 +46,9 @@
 const SIZE_LIMIT = 52428800; //File size border of Box
 //50MB
 
-main();
-
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const idDataDef = configs.getObject("fileId");
     const urlDataDef = configs.getObject("fileUrl");
     //// == ワークフローデータの参照 / Data Retrieving ==
@@ -156,7 +155,7 @@ function checkFileNameOverlap(files) {
  * 通信数が制限を超えたらエラーを出す
  * 通信数=50MB以下のファイルの数 + <50MBを超えるファイルそれぞれについて>(ceil(ファイルサイズ/パケットサイズ) + 2)
  * パケットサイズはセッション作成時に指定される
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {Array<File>} files  アップロードしようとするファイルの配列
  * @param {String} folderId  アップロード先フォルダのID
  * @return {Array<Object>} アップロードセッションの配列(50MB以下のファイルについては空オブジェクト)
@@ -183,7 +182,7 @@ function prepareSessionsAndCheckRequestNumber(oauth2, files, folderId) {
 /**
  * 各ファイルのアップロード処理を行う
  * ファイルのサイズごとに工程は異なる
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {Array<File>} files  アップロードしようとするファイルの配列
  * @param {String} folderId  アップロード先のフォルダのパス
  * @param {Array<Array<String>>} uploadedFileData  アップロードしたファイルの情報を格納する二次元配列
@@ -204,7 +203,7 @@ function uploadAllFiles(oauth2, files, folderId, uploadedFileData, session) {
 
 /**
  * 50MB以下のファイルをアップロードする。一回につき一つのみ。
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {File} file  アップロードするファイル
  * @param {String} folderId  アップロード先フォルダのID
  * @param {Array<Array<String>>} uploadedFileData  アップロードしたファイルの情報を格納する二次元配列
@@ -235,7 +234,7 @@ function upload(oauth2, file, folderId, uploadedFileData) {
 
 /**
  * 50MBを超えるファイルのアップロード処理を行う
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {File} file  アップロードするファイル
  * @param {String} folderId  アップロード先のフォルダのパス
  * @param {Array<Array<String>>} uploadedFileData  アップロードしたファイルの情報を格納する二次元配列
@@ -258,7 +257,7 @@ function processLargeFile(oauth2, file, folderId, uploadedFileData, session) {
 
 /**
  * アップロード用のセッションを作成する
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {File} file  アップロードするファイル
  * @param {String} folderId  アップロード先のフォルダのID
  * @return {JSON Object}  アップロードセッション
@@ -287,7 +286,7 @@ function createSession(oauth2, file, folderId) {
 
 /**
  * 50MBを超えるファイルについて、各部分のアップロードを実行する
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} sessionId  アップロードセッションの ID
  * @param {Number} range  range
  * @param {ByteArrayWrapper} packet  アップロードするバイナリ
@@ -320,7 +319,7 @@ function uploadLargeFile(oauth2, sessionId, range, packet, fileSize, uploadedFil
 
 /**
  * 50MBを超えるファイルについて、アップロードをコミットする
- * @param {String} oauth2  OAuth2 設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} sessionId  アップロードセッションの ID
  * @param {Object} partObj  これまでのアップロートパートをまとめたオブジェクト
  * @param {File} file  アップロードするファイル
@@ -405,7 +404,17 @@ function setData(dataDef, uploadedFileData) {
  * }}
  */
 const prepareConfigs = (configs, files, folderId) => {
-    configs.put('conf_OAuth2', 'Box');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Box',
+        'https://account.box.com/api/oauth2/authorize',
+        'https://api.box.com/oauth2/token',
+        'root_readwrite',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
 
     const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
     configs.putObject('uploadedFile', fileDef);
@@ -451,13 +460,27 @@ const createQfile = (name, size) => {
     return engine.createQfile(name, 'text/plain; charset=US-ASCII', text);
 };
 
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    try {
+        func();
+        fail();
+    } catch (e) {
+        expect(e.toString()).toEqual(errorMsg);
+    }
+};
+
 test('File is null', () => {
     const {
         idDef,
         urlDef
     } = prepareConfigs(configs, null, '');
 
-    execute();
+    main();
 
     expect(engine.findData(idDef)).toEqual('');
     expect(engine.findData(urlDef)).toEqual('');
@@ -471,7 +494,7 @@ test('File Count > requestingLimit', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Number of requests is over the limit');
+    assertError(main, 'Number of requests is over the limit');
 });
 
 test('File Name contains /', () => {
@@ -481,7 +504,7 @@ test('File Name contains /', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Name contains \\', () => {
@@ -491,7 +514,7 @@ test('File Name contains \\', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Name starts with space', () => {
@@ -501,7 +524,7 @@ test('File Name starts with space', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Name ends with space', () => {
@@ -511,7 +534,7 @@ test('File Name ends with space', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Name is .', () => {
@@ -521,7 +544,7 @@ test('File Name is .', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Name is ..', () => {
@@ -531,7 +554,7 @@ test('File Name is ..', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Invalid File Name');
+    assertError(main, 'Invalid File Name');
 });
 
 test('File Names are duplicated', () => {
@@ -541,7 +564,7 @@ test('File Names are duplicated', () => {
 
     prepareConfigs(configs, files, '');
 
-    expect(execute).toThrow('Two or more files to upload have the same name.');
+    assertError(main, 'Two or more files to upload have the same name.');
 });
 
 test('Fail to multipart upload', () => {
@@ -557,7 +580,7 @@ test('Fail to multipart upload', () => {
         return httpClient.createHttpResponse(409, 'application/json', JSON.stringify({}));
     });
 
-    expect(execute).toThrow('failed to upload\nstatus: 409\nfile: fail.txt');
+    assertError(main, 'failed to upload\nstatus: 409\nfile: fail.txt');
 });
 
 test('Failed to create upload session', () => {
@@ -573,7 +596,7 @@ test('Failed to create upload session', () => {
         return httpClient.createHttpResponse(403, 'application/json', JSON.stringify({}));
     });
 
-    expect(execute).toThrow('failed to create upload session \nstatus: 403\nfile: large.txt');
+    assertError(main, 'failed to create upload session \nstatus: 403\nfile: large.txt');
 });
 
 test('Failed to partial upload', () => {
@@ -606,7 +629,7 @@ test('Failed to partial upload', () => {
         }
     });
 
-    expect(execute).toThrow('failed to upload\nstatus: 412\nfile: large.txt');
+    assertError(main, 'failed to upload\nstatus: 412\nfile: large.txt');
 });
 
 test('Failed to commit upload session', () => {
@@ -648,7 +671,7 @@ test('Failed to commit upload session', () => {
         }
     });
 
-    expect(execute).toThrow('failed to commit upload session \nstatus: 416\nfile: 大きい.txt');
+    assertError(main, 'failed to commit upload session \nstatus: 416\nfile: 大きい.txt');
 });
 
 test('File Count > 1 and FileId is TextField', () => {
@@ -662,7 +685,7 @@ test('File Count > 1 and FileId is TextField', () => {
     const idDef = engine.createDataDefinition('ファイルID', 2, 'q_ids', 'STRING_TEXTFIELD');
     configs.putObject('fileId', idDef);
 
-    expect(execute).toThrow('Multiple files are set though the Data Item to save the output is Single-line String.');
+    assertError(main, 'Multiple files are set though the Data Item to save the output is Single-line String.');
 });
 
 test('File Count > 1 and FileUrl is TextField', () => {
@@ -676,7 +699,7 @@ test('File Count > 1 and FileUrl is TextField', () => {
     const urlDef = engine.createDataDefinition('ファイルURL', 3, 'q_urls', 'STRING_TEXTFIELD');
     configs.putObject('fileUrl', urlDef);
 
-    expect(execute).toThrow('Multiple files are set though the Data Item to save the output is Single-line String.');
+    assertError(main, 'Multiple files are set though the Data Item to save the output is Single-line String.');
 });
 
 test('File Count = 1 and FileId FileUrl is TextField', () => {
@@ -716,7 +739,7 @@ test('File Count = 1 and FileId FileUrl is TextField', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    execute();
+    main();
 
     expect(engine.findData(idDef)).toEqual('1234');
     expect(engine.findData(urlDef)).toEqual('https://app.box.com/file/1234');
@@ -744,7 +767,7 @@ test('Failed to Upload too Large File', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    expect(execute).toThrow('Number of requests is over the limit');
+    assertError(main, 'Number of requests is over the limit');
 });
 
 test('Failed to Upload Large File and Small File', () => {
@@ -769,7 +792,7 @@ test('Failed to Upload Large File and Small File', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    expect(execute).toThrow('Number of requests is over the limit');
+    assertError(main, 'Number of requests is over the limit');
 });
 
 test('Succeed to Upload Large File', () => {
@@ -830,7 +853,7 @@ test('Succeed to Upload Large File', () => {
         }
     });
 
-    execute();
+    main();
 
     expect(engine.findData(idDef)).toEqual('98765');
     expect(engine.findData(urlDef)).toEqual('https://app.box.com/file/98765');
@@ -920,7 +943,7 @@ test('Succeed to Upload multiple size files', () => {
         }
     });
 
-    execute();
+    main();
 
     expect(engine.findData(idDef)).toEqual('10\n20\n30\n40');
     expect(engine.findData(urlDef)).toEqual('https://app.box.com/file/10\nhttps://app.box.com/file/20\nhttps://app.box.com/file/30\nhttps://app.box.com/file/40');


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。