### PR TITLE
response が複数のパートに分かれている場合の、結合方法を変更。

### DIFF
--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -209,7 +209,9 @@ const invokeModel = (auth, region, projectId, model, maxTokens, message) => {
     }
     engine.log(respTxt);
     const json = JSON.parse(respTxt);
-    return json.map(({candidates}) => candidates[0].content.parts[0].text).join('\n');
+    return json
+        .map(({candidates}) => candidates[0].content.parts[0].text)
+        .join('');
 };
 
 /**
@@ -529,16 +531,16 @@ const assertRequest = ({
 
 /**
  * API のレスポンスボディを作成
- * @param {String} answerText
+ * @param {String} answers
  * @returns {String} response
  */
-const createResponse = (answerText) => {
-    const responseObj = [{
+const createResponse = (...answers) => {
+    const responseObj = answers.map(answer => ({
         "candidates": [{
             "content": {
                 "parts": [
                     {
-                        "text": answerText
+                        "text": answer
                     }
                 ]
             },
@@ -548,7 +550,7 @@ const createResponse = (answerText) => {
                 "citations": []
             }
         }]
-    }];
+    }));
     return JSON.stringify(responseObj);
 };
 
@@ -596,7 +598,6 @@ test('Success - with default max tokens', () => {
     const answerDef = prepareConfigs(privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, message);
 
     const token = 'token-12345';
-    const answer = 'Fine, thanks.';
     let reqCount = 0;
     httpClient.setRequestHandler((request) => {
         if (reqCount++ === 0) {
@@ -606,11 +607,11 @@ test('Success - with default max tokens', () => {
             }));
         }
         assertRequest(request, token, region, projectId, model, 2048, message);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse(answer));
+        return httpClient.createHttpResponse(200, 'application/json', createResponse('Fine, thanks. ', 'How about you?'));
     });
 
     expect(main()).toEqual(undefined);
-    expect(engine.findData(answerDef)).toEqual(answer);
+    expect(engine.findData(answerDef)).toEqual('Fine, thanks. How about you?');
 });
 
 /**
@@ -629,7 +630,6 @@ test('Success - with max tokens', () => {
     const answerDef = prepareConfigs(privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, message);
 
     const token = 'token-67890';
-    const answer = 'こんにちは。元気ですか？';
     let reqCount = 0;
     httpClient.setRequestHandler((request) => {
         if (reqCount++ === 0) {
@@ -639,11 +639,11 @@ test('Success - with max tokens', () => {
             }));
         }
         assertRequest(request, token, region, projectId, model, -1, message);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse(answer));
+        return httpClient.createHttpResponse(200, 'application/json', createResponse('こんにちは。元気ですか？'));
     });
 
     expect(main()).toEqual(undefined);
-    expect(engine.findData(answerDef)).toEqual(answer);
+    expect(engine.findData(answerDef)).toEqual('こんにちは。元気ですか？');
 });
 ]]></test>
 </service-task-definition>


### PR DESCRIPTION
また単体テストのテストケースに、response が複数のパートに分かれているケースを追加。