### PR TITLE
t9688&9732 Google スプレッドシート: 行更新　engine-type の変更、auth-type の設定 値の解釈方法を選択できるように

### DIFF
--- a/google-sheets-row-update.xml
+++ b/google-sheets-row-update.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2023-02-16</last-modified>
+<last-modified>2024-02-08</last-modified>
 <license>(C) Questetra, In. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Google Sheets: Update Row </label>
 <label locale="ja">Google スプレッドシート: 行更新</label>
 <summary>This item updates data in a specified row of a Google Sheet.</summary>
@@ -11,7 +12,7 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-sheets-row-update/</help-page-url>
 
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -23,53 +24,66 @@
     <label>C3: Target Sheet Title</label>
     <label locale="ja">C3: 入力先のシートタイトル</label>
   </config>
-  <config name="conf_RowNo" required="true" form-type="SELECT"  select-data-type="STRING_TEXTFIELD">
-    <label>C4: Row to Update (e.g. "1", "11")</label>
-    <label locale="ja">C4: 更新する行 (例 "1", "11")</label>
+  <config name="conf_ValueInputOption" required="false" form-type="SELECT_ITEM">
+    <label>C4: How values should be interpreted when updating row</label>
+    <label locale="ja">C4: 行更新時の値の解釈方法</label>
+      <item value="RAW">
+        <label>as RAW values (default)</label>
+        <label locale="ja">RAW 方式（デフォルト）</label>
+      </item>
+      <item value="USER_ENTERED">
+        <label>as USER_ENTERED values</label>
+        <label locale="ja">USER_ENTERED 方式</label>
+      </item>
   </config>
+  <config name="conf_RowNo" required="true" form-type="SELECT"  select-data-type="STRING_TEXTFIELD">
+    <label>C5: Row to Update (e.g. "1", "11")</label>
+    <label locale="ja">C5: 更新する行 (例 "1", "11")</label>
+  </config>
+
   <config name="conf_Range" required="true" form-type="TEXTFIELD">
-    <label>C5: Column Range to Update (e.g. "A:J")(Up to 10 columns)</label>
-    <label locale="ja">C5: 更新する列範囲 (例 "A:J","K:L") (最大 10 列)</label>
+    <label>C6: Column Range to Update (e.g. "A:J")(Up to 10 columns)</label>
+    <label locale="ja">C6: 更新する列範囲 (例 "A:J","K:L") (最大 10 列)</label>
   </config>
   <config name="conf_Column1" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_1: Value that is updated in the 1st column </label>
-    <label locale="ja">C6_1: 列範囲のうち 1 列目の更新後の値</label>
+    <label>C7_1: Value that is updated in the 1st column </label>
+    <label locale="ja">C7_1: 列範囲のうち 1 列目の更新後の値</label>
   </config>
   <config name="conf_Column2" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_2: Value that is updated in the 2nd column</label>
-    <label locale="ja">C6_1: 列範囲のうち 2 列目の更新後の値</label>
+    <label>C7_2: Value that is updated in the 2nd column</label>
+    <label locale="ja">C7_2: 列範囲のうち 2 列目の更新後の値</label>
   </config>
   <config name="conf_Column3" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_3: Value that is updated in the 3rd column </label>
-    <label locale="ja">C6_3: 列範囲のうち 3 列目の更新後の値</label>
+    <label>C7_3: Value that is updated in the 3rd column </label>
+    <label locale="ja">C7_3: 列範囲のうち 3 列目の更新後の値</label>
   </config>
   <config name="conf_Column4" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_4: Value that is updated in the 4th column </label>
-    <label locale="ja">C6_4: 列範囲のうち 4 列目の更新後の値</label>
+    <label>C7_4: Value that is updated in the 4th column </label>
+    <label locale="ja">C7_4: 列範囲のうち 4 列目の更新後の値</label>
   </config>
   <config name="conf_Column5" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_5: Value that is updated in the 5th column </label>
-    <label locale="ja">C6_5: 列範囲のうち 5 列目の更新後の値</label>
+    <label>C7_5: Value that is updated in the 5th column </label>
+    <label locale="ja">C7_5: 列範囲のうち 5 列目の更新後の値</label>
   </config>
   <config name="conf_Column6" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_6: Value that is updated in the 6th column </label>
-    <label locale="ja">C6_6: 列範囲のうち 6 列目の更新後の値</label>
+    <label>C7_6: Value that is updated in the 6th column </label>
+    <label locale="ja">C7_6: 列範囲のうち 6 列目の更新後の値</label>
   </config>
   <config name="conf_Column7" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_7: Value that is updated in the 7th column </label>
-    <label locale="ja">C6_7: 列範囲のうち 7 列目の更新後の値</label>
+    <label>C7_7: Value that is updated in the 7th column </label>
+    <label locale="ja">C7_7: 列範囲のうち 7 列目の更新後の値</label>
   </config>
   <config name="conf_Column8" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_8: Value that is updated in the 8th column </label>
-    <label locale="ja">C6_8: 列範囲のうち 8 列目の更新後の値</label>
+    <label>C7_8: Value that is updated in the 8th column </label>
+    <label locale="ja">C7_8: 列範囲のうち 8 列目の更新後の値</label>
   </config>
   <config name="conf_Column9" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_9: Value that is updated in the 9th column </label>
-    <label locale="ja">C6_9: 列範囲のうち 9 列目の更新後の値</label>
+    <label>C7_9: Value that is updated in the 9th column </label>
+    <label locale="ja">C7_9: 列範囲のうち 9 列目の更新後の値</label>
   </config>
   <config name="conf_Column10" required="false" form-type="TEXTAREA" el-enabled="true">
-    <label>C6_10: Value that is updated in the 10 column </label>
-    <label locale="ja">C6_10: 列範囲のうち 10 列目の更新後の値</label>
+    <label>C7_10: Value that is updated in the 10 column </label>
+    <label locale="ja">C7_10: 列範囲のうち 10 列目の更新後の値</label>
   </config>
 </configs>
 
@@ -84,11 +98,10 @@
 
 const COLUMN_MAX_NUM = 10;
 
-main();
 function main(){
 
   //// == 工程コンフィグの参照 / Config Retrieving ==
-  const oauth = configs.get( "conf_OAuth2" );
+  const oauth = configs.getObject("conf_OAuth2");
   const sheetId = retrieveStringData( "conf_SheetId", "Target Spreadsheet ID" );
   const sheetTitle = retrieveStringData( "conf_SheetTitle", "Target Sheet Title" );
   const rowNo = retrieveRowNo();
@@ -96,9 +109,14 @@ function main(){
   checkRowNoAndRange( rowNo, range );
   const rangeArr = range.split(':');
   const dataArray = retrieveRowValues(rangeArr);
+
+  let valueInputOption = configs.get('conf_ValueInputOption');
+  if (valueInputOption === '') {
+    valueInputOption = 'RAW';
+  }
   
   //// == 演算 / Calculating ==
-  updateRowData( oauth, sheetId, sheetTitle, rowNo, rangeArr, dataArray  );
+  updateRowData( oauth, sheetId, sheetTitle, valueInputOption, rowNo, rangeArr, dataArray  );
 
 }
 
@@ -200,14 +218,14 @@ function isValidRange( rangeString ) {
 
 /**
  * Google スプレッドシートの行データを更新
- * @param {String} oauth OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth  OAuth2 認証設定
  * @param {String} sheetId スプレッドシートの ID
  * @param {String} sheetTitle シート名
  * @param {String} rowNo 更新する行
  * @param {Array<String>} rangeArr 更新する列範囲の最初の列と最終の列が格納された配列
  * @param {Array<String>} dataArray 更新後の値の配列
  */
-function updateRowData( oauth, sheetId, sheetTitle, rowNo, rangeArr, dataArray  ) {
+function updateRowData( oauth, sheetId, sheetTitle, valueInputOption, rowNo, rangeArr, dataArray  ) {
 
   const enSheetId = encodeURIComponent(sheetId);
   const enSheetTitle = encodeURIComponent(sheetTitle);
@@ -218,7 +236,7 @@ function updateRowData( oauth, sheetId, sheetTitle, rowNo, rangeArr, dataArray  
   const uri = `https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}`;
   const response = httpClient.begin()
     .authSetting( oauth )
-    .queryParam( "valueInputOption", "RAW" )
+    .queryParam( "valueInputOption",  valueInputOption )
     .body( JSON.stringify( requestObj ), "application/json" )
     .put( uri );
   const status = response.getStatusCode();
@@ -231,7 +249,7 @@ function updateRowData( oauth, sheetId, sheetTitle, rowNo, rangeArr, dataArray  
 }
 
 
-  /**
+/**
   * configから更新情報を読み出し、JSON オブジェクトを返す
   * @param {Array<String>} dataArray 更新後の値の配列
   * @return {Object} requestObj  JSON オブジェクト
@@ -291,7 +309,17 @@ AEwJzTC2ALrNAAAAAElFTkSuQmCC
  * @param rowData
  */
 const prepareConfigs = (spreadSheetId, sheetTitle, rowNo, range, rowData) => {
-  configs.put('conf_OAuth2', 'Google');
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Google',
+    'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+    'https://accounts.google.com/o/oauth2/token',
+    'spreadsheets',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_OAuth2', auth);
 
   // スプレッドシートの ID を設定した文字型データ項目（単一行）を準備し、設定
   const spreadSheetIdDef = engine.createDataDefinition('スプレッドシートの ID', 1, 'q_SpreadSheetId', 'STRING_TEXTFIELD');
@@ -302,6 +330,8 @@ const prepareConfigs = (spreadSheetId, sheetTitle, rowNo, range, rowData) => {
   const sheetTitleDef = engine.createDataDefinition('シートのタイトル', 2, 'q_SheetTitle', 'STRING_TEXTFIELD');
   engine.setData(sheetTitleDef, sheetTitle);
   configs.putObject('conf_SheetTitle', sheetTitleDef);
+
+  configs.put('conf_ValueInputOption', ''); // テスト時に値が null にならないように空文字を設定
 
   // 更新する行の行番号を設定した文字型データ項目（単一行）を準備し、設定
   const rowNoDef = engine.createDataDefinition('更新する行の行番号', 3, 'q_RowNo', 'STRING_TEXTFIELD');
@@ -322,13 +352,30 @@ const SAMPLE_ROW = ['1列目の値', '2列目の値', '3列目の値', '4列目�
 const SAMPLE_ROW_BLANK = new Array(10).fill(''); // 全ての要素が空文字列
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
+
+/**
  * スプレッドシートの ID をデータ項目で指定し、値が空でエラーになる場合
  */
 test('Target Spreadsheet ID is empty', () => {
   prepareConfigs(null, 'シート1', '1', 'A:J', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Target Spreadsheet ID is empty.');
+  assertError(main, 'Target Spreadsheet ID is empty.');
 });
 
 /**
@@ -338,7 +385,7 @@ test('Target Sheet Title is empty', () => {
   prepareConfigs('abc123', null, '1', 'A:J', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Target Sheet Title is empty.');
+  assertError(main, 'Target Sheet Title is empty.');
 
 });
 
@@ -349,7 +396,7 @@ test('Row number is empty', () => {
   prepareConfigs('abc123', 'シート1', null, 'A:J', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Row number is empty.');
+  assertError(main, 'Row number is empty.');
 });
 
 /**
@@ -359,7 +406,7 @@ test('Invalid Row number', () => {
   prepareConfigs('abc123', 'シート1', '0', 'A:J', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Row number.');
+  assertError(main, 'Invalid Row number.');
 });
 
 /**
@@ -369,7 +416,7 @@ test('Invalid Range - Invalid Format', () => {
   prepareConfigs('abc123', 'シート1', '1', 'A', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Range.');
+  assertError(main, 'Invalid Range.');
 });
 
 /**
@@ -379,7 +426,7 @@ test('Invalid Range - Invalid Order', () => {
   prepareConfigs('abc123', 'シート1', '1', 'AA:A', SAMPLE_ROW);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Range.');
+  assertError(main, 'Invalid Range.');
 });
 
 /**
@@ -393,7 +440,7 @@ test('Over 50,000 characters', () => {
   prepareConfigs('abc123', 'シート1', '1', 'A:J', rowData);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow("Can't set text over 50,000 characters.");
+  assertError(main, 'Can\'t set text over 50,000 characters.');
 });
 
 /**
@@ -408,12 +455,19 @@ test('Over 50,000 characters', () => {
  * @param rangeWithRowNo
  * @param values
  */
-const assertPutRequest = ({url, method, contentType, body}, spreadSheetId, sheetTitle, rangeWithRowNo, values) => {
+const assertPutRequest = ({url, method, contentType, body}, spreadSheetId, sheetTitle, rangeWithRowNo, values, valueInputOption) => {
+  if (valueInputOption === ''){
+    valueInputOption = 'RAW';
+  }
   expect(url).toEqual(`https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(
       spreadSheetId
     )}/values/${encodeURIComponent(
       sheetTitle
-    )}!${rangeWithRowNo}?valueInputOption=RAW`);
+    )}!${rangeWithRowNo}?valueInputOption=${valueInputOption}`);
+
+
+//const uri = `https://sheets.googleapis.com/v4/spreadsheets/${enSheetId}/values/${enSheetTitle}!${rangeArr[0]}${rowNo}:${rangeArr[1]}${rowNo}`;
+
   expect(method).toEqual('PUT');
   expect(contentType).toEqual('application/json');
   const bodyObj = JSON.parse(body);
@@ -425,104 +479,108 @@ const assertPutRequest = ({url, method, contentType, body}, spreadSheetId, sheet
 };
 
 /**
- * 行更新成功 - 10 列すべてを更新
+ * 行更新成功 - 10 列すべてを更新 valueInputOption 指定なし
  * スプレッドシートの ID とシートのタイトルはデータ項目で指定
  */
-test('Success - All columns updated', () => {
+test('Success - All columns updated, valueInputOption not specified', () => {
   prepareConfigs('abc123', 'シート1', '1', 'A:J', SAMPLE_ROW);
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, 'abc123', 'シート1', 'A1:J1', SAMPLE_ROW);
+    assertPutRequest(request, 'abc123', 'シート1', 'A1:J1', SAMPLE_ROW, '');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
- * 行更新成功 - 10 列すべてを空文字列で更新
+ * 行更新成功 - 10 列すべてを空文字列で更新 valueInputOption 指定なし
  * スプレッドシートの ID とシートのタイトルは固定値で指定
  */
-test('Success - All columns updated as blank', () => {
+test('Success - All columns updated as blank, valueInputOption not specified', () => {
   prepareConfigs(null, null, '100', 'K:T', SAMPLE_ROW_BLANK);
   configs.put('conf_SheetId', '456789vwxyz');
   configs.put('conf_SheetTitle', 'シート 1/2!');
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, '456789vwxyz', 'シート 1/2!', 'K100:T100', SAMPLE_ROW_BLANK);
+    assertPutRequest(request, '456789vwxyz', 'シート 1/2!', 'K100:T100', SAMPLE_ROW_BLANK, '');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
- * 行更新成功 - 列範囲を 11 列以上指定
+ * 行更新成功 - 列範囲を 11 列以上指定 valueInputOption に RAW を指定
  */
-test('Success - Range has more than 10 columns', () => {
+test('Success - Range has more than 10 columns, select RAW', () => {
   prepareConfigs('abc123', 'シート1', '2', 'B:AA', SAMPLE_ROW);
+  configs.put('conf_ValueInputOption', 'RAW');
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, 'abc123', 'シート1', 'B2:AA2', SAMPLE_ROW);
+    assertPutRequest(request, 'abc123', 'シート1', 'B2:AA2', SAMPLE_ROW, 'RAW');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
- * 行更新成功 - 列範囲を 1 列のみ指定
+ * 行更新成功 - 列範囲を 1 列のみ指定 valueInputOption に RAW を指定
  */
-test('Success - 1 column updated', () => {
+test('Success - 1 column updated, select RAW', () => {
   prepareConfigs('abc123', 'シート1', '3', 'AB:AB', SAMPLE_ROW);
+  configs.put('conf_ValueInputOption', 'RAW');
   const values = SAMPLE_ROW.slice(0, 1); // 送られるデータは 1 列分のみ
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, 'abc123', 'シート1', 'AB3:AB3', values);
+    assertPutRequest(request, 'abc123', 'シート1', 'AB3:AB3', values, 'RAW');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
- * 行更新成功 - 列範囲を 3 列のみ指定
+ * 行更新成功 - 列範囲を 3 列のみ指定 valueInputOption に USER_ENTERED を指定
  */
-test('Success - 3 columns updated', () => {
+test('Success - 3 columns updated, select USER_ENTERED', () => {
   prepareConfigs('abc123', 'シート1', '4', 'AA:AC', SAMPLE_ROW);
+  configs.put('conf_ValueInputOption', 'USER_ENTERED');
   const values = SAMPLE_ROW.slice(0, 3); // 送られるデータは 3 列分のみ
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, 'abc123', 'シート1', 'AA4:AC4', values);
+    assertPutRequest(request, 'abc123', 'シート1', 'AA4:AC4', values, 'USER_ENTERED');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
- * 行更新成功 - 値が設定されている列と設定されていない列が混在
+ * 行更新成功 - 値が設定されている列と設定されていない列が混在  valueInputOption に USER_ENTERED を指定
  * 50,000 文字までは設定できる
  */
-test('Success - Some columns are blank', () => {
+test('Success - Some columns are blank, select USER_ENTERED', () => {
   const rowData = ['', '2列目の値', '', '', '5列目の値', '', '', '8列目の値', '9列目の\n値', ''];
   // 3列目の値を 50,000 文字に
   rowData[2] = 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUV'
     .repeat(500);
   prepareConfigs('abc123', 'シート1', '1', 'A:J', rowData);
+  configs.put('conf_ValueInputOption', 'USER_ENTERED');
 
   httpClient.setRequestHandler((request) => {
-    assertPutRequest(request, 'abc123', 'シート1', 'A1:J1', rowData);
+    assertPutRequest(request, 'abc123', 'シート1', 'A1:J1', rowData, 'USER_ENTERED');
     return httpClient.createHttpResponse(200, 'application/json', `{}`);
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -536,7 +594,7 @@ test('Fail in PUT Request', () => {
     return httpClient.createHttpResponse(400, 'application/json', `{}`);
   });
 
-  expect(execute).toThrow('Failed to update. status:400');
+  assertError(main, 'Failed to update. status:400');
 });
 
 ]]></test>


### PR DESCRIPTION
@hatanaka-akihiro  さん

レビューをお願いします。
変更箇所を見ていただきたかったので、スペース 4 でフォーマットをかけていません。スペース 2 のままです。

コンフィグに、「C4: 行更新時の値の解釈方法」を追加し、値の解釈方法を選択できるように処理しました。

日本語のみ、「C6_1: 列範囲のうち 2 列目の更新後の値」の序数が「C6_1: 列範囲のうち 1 列目の更新後の値」と同じになっていたので修正しました。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
<addon-version>2</addon-version> を設定しました。
engine-type を 3 に変更しました。