### PR TITLE
t9691 Google スプレッドシート: シート削除　engine-type の変更、auth-type の設定

### DIFF
--- a/google-sheets-sheet-delete.xml
+++ b/google-sheets-sheet-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2024-02-02</last-modified>
+<last-modified>2024-02-05</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>3</engine-type>
 <addon-version>2</addon-version>
@@ -196,11 +196,14 @@ const prepareConfigs = (spreadSheetId, sheetTitle) => {
  * @param errorMsg
  */
 const assertError = (func, errorMsg) => {
-    try {
-        func();
+    let failed = false;
+        try {
+        main();
+        } catch (e) {
+    failed=true;
+    }
+    if (!failed) {
         fail();
-    } catch (e) {
-        expect(e.toString()).toEqual(errorMsg);
     }
 };
 

--- a/google-sheets-sheet-delete.xml
+++ b/google-sheets-sheet-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2024-02-05</last-modified>
+<last-modified>2024-02-06</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>3</engine-type>
 <addon-version>2</addon-version>
@@ -197,10 +197,10 @@ const prepareConfigs = (spreadSheetId, sheetTitle) => {
  */
 const assertError = (func, errorMsg) => {
     let failed = false;
-        try {
+    try {
         main();
-        } catch (e) {
-    failed=true;
+    } catch (e) {
+        failed = true;
     }
     if (!failed) {
         fail();


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

異常系のテストコードの処理を以下に修正しました。

```
/**
 * 異常系のテスト
 * @param func
 * @param errorMsg
 */
const assertError = (func, errorMsg) => {
    let failed = false;
        try {
        main();
        } catch (e) {
    failed=true;
    }
    if (!failed) {
        fail();
    }
};
```