### PR TITLE
t9691 Google スプレッドシート: シート削除　engine-type の変更、auth-type の設定

### DIFF
--- a/google-sheets-sheet-delete.xml
+++ b/google-sheets-sheet-delete.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2023-02-16</last-modified>
+<last-modified>2024-02-02</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Google Sheets: Delete Sheet</label>
 <label locale="ja">Google スプレッドシート: シート削除</label>
 <summary>This item deletes a single sheet in a Google Sheet. When the Google Sheet has only one sheet, it cannot be deleted.</summary>
@@ -11,7 +12,7 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-sheets-sheet-delete/</help-page-url>
 
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -33,10 +34,9 @@
 // Consumer Key: (Get by Google Developers Console)
 // Consumer Secret: (Get by Google Developers Console)
 
-main();
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
-    const oauth2 = configs.get("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2");
     const spreadSheetId = retrieveSpreadSheetId();
     const sheetTitle = configs.get("conf_SheetTitle");
     if (sheetTitle === "" || sheetTitle === null) {
@@ -71,7 +71,7 @@ function retrieveSpreadSheetId() {
 
 /**
  * Google スプレッドシートのシート ID を取得
- * @param {String} oauth2 OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} spreadSheetId スプレッドシートの ID
  * @param {String} sheetTitle シートタイトル
  * @return {Number} sheetId シート ID
@@ -100,7 +100,7 @@ function getSheetId(oauth2, spreadSheetId, sheetTitle) {
 
 /**
  * Google スプレッドシートのシートを削除
- * @param {String} oauth2 OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} spreadSheetId スプレッドシートの ID
  * @param {String} sheetId シートの ID
  */
@@ -170,7 +170,17 @@ AEwJzTC2ALrNAAAAAElFTkSuQmCC
  * @param sheetTitle
  */
 const prepareConfigs = (spreadSheetId, sheetTitle) => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('conf_SheetTitle', sheetTitle);
 
     // 文字型データ項目（単一行）を準備
@@ -181,13 +191,27 @@ const prepareConfigs = (spreadSheetId, sheetTitle) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    try {
+        func();
+        fail();
+    } catch (e) {
+        expect(e.toString()).toEqual(errorMsg);
+    }
+};
+
+/**
  * conf_SheetTitle が、空でエラーになる場合
  */
 test('Sheet Title is blank', () => {
     prepareConfigs('abc123', '');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Sheet Title is empty.');
+    assertError(main, 'Sheet Title is empty.');
 });
 
 /**
@@ -197,7 +221,7 @@ test('Spreadsheet ID is blank', () => {
     prepareConfigs('', 'シート1');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Spreadsheet ID is empty.');
+    assertError(main, 'Spreadsheet ID is empty.');
 });
 
 const SAMPLE_GET = {
@@ -289,7 +313,7 @@ test('Success - 1st sheet', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(SAMPLE_POST));
     });
 
-    execute();
+    main();
 });
 
 /**
@@ -309,14 +333,24 @@ test('Success - 2nd sheet', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(SAMPLE_POST));
     });
 
-    execute();
+    main();
 });
 
 /**
  * シート削除成功の場合 - スプレッドシートの ID を固定値で指定
  */
 test('Success - Set the Spreadsheet ID as a fixed value', () => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('conf_SpreadSheetId', 'abc123');
     configs.put('conf_SheetTitle', 'シート1');
 
@@ -331,7 +365,7 @@ test('Success - Set the Spreadsheet ID as a fixed value', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(SAMPLE_POST));
     });
 
-    execute();
+    main();
 });
 
 /**
@@ -346,7 +380,7 @@ test('GET Failed', () => {
     });
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Failed to get sheet information. status: 400');
+    assertError(main, 'Failed to get sheet information. status: 400');
 });
 
 /**
@@ -386,7 +420,7 @@ test('POST Failed', () => {
     });
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Failed to delete sheet. status: 400');
+    assertError(main, 'Failed to delete sheet. status: 400');
 });
 
 /**
@@ -420,7 +454,7 @@ test('Sheet Title dose not exist', () => {
     });
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Sheet シート3 does not exist');
+    assertError(main, 'Sheet シート3 does not exist');
 });
 
 ]]></test>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。