### PR TITLE
t9689 Google スプレッドシート: シート追加　engine-type の変更、auth-type の設定

### DIFF
--- a/google-sheets-sheet-add.xml
+++ b/google-sheets-sheet-add.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2023-02-16</last-modified>
+<last-modified>2024-02-01</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Google Sheets: Add New Sheet</label>
 <label locale="ja">Google スプレッドシート: シート追加</label>
 <summary>This item adds a new sheet to a Google Sheet.</summary>
@@ -11,7 +12,7 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-sheets-sheet-add/</help-page-url>
 
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -38,10 +39,9 @@
 // Consumer Key: (Get by Google Developers Console)
 // Consumer Secret: (Get by Google Developers Console)
 
-main();
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const spreadSheetId = retrieveSpreadSheetId();
     const sheetTitle = configs.get("conf_SheetTitle");
     const addedSheetTitleDef = configs.getObject("conf_AddedSheetTitle");
@@ -73,7 +73,7 @@ function retrieveSpreadSheetId() {
 
 /**
  * Google スプレッドシートに新しいシートを追加
- * @param {String} oauth2 OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} spreadSheetId スプレッドシートの ID
  * @param {String} sheetTitle シートのタイトル
  * @return {String} addedSheetTitle 追加したシートのタイトル
@@ -144,7 +144,18 @@ AEwJzTC2ALrNAAAAAElFTkSuQmCC
  * @return addedSheetTitleDef
  */
 const prepareConfigs = (spreadSheetId, sheetTitle) => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
+	
     configs.put('conf_SheetTitle', sheetTitle);
 
     // スプレッドシートの ID を設定した文字型データ項目（単一行）を準備
@@ -161,13 +172,27 @@ const prepareConfigs = (spreadSheetId, sheetTitle) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    try {
+        func();
+        fail();
+    } catch (e) {
+        expect(e.toString()).toEqual(errorMsg);
+    }
+};
+
+/**
  * conf_SheetId でデータ項目を選択し、値が空でエラーになる場合
  */
 test('Spreadsheet ID is blank', () => {
     prepareConfigs('', '新しいシート');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Target Spreadsheet ID isn\'t set.');
+    assertError(main, 'Target Spreadsheet ID isn\'t set.');
   });
 
 /**
@@ -233,7 +258,7 @@ test('Success - with New Sheet Title', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // 文字型データ項目の値をチェック
     expect(engine.findData(addedSheetTitleDef)).toEqual('新しいシート / 1');
@@ -251,7 +276,7 @@ test('Success - without New Sheet Title', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // 文字型データ項目の値をチェック
     expect(engine.findData(addedSheetTitleDef)).toEqual('シート2');
@@ -261,7 +286,17 @@ test('Success - without New Sheet Title', () => {
  * シート追加成功の場合 - スプレッドシートの ID を固定値で指定
  */
 test('Success - Set the Spreadsheet ID as a fixed value', () => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('conf_SheetId', 'abc123');
     configs.put('conf_SheetTitle', '新しいシート');
 
@@ -276,7 +311,7 @@ test('Success - Set the Spreadsheet ID as a fixed value', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // 文字型データ項目の値をチェック
     expect(engine.findData(addedSheetTitleDef)).toEqual('新しいシート');
@@ -286,7 +321,17 @@ test('Success - Set the Spreadsheet ID as a fixed value', () => {
  * シート追加成功の場合 - 追加したシートのタイトルを保存しない
  */
 test('Success - Added Sheet Title not saved', () => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('conf_SheetId', 'abc123');
     configs.put('conf_SheetTitle', '新しいシート');
 
@@ -296,7 +341,7 @@ test('Success - Added Sheet Title not saved', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 });
 
 /**
@@ -311,8 +356,9 @@ test('POST Failed', () => {
     });
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Failed to add a new sheet. status: 400');
+    assertError(main, 'Failed to add a new sheet. status: 400');
 });
+
 
 ]]></test>
 


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。
auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。
