### PR TITLE
t9675 Google BigQuery: データ追加　engine-type の変更、auth-type の設定、summary の変更

### DIFF
--- a/google-bigquery-data-insert.xml
+++ b/google-bigquery-data-insert.xml
@@ -2,13 +2,14 @@
 <service-task-definition>
     <label>Google BigQuery: Insert New Data</label>
     <label locale="ja">Google BigQuery: データ追加</label>
-    <last-modified>2022-04-06</last-modified>
+    <last-modified>2024-03-21</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
-    <summary>Insert a new data row to a table on BigQuery.</summary>
-    <summary locale="ja">BigQuery のテーブルにデータを１行追加します。</summary>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
+    <summary>This item inserts a new data row to a table on BigQuery.</summary>
+    <summary locale="ja">この工程は、BigQuery のテーブルにデータを１行追加します。</summary>
     <configs>
-        <config name="conf_auth" required="true" form-type="OAUTH2"
+        <config name="conf_auth" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://www.googleapis.com/auth/bigquery">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -101,10 +102,9 @@
 
 const FIELD_NUM = 7; // 扱えるフィールドの数
 
-main();
 function main(){
   //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
-  const oauth2 = configs.get("conf_auth");
+  const oauth2 = configs.getObject("conf_auth");
   const projectId = configs.get("conf_projectId");
   const datasetId = configs.get("conf_datasetId");
   const tableId = configs.get("conf_tableId");
@@ -193,7 +193,7 @@ function retrieveDataObj() {
 
 /**
   * データ追加の POST リクエストを送信する
-  * @param {String} oauth  OAuth2 認証設定
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {String} projectId  プロジェクト ID
   * @param {String} datasetId  データセット ID
   * @param {String} tableId  テーブル ID
@@ -268,7 +268,17 @@ const FIELD_SIZE = 7; // 扱えるフィールドの数
  * @return dataObj
  */
 const prepareConfigs = (projectId, datasetId, tableId, templateSuffix) => {
-  configs.put('conf_auth', 'Google');
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Google',
+    'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+    'https://accounts.google.com/o/oauth2/token',
+    'spreadsheets',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_auth', auth);
   configs.put('conf_projectId', projectId);
   configs.put('conf_datasetId', datasetId);
   configs.put('conf_tableId', tableId);
@@ -286,6 +296,23 @@ const prepareConfigs = (projectId, datasetId, tableId, templateSuffix) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed=true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
+
+/**
  * プロジェクト ID が不正な文字列でエラーになる場合
  * 最初の文字が数字
  */
@@ -293,7 +320,7 @@ test('Invalid Project ID - Starts with a number', () => {
   prepareConfigs('123456', 'Dataset_1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Project ID.');
+  assertError(main, 'Invalid Project ID.');
 });
 
 /**
@@ -304,7 +331,7 @@ test('Invalid Project ID - Ends with a hyphen', () => {
   prepareConfigs('project-', 'Dataset_1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Project ID.');
+  assertError(main, 'Invalid Project ID.');
 });
 
 /**
@@ -315,7 +342,7 @@ test('Invalid Project ID - Includes an invalid character', () => {
   prepareConfigs('project_1', 'Dataset_1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Project ID.');
+  assertError(main, 'Invalid Project ID.');
 });
 
 /**
@@ -326,7 +353,7 @@ test('Invalid Project ID - Too short', () => {
   prepareConfigs('p-123', 'Dataset_1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Project ID.');
+  assertError(main, 'Invalid Project ID.');
 });
 
 /**
@@ -337,7 +364,7 @@ test('Invalid Project ID - Too long', () => {
   prepareConfigs('p012345678901234567890123456789', 'Dataset_1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Project ID.');
+  assertError(main, 'Invalid Project ID.');
 });
 
 /**
@@ -348,7 +375,7 @@ test('Invalid Dataset ID - Includes an invalid character', () => {
   prepareConfigs('project-1', 'Dataset-1', 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Dataset ID.');
+  assertError(main, 'Invalid Dataset ID.');
 });
 
 /**
@@ -360,7 +387,7 @@ test('Invalid Dataset ID - Too long', () => {
   prepareConfigs('project-1', datasetId, 'テーブル 1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Dataset ID.');
+  assertError(main, 'Invalid Dataset ID.');
 });
 
 /**
@@ -371,7 +398,7 @@ test('Invalid Table ID - Includes an invalid character', () => {
   prepareConfigs('project-1', 'Dataset_1', 'テーブル(1)', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Table ID and/or Template Suffix. Includes an invalid character.');
+  assertError(main, 'Invalid Table ID and/or Template Suffix. Includes an invalid character.');
 });
 
 /**
@@ -387,7 +414,7 @@ test('Invalid Table ID - Too long', () => {
   prepareConfigs('project-1', 'Dataset_1', tableId, '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Table ID and/or Template Suffix. Too long.');
+  assertError(main, 'Invalid Table ID and/or Template Suffix. Too long.');
 });
 
 /**
@@ -398,7 +425,7 @@ test('Invalid Template Suffix - Includes an invalid character', () => {
   prepareConfigs('project-1', 'Dataset_1', 'テーブル 1', '>サフィックス');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Table ID and/or Template Suffix. Includes an invalid character.');
+  assertError(main, 'Invalid Table ID and/or Template Suffix. Includes an invalid character.');
 });
 
 /**
@@ -416,7 +443,7 @@ test('Invalid Template Suffix - Too long', () => {
   prepareConfigs('project-1', 'Dataset_1', tableId, templateSuffix);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Table ID and/or Template Suffix. Too long.');
+  assertError(main, 'Invalid Table ID and/or Template Suffix. Too long.');
 });
 
 /**
@@ -428,7 +455,7 @@ test('Invalid Field Name - Includes an invalid character', () => {
   configs.put('conf_field3', 'Field-3');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Field Name: Field-3.');
+  assertError(main, 'Invalid Field Name: Field-3.');
 });
 
 /**
@@ -440,7 +467,7 @@ test('Invalid Field Name - Starts with a number', () => {
   configs.put('conf_field1', '111111');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Field Name: 111111.');
+  assertError(main, 'Invalid Field Name: 111111.');
 });
 
 /**
@@ -452,7 +479,7 @@ test('Invalid Field Name - Invalid Prefix', () => {
   configs.put('conf_field4', '_FILE_4');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Invalid Field Name: _FILE_4.');
+  assertError(main, 'Invalid Field Name: _FILE_4.');
 });
 
 /**
@@ -465,7 +492,7 @@ test('Invalid Field Name - Too long', () => {
   configs.put('conf_field5', fieldName);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow(`Invalid Field Name: ${fieldName}.`);
+  assertError(main, `Invalid Field Name: ${fieldName}.`);
 });
 
 /**
@@ -476,7 +503,7 @@ test('The same field is set multiple times', () => {
   configs.put('conf_field2', 'Field_6');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('The same field Field_6 is set multiple times.');
+  assertError(main, 'The same field Field_6 is set multiple times.');
 });
 
 /**
@@ -520,7 +547,7 @@ test('POST Failed - Status code is greater than 300', () => {
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Failed to insert data. status: 400');
+  assertError(main, 'Failed to insert data. status: 400');
 });
 
 /**
@@ -548,7 +575,7 @@ test('POST Failed - Response has insert errors', () => {
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Failed to insert data.');
+  assertError(main, 'Failed to insert data.');
 });
 
 /**
@@ -564,7 +591,7 @@ test('Success - All fields are set', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -583,7 +610,7 @@ test('Success - No fields are set', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -603,7 +630,7 @@ test('Success - Some fields are empty', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -625,7 +652,7 @@ test('Success - Some values are empty', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -655,7 +682,7 @@ test('Success - Project ID, Dataset ID, Table ID, Field Name are at maximum leng
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -671,7 +698,7 @@ test('Success - Project ID is at minimum length', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -693,7 +720,7 @@ test('Success - With Template Suffix', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 ]]></test>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
addon-version を 2 に設定しました。
engine-type を 3 に変更しました。
summary を修正しました。（「この工程は、」「This item」を追加）