### PR TITLE
t9681 Google ドライブ: フォルダ検索　engine-type の変更、auth-type の設定

### DIFF
--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2024-03-07</last-modified>
+<last-modified>2024-03-08</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>3</engine-type>
 <addon-version>2</addon-version>
@@ -291,7 +291,6 @@ const assertError = (func, errorMsg) => {
 test('Folder Name is blank.', () => {
     prepareConfigs(configs, '12345abcde', '');
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Folder Name is blank.');
     assertError(main, 'Folder Name is blank.');
 });
 
@@ -309,7 +308,6 @@ test('Neither of Data Items to save result are set.', () => {
     configs.put('WebViewUrlItem', '');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Neither of Data Items to save result are set.');
     assertError(main, 'Neither of Data Items to save result are set.');
 });
 
@@ -398,7 +396,6 @@ test('GET Get Parent folderId Failed', () => {
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Failed to get parent folder with parent folder ID:abcd12345678. status:400');
     assertError(main, 'Failed to get parent folder with parent folder ID:abcd12345678. status:400');
 });
 
@@ -420,7 +417,6 @@ test('GET Search Failed', () => {
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Failed to search. status:400');
     assertError(main, 'Failed to search. status:400');
 });
 
@@ -449,7 +445,6 @@ test('Success - Shared drive - UrlData Items to save result are not set', () => 
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('aaabbbccc111222333')));
     });
     // <script> のスクリプトを実行
-    //execute();
     main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_aaabbbccc111222333\nFolder2_aaabbbccc111222333\nFolder3_aaabbbccc111222333');
@@ -479,7 +474,6 @@ test('Success - My drive - Escape character', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('dddeeefff444555666')));
     });
     // <script> のスクリプトを実行
-    //execute();
     main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_dddeeefff444555666\nFolder2_dddeeefff444555666\nFolder3_dddeeefff444555666');
@@ -513,7 +507,6 @@ test('Success - Shared drive - IdData Items to save result are not set', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('ggghhhiii777888999')));
     });
     // <script> のスクリプトを実行
-    //execute();
     main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(urlDef)).toEqual('https://drive.google.com/drive/folders/Folder1_ggghhhiii777888999\nhttps://drive.google.com/drive/folders/Folder2_ggghhhiii777888999\nhttps://drive.google.com/drive/folders/Folder3_ggghhhiii777888999');
@@ -544,7 +537,6 @@ test('Could not find Folder', () => {
         return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
     assertError(main, 'Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
 });
 
@@ -568,7 +560,6 @@ test('Cannot set multiple Folders to single-line string Data Item', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('jjjkkklll000111222')));
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    //expect(execute).toThrow('Multiple folders are found. Can\'t set data to single-line string Data Item.');
     assertError(main, 'Multiple folders are found. Can\'t set data to single-line string Data Item.');
 });
 
@@ -604,7 +595,6 @@ test('Success -　Set a Folder to single-line string Data Item', () => {
         return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行
-    //execute();
     main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_mmmnnnooo333444555');

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-12-16</last-modified>
+<last-modified>2024-03-07</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Google Drive: Search Folder</label>
 <label locale="ja">Google ドライブ: フォルダ検索</label>
 <summary>This item searches for the folder with the specific name, directly under the specified folder on Google Drive.</summary>
@@ -10,7 +11,7 @@
 <help-page-url>https://support.questetra.com/bpmn-icons/googledrive-foldersearch/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/googledrive-foldersearch/</help-page-url>
 <configs>
-  <config name="OAuth" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/drive.metadata.readonly">
+  <config name="OAuth" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/drive.metadata.readonly">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2設定</label>
   </config>
@@ -33,7 +34,6 @@
 </configs>
 
 <script><![CDATA[
-main();
 function main() {
     //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     let parentFolderId = configs.get("ParentFolderId");
@@ -50,7 +50,7 @@ function main() {
     if (idDataDef === null && urlDataDef === null) {
         throw "Neither of Data Items to save result are set.";
     }
-    const oauth = configs.get("OAuth");
+    const oauth = configs.getObject("OAuth");
 
     //// == 演算 / Calculating ==
     const driveId = getDriveId(oauth, parentFolderId);
@@ -73,7 +73,7 @@ function main() {
 
 /**
  * 親フォルダのドライブ ID を取得する
- * @param {String} oauth OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth  OAuth2 認証設定
  * @param {String} parentFolderId 親フォルダの ID
  * @return {String} driveId ドライブ ID (共有ドライブになければ null)
  */
@@ -104,7 +104,7 @@ function getDriveId(oauth, parentFolderId) {
 
 /**
  * Google ドライブのフォルダを検索
- * @param {String} oauth OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth  OAuth2 認証設定
  * @param {String} driveId 親フォルダのドライブ ID (共有ドライブになければ null)
  * @param {String} parentFolderId 親フォルダの ID
  * @param {String} folderName 検索するフォルダの名前
@@ -190,8 +190,17 @@ rj0X+Cb77f9UbmpYjp7wCDoAlCC//xbZQazviFGHnPAIOoAYA6mlhqh+AbUsw2bOgDsAAHEO2FDM
  * }
  */
 const prepareConfigs = (configs, folderId, folderName) => {
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
 
-    configs.put('OAuth', 'Google');
+    configs.putObject('OAuth', auth);
     configs.put('ParentFolderId', folderId,);
     configs.put('FolderName', folderName);
 
@@ -225,8 +234,17 @@ const prepareConfigs = (configs, folderId, folderName) => {
  * }
  */
 const prepareSingleLineConfigs = (configs, folderId, folderName) => {
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
 
-    configs.put('OAuth', 'Google');
+    configs.putObject('OAuth', auth);
     configs.put('ParentFolderId', folderId,);
     configs.put('FolderName', folderName);
 
@@ -249,6 +267,23 @@ const prepareSingleLineConfigs = (configs, folderId, folderName) => {
 };
 
 
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    let failed = false;
+    try {
+        main();
+    } catch (e) {
+        failed = true;
+    }
+    if (!failed) {
+        fail();
+    }
+};
+
 
 /**
  * フォルダ名が空でエラーになる場合
@@ -256,7 +291,8 @@ const prepareSingleLineConfigs = (configs, folderId, folderName) => {
 test('Folder Name is blank.', () => {
     prepareConfigs(configs, '12345abcde', '');
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Folder Name is blank.');
+    //expect(execute).toThrow('Folder Name is blank.');
+    assertError(main, 'Folder Name is blank.');
 });
 
 
@@ -273,7 +309,8 @@ test('Neither of Data Items to save result are set.', () => {
     configs.put('WebViewUrlItem', '');
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Neither of Data Items to save result are set.');
+    //expect(execute).toThrow('Neither of Data Items to save result are set.');
+    assertError(main, 'Neither of Data Items to save result are set.');
 });
 
 
@@ -361,7 +398,8 @@ test('GET Get Parent folderId Failed', () => {
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Failed to get parent folder with parent folder ID:abcd12345678. status:400');
+    //expect(execute).toThrow('Failed to get parent folder with parent folder ID:abcd12345678. status:400');
+    assertError(main, 'Failed to get parent folder with parent folder ID:abcd12345678. status:400');
 });
 
 
@@ -382,7 +420,8 @@ test('GET Search Failed', () => {
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Failed to search. status:400');
+    //expect(execute).toThrow('Failed to search. status:400');
+    assertError(main, 'Failed to search. status:400');
 });
 
 
@@ -410,7 +449,8 @@ test('Success - Shared drive - UrlData Items to save result are not set', () => 
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('aaabbbccc111222333')));
     });
     // <script> のスクリプトを実行
-    execute();
+    //execute();
+    main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_aaabbbccc111222333\nFolder2_aaabbbccc111222333\nFolder3_aaabbbccc111222333');
 });
@@ -439,7 +479,8 @@ test('Success - My drive - Escape character', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('dddeeefff444555666')));
     });
     // <script> のスクリプトを実行
-    execute();
+    //execute();
+    main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_dddeeefff444555666\nFolder2_dddeeefff444555666\nFolder3_dddeeefff444555666');
 
@@ -472,7 +513,8 @@ test('Success - Shared drive - IdData Items to save result are not set', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('ggghhhiii777888999')));
     });
     // <script> のスクリプトを実行
-    execute();
+    //execute();
+    main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(urlDef)).toEqual('https://drive.google.com/drive/folders/Folder1_ggghhhiii777888999\nhttps://drive.google.com/drive/folders/Folder2_ggghhhiii777888999\nhttps://drive.google.com/drive/folders/Folder3_ggghhhiii777888999');
 });
@@ -502,7 +544,8 @@ test('Could not find Folder', () => {
         return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
+    //expect(execute).toThrow('Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
+    assertError(main, 'Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
 });
 
 
@@ -525,7 +568,8 @@ test('Cannot set multiple Folders to single-line string Data Item', () => {
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(prepareGetSerchDriveResponse('jjjkkklll000111222')));
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Multiple folders are found. Can\'t set data to single-line string Data Item.');
+    //expect(execute).toThrow('Multiple folders are found. Can\'t set data to single-line string Data Item.');
+    assertError(main, 'Multiple folders are found. Can\'t set data to single-line string Data Item.');
 });
 
 
@@ -560,7 +604,8 @@ test('Success -　Set a Folder to single-line string Data Item', () => {
         return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行
-    execute();
+    //execute();
+    main();
     // 文字型データ項目の値をチェック	  
     expect(engine.findData(idDef)).toEqual('Folder1_mmmnnnooo333444555');
     expect(engine.findData(urlDef)).toEqual('https://drive.google.com/drive/folders/Folder1_mmmnnnooo333444555');


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
addon-version 2 を設定しました。
engine-type を 3 に変更しました。
