### PR TITLE
t9405 Box: ファイルに電子すかし適用　engine-type の変更、auth-type の設定

### DIFF
--- a/box-file-watermark-apply.xml
+++ b/box-file-watermark-apply.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2022-05-06</last-modified>
+    <last-modified>2024-01-25</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
     <label>Box: Apply Watermark to File</label>
     <label locale="ja">Box: ファイルに電子すかし適用</label>
     <summary>This item applies watermark to the specified file on Box.</summary>
@@ -11,7 +12,7 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-box-file-watermark-apply/
     </help-page-url>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://app.box.com/api/oauth2/root_readwrite">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -24,9 +25,8 @@
 
     <script><![CDATA[
 
-main();
 function main(){
-    const oauth2 = configs.get('conf_OAuth2');
+    const oauth2 = configs.getObject("conf_OAuth2");
     const fileId = decideFileId();
     applyWatermark(oauth2, fileId);
 }
@@ -45,7 +45,7 @@ function decideFileId(){
 
 /**
   * 電子すかしを適用
-  * @param {String} oauth OAuth2 設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {String} fileId ファイル ID
   */
 function applyWatermark(oauth2, fileId) {
@@ -94,7 +94,17 @@ function applyWatermark(oauth2, fileId) {
  * @param fileId
  */
 const prepareConfigs = (fileId) => {
-    configs.put('conf_OAuth2', 'Box');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Box',
+        'https://account.box.com/api/oauth2/authorize',
+        'https://api.box.com/oauth2/token',
+        'root_readwrite',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
 
     // ファイル ID を保存した文字型データ項目（単一行）を準備し、設定
     const fileIdDef = engine.createDataDefinition('ファイル ID', 1, 'q_FileId', 'STRING_TEXTFIELD');
@@ -103,11 +113,25 @@ const prepareConfigs = (fileId) => {
 }
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    try {
+        func();
+        fail();
+    } catch (e) {
+        expect(e.toString()).toEqual(errorMsg);
+    }
+};
+
+/**
  * ファイル ID の値が空でエラー
  */
 test('File ID is blank', () => {
     prepareConfigs(null);
-    expect(execute).toThrow('File ID is blank.');
+    assertError(main, 'File ID is blank.');
 });
 
 /**
@@ -138,7 +162,7 @@ test('Fail in API Request', () => {
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
 
-    expect(execute).toThrow('Failed to apply watermark. status:400');
+    assertError(main, 'Failed to apply watermark. status:400');
 });
 
 /**
@@ -153,7 +177,7 @@ test('Succeed to apply watermark', () => {
         return httpClient.createHttpResponse(201, 'application/json', '{}');
     });
 
-    execute();
+    main();
 });
 
 /**
@@ -168,7 +192,7 @@ test('Succeed to update watermark', () => {
         return httpClient.createHttpResponse(200, 'application/json', '{}');
     });
 
-    execute();
+    main();
 });
 
     ]]></test>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。