### PR TITLE
T9804: Google Vertex AI Gemini: チャット　scope を HTTP 認証設定で行うように

### DIFF
--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Google Vertex AI: Gemini: Chat</label>
     <label locale="ja">Google Vertex AI: Gemini: チャット</label>
-    <last-modified>2024-03-14</last-modified>
+    <last-modified>2024-03-18</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to a Gemini model on Google Vertex AI
         and stores the response in the specified data item.</summary>
@@ -15,8 +15,8 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-vertexai-gemini-chat/</help-page-url>
     <configs>
         <config name="conf_Auth" required="true" form-type="OAUTH2" auth-type="OAUTH2_JWT_BEARER">
-            <label>C1: サービスアカウント設定</label>
-            <label locale="ja">C1: Service Account Setting</label>
+            <label>C1: Service Account Setting</label>
+            <label locale="ja">C1: サービスアカウント設定</label>
         </config>
         <config name="conf_Region" required="true" form-type="TEXTFIELD">
             <label>C2: Region Code</label>


### PR DESCRIPTION
C1 のラベルが日英逆だったのを修正しました。