### PR TITLE
T9810-T9812: OpenAI ChatGPT: チャット　改良

### DIFF
--- a/chatgpt-chat-completion.xml
+++ b/chatgpt-chat-completion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2024-04-04</last-modified>
+    <last-modified>2024-04-08</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -223,7 +223,6 @@ const createChat = (auth, organizationId, model, maxTokens, temperature, stopSeq
         n: 1,
         max_tokens: maxTokens,
         temperature,
-        stop: stopSequences,
         messages: []
     };
     if (gptRole !== '') {
@@ -231,6 +230,9 @@ const createChat = (auth, organizationId, model, maxTokens, temperature, stopSeq
             role: 'system',
             content: gptRole
         });
+    }
+    if (stopSequences.length > 0) { // モデルによっては、空配列をセットするとエラーになる
+        requestJson.stop = stopSequences;
     }
     const message1Content = [];
     message1Content.push({
@@ -512,7 +514,6 @@ const assertRequest = ({
     expect(bodyObj.n).toEqual(1);
     expect(bodyObj.max_tokens).toEqual(maxTokens);
     expect(bodyObj.temperature).toEqual(temperature);
-    expect(bodyObj.stop).toEqual(stopSequences);
     if (gptRole === '') {
         expect(bodyObj.messages.length).toEqual(1);
     } else {
@@ -521,6 +522,11 @@ const assertRequest = ({
             role: 'system',
             content: gptRole
         });
+    }
+    if (stopSequences.length === 0) {
+        expect(bodyObj.stop).toEqual(undefined);
+    } else {
+        expect(bodyObj.stop).toEqual(stopSequences);
     }
     const userMessage = bodyObj.messages[bodyObj.messages.length - 1];
     expect(userMessage.role).toEqual('user');


### PR DESCRIPTION
停止シーケンスを指定しない場合、パラメータ自体をセットしないように。
モデルによっては、空の配列を指定するとエラーになる場合があるため。