### PR TITLE
T9798: Google ドライブ: ファイルダウンロード　の作成

### DIFF
--- a/google-drive-file-download.xml
+++ b/google-drive-file-download.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Google Drive: Download File</label>
     <label locale="ja">Google ドライブ: ファイルダウンロード</label>
-    <last-modified>2024-03-29</last-modified>
+    <last-modified>2024-04-02</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>
         This item downloads the specified files on Google Drive. You can download multiple files at once.
@@ -18,8 +18,8 @@
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/service-task-google-drive-file-download/</help-page-url>
     <configs>
         <config name="conf_Auth" required="true" form-type="OAUTH2" auth-type="OAUTH2_JWT_BEARER">
-            <label>C1: サービスアカウント設定</label>
-            <label locale="ja">C1: Service Account Setting</label>
+            <label>C1: Service Account Setting</label>
+            <label locale="ja">C1: サービスアカウント設定</label>
         </config>
         <config name="conf_FileIds" required="true" form-type="SELECT" select-data-type="STRING_TEXTAREA" editable="true">
             <label>C2: File IDs to download (Write one per line)</label>


### PR DESCRIPTION
C1 の日本語と英語のラベルが入れ替わっていたため、修正しました。