### PR TITLE
T9887 Google アイテム　engine-type の変更／廃止予定の authSetting(String) の使用をやめる

### DIFF
--- a/gmail-message-get.xml
+++ b/gmail-message-get.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Get Email Message</label>
 <label locale="ja">Gmail: メール取得</label>
-<last-modified>2022-11-04</last-modified>
+<last-modified>2024-04-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <summary>This item gets an email message in Gmail.</summary>
 <summary locale="ja">この工程は、Gmail のメールを取得します。</summary>
 <configs>
-  <config name="conf_auth" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/gmail.readonly">
+  <config name="conf_auth" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/gmail.readonly">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -60,10 +61,9 @@
 // - Consumer Key: (Get by Google Developer Console)
 // - Consumer Secret: (Get by Google Developer Console)
 
-main();
 function main(){
   //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
-  const auth = configs.get("conf_auth");
+  const auth = configs.getObject("conf_auth");
   const messageId = engine.findData( configs.getObject("conf_messageId") );
   const defs = retrieveDefs();
 
@@ -381,7 +381,7 @@ function getContentType( part ) {
   * ない場合は Gmail REST API に添付ファイル取得の GET リクエストを送信し、
   * 本体データを追加する
   * @param {String} apiUri  API の URI（/messages/{messageId} まで）
-  * @param {String} auth  認証設定名
+  * @param {AuthSettingWrapper} auth  OAuth2 認証設定
   * @param {Array<Object>} attachments  添付ファイルの情報（オブジェクト）が格納された配列
   *  配列内の添付ファイルの情報の形式は：
   *   {
@@ -472,7 +472,17 @@ S023j9MN1Lsm1b9qWLIw6P4tOAAAAABJRU5ErkJggg==
  * @return dataDefs
  */
 const prepareConfigs = (messageId) => {
-  configs.put('conf_auth', 'Google');
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Google',
+    'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+    'https://accounts.google.com/o/oauth2/token',
+    'gmail',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_auth', auth);
 
   // メール ID を設定
   const messageIdDef = engine.createDataDefinition('メール ID', 1, 'q_messageId', 'STRING_TEXTFIELD');
@@ -513,13 +523,30 @@ const prepareConfigs = (messageId) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
+
+/**
  * メール ID が空であればエラー
  */
 test('Message ID is empty', () => {
   prepareConfigs(null);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Message ID is empty.');
+  assertError(main, 'Message ID is empty.');
 });
 
 /**
@@ -534,7 +561,7 @@ test('Data items not set', () => {
   configs.putObject('conf_messageId', messageIdDef);
 
   // スクリプトを実行
-  execute();
+  main();
 });
 
 /**
@@ -546,7 +573,7 @@ test('The same data item is set multiple times - fromAddress and subject', () =>
   configs.putObject('conf_subject', dataDefs.fromAddress);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('The same data item is set multiple times.');
+  assertError(main, 'The same data item is set multiple times.');
 });
 
 /**
@@ -558,7 +585,7 @@ test('The same data item is set multiple times - recipientNames and body', () =>
   configs.putObject('conf_recipientNames', dataDefs.body);
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('The same data item is set multiple times.');
+  assertError(main, 'The same data item is set multiple times.');
 });
 
 /**
@@ -602,7 +629,7 @@ test('Fail in 1st GET Request', () => {
     return httpClient.createHttpResponse(400, 'application/json', `{}`);
   });
 
-  expect(execute).toThrow('Failed to get message. status: 400');
+  assertError(main, 'Failed to get message. status: 400');
 });
 
 /**
@@ -755,7 +782,7 @@ test('200 Success - Multipart message with one attachment', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   expect(engine.findData(dataDefs.fromAddress)).toEqual('From@example.com');
@@ -801,7 +828,7 @@ test('Fail in 2nd GET Request', () => {
     return httpClient.createHttpResponse(400, 'application/json', `{}`);
   });
 
-  expect(execute).toThrow('Failed to get attachment. status: 400');
+  assertError(main, 'Failed to get attachment. status: 400');
 });
 
 /**
@@ -969,7 +996,7 @@ test('200 Success - Multipart message with two attachments', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   expect(engine.findData(dataDefs.fromAddress)).toEqual('From2@example.com');
@@ -1071,7 +1098,7 @@ test('200 Success - Single-part message with text/plain body encoded in Shift_JI
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   expect(engine.findData(dataDefs.fromAddress)).toEqual('From@example.com');
@@ -1182,7 +1209,7 @@ test('200 Success - Single-part message with text/html body', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   expect(engine.findData(dataDefs.fromAddress)).toEqual('From@example.com');
@@ -1257,7 +1284,7 @@ test('200 Success - Single-part message with no Content-Type/To/Cc/Bcc/Subject h
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   expect(engine.findData(dataDefs.fromAddress)).toEqual('From@example.com');
@@ -1326,7 +1353,7 @@ test('Number of HTTP requests is over the limit', () => {
     return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(SAMPLE_ATTACHMENT_1));
   });
 
-  expect(execute).toThrow('Number of HTTP requests is over the limit.');
+  assertError(main, 'Number of HTTP requests is over the limit.');
 });
 
 /**
@@ -1358,7 +1385,7 @@ test('200 Success - Number of HTTP requests is within the limit', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存されているファイルの個数をチェック。事前ファイルは削除されるので、合計 httpRequestLimit - 1 個のはず
   const files = engine.findData(dataDefs.attachments);
@@ -1391,7 +1418,7 @@ test('200 Success - Attachment has no name', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   const files = engine.findData(dataDefs.attachments);
@@ -1427,7 +1454,7 @@ test('200 Success - Attachment has no Content-Type', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   const files = engine.findData(dataDefs.attachments);
@@ -1464,7 +1491,7 @@ test('200 Success - Attachment has no Content-Disposition', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック
   const files = engine.findData(dataDefs.attachments);
@@ -1489,7 +1516,7 @@ test('200 Success - Attachments not saved', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // データ項目の値をチェック。事前ファイルは残ったまま
   const files = engine.findData(dataDefs.attachments);
@@ -1522,7 +1549,7 @@ test('200 Success - No files were pre-set', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック。ファイルが追加されている
   const files = engine.findData(fileDataDef);
@@ -1558,7 +1585,7 @@ test('200 Success - Some data items are not set', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 
   // 保存先データ項目の値をチェック。設定されたデータ項目にのみ値が保存される
   expect(engine.findData(dataDefs.fromAddress)).toEqual('事前文字列');

--- a/gmail-message-label-remove.xml
+++ b/gmail-message-label-remove.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?><service-task-definition>
 <label>Gmail: Remove Label from Email Message</label>
 <label locale="ja">Gmail: メールのラベルを解除</label>
-<last-modified>2022-04-25</last-modified>
+<last-modified>2024-04-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <summary>Remove labels from an email message in Gmail. You can remove multiple labels at once. When you remove multiple ones, you should write one label on each line.</summary>
 <summary locale="ja">Gmail のメールからラベルを外します。一度に複数のラベルの解除が可能です。複数解除する場合、データ項目では1行につき1つずつラベルを書くようにしてください。</summary>
 <configs>
-  <config name="conf_auth" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/gmail.modify">
+  <config name="conf_auth" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/gmail.modify">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -32,10 +33,9 @@
 // - Consumer Key: (Get by Google Developer Console)
 // - Consumer Secret: (Get by Google Developer Console)
 
-main();
 function main(){
   //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
-  const auth = configs.get("conf_auth");
+  const auth = configs.getObject("conf_auth");
   const messageId = engine.findData( configs.getObject("conf_messageId") );
   const labels = retrieveLabels();
 
@@ -162,7 +162,17 @@ S023j9MN1Lsm1b9qWLIw6P4tOAAAAABJRU5ErkJggg==
  * @param label
  */
 const prepareConfigs = (messageId, label) => {
-  configs.put('conf_auth', 'Google');
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Google',
+    'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+    'https://accounts.google.com/o/oauth2/token',
+    'gmail',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_auth', auth);
   
   // メール ID を保存する文字型データ項目（単数行）を準備
   const messageIdDef = engine.createDataDefinition('メール ID', 1, 'q_messageId', 'STRING_TEXTFIELD');
@@ -174,13 +184,30 @@ const prepareConfigs = (messageId, label) => {
 };
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
+
+/**
  * メール ID が空であればエラー
  */
 test('Message ID is empty', () => {
   prepareConfigs(null, 'ラベル1');
   
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('Message ID is empty.');
+  assertError(main, 'Message ID is empty.');
 });
 
 /**
@@ -190,7 +217,7 @@ test('No labels to remove are set - Label is line break only', () => {
   prepareConfigs('abc123', '\n');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow('No labels to remove are set.');
+  assertError(main, 'No labels to remove are set.');
 });
 
 /**
@@ -215,7 +242,7 @@ test('GET Failed', () => {
     return httpClient.createHttpResponse(400, 'application/json', '{}');
   });
   
-  expect(execute).toThrow('Failed to get labels. status: 400');
+  assertError(main, 'Failed to get labels. status: 400');
 
 });
 
@@ -246,7 +273,7 @@ test('label ids not found - Correct labels contain a line of strings that does n
     return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(SAMPLE_GET1));
   });
   
-  expect(execute).toThrow('label ids of ラベル3 not found');
+  assertError(main, 'label ids of ラベル3 not found');
 });
 
 /**
@@ -285,7 +312,7 @@ test('POST Failed', () => {
     return httpClient.createHttpResponse(400, 'application/json', '{}');
   });
   
-  expect(execute).toThrow('Failed to remove labels. status: 400');
+  assertError(main, 'Failed to remove labels. status: 400');
 });
 
 /**
@@ -306,7 +333,7 @@ test('200 Success - 1 label', () => {
     return httpClient.createHttpResponse(200, 'application/json', '{}');
   });
   
-  execute();
+  main();
 });
 
 const SAMPLE_GET2 = {
@@ -355,7 +382,7 @@ test('200 Success - 2 labels', () => {
     return httpClient.createHttpResponse(200, 'application/json', '{}');
   });
   
-  execute();
+  main();
 });
 
 /**
@@ -377,7 +404,7 @@ test('200 Success - 2 labels/Includes lines with only line breaks in the middle'
     return httpClient.createHttpResponse(200, 'application/json', '{}');
   });
   
-  execute();
+  main();
 });
 
 ]]></test>

--- a/google-sheets-choice-batchget.xml
+++ b/google-sheets-choice-batchget.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2023-03-16</last-modified>
+<last-modified>2024-04-16</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Google Sheets: Download Choice Data</label>
 <label locale="ja">Google スプレッドシート: 選択肢データの一括取得</label>
 <summary>This item downloads Choice Data in specified 2 columns from Google Sheet.</summary>
@@ -11,7 +12,7 @@
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/googlesheets-getidslabels/</help-page-url>
 
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets.readonly">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://www.googleapis.com/auth/spreadsheets.readonly">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -49,10 +50,9 @@
 // Scope: https://www.googleapis.com/auth/spreadsheets.readonly
 // Consumer Key: (Get by Google Developers Console)
 // Consumer Secret: (Get by Google Developers Console)
-main();
 function main() {
     //// == 工程コンフィグの参照 / Config Retrieving ==
-    const oauth = configs.get("conf_OAuth2");
+    const oauth = configs.getObject("conf_OAuth2");
     const docId = configs.get("conf_DataIdB");
     const sheet = configs.get("conf_DataIdC");
     const rangeI = configs.get("conf_DataIdD");
@@ -70,7 +70,7 @@ function main() {
 
 /**
  * Google スプレッドシートの選択肢データを取得
- * @param {String} oauth OAuth2 認証設定
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} docId スプレッドシートの ID
  * @param {String} sheet シート名
  * @param {String} rangeI 選択肢 ID の領域
@@ -197,7 +197,17 @@ AEwJzTC2ALrNAAAAAElFTkSuQmCC
  * }
  */
 const prepareConfigs = (configs, sheetId, sheetTitle, rangeI, rangeL) => {
-    configs.put('conf_OAuth2', 'Google');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'spreadsheets',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('conf_DataIdB', sheetId);
     configs.put('conf_DataIdC', sheetTitle);
     configs.put('conf_DataIdD', rangeI);
@@ -246,6 +256,22 @@ const assertGetRequest = ({ url, method, contentType, body }, sheetId, sheetTitl
     expect(method).toEqual('GET');
 };
 
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    let failed = false;
+    try {
+        main();
+    } catch (e) {
+        failed = true;
+    }
+    if (!failed) {
+        fail();
+    }
+};
 
 /**
  * GET API リクエストでエラーになる場合
@@ -260,7 +286,7 @@ test('GET Failed', () => {
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
 
-    expect(execute).toThrow('Failed to get. status:400');
+    assertError(main, 'Failed to get. status:400');
 });
 
 
@@ -314,7 +340,7 @@ test('Success', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // 文字型データ項目の値をチェック
     expect(engine.findData(idDataDef)).toEqual('1\n2\n3\n4\n5');
@@ -376,7 +402,7 @@ test('Success - without line range specified', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // 文字型データ項目の値をチェック
     expect(engine.findData(idDataDef)).toEqual('1\n2\n3\n4\n5\n6\n7');
@@ -429,7 +455,7 @@ test('error for different number of cells', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Number of cells in two ranges is different.');
+    assertError(main, 'Number of cells in two ranges is different.');
 });
 
 
@@ -472,7 +498,7 @@ test('error for over 150,000 of Choice Data ', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Number of Choice Data is over 150,000.');
+    assertError(main, 'Number of Choice Data is over 150,000.');
 });
 
 
@@ -523,7 +549,7 @@ test('error for same ids', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Same Choice-IDs are in range.');
+    assertError(main, 'Same Choice-IDs are in range.');
 });
 
 
@@ -575,7 +601,7 @@ test('error for Empty Cell is in', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Empty Cell is in Choice-IDs range.');
+    assertError(main, 'Empty Cell is in Choice-IDs range.');
 });
 
 
@@ -620,7 +646,7 @@ test('error for empty column', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('No Data in Choice-IDs range.');
+    assertError(main, 'No Data in Choice-IDs range.');
 });
 
 
@@ -673,7 +699,7 @@ test('error for over 1000 characters is in', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Over 1000-character Label is in range.');
+    assertError(main, 'Over 1000-character Label is in range.');
 });
 
 
@@ -732,7 +758,7 @@ test('error for multiple columns', () => {
 
 
     // <script> のスクリプトを実行し、エラーがスローされることを確認
-    expect(execute).toThrow('Multiple Columns in Labels range.');
+    assertError(main, 'Multiple Columns in Labels range.');
 });
 ]]></test>
 </service-task-definition>

--- a/start_event/gmail-message-received.xml
+++ b/start_event/gmail-message-received.xml
@@ -3,13 +3,14 @@
     <addon-type>START_EVENT</addon-type>
     <label>Start: Gmail: Email Message Received</label>
     <label locale="ja">開始: Gmail: メール受信時</label>
-    <last-modified>2022-09-05</last-modified>
+    <last-modified>2024-04-16</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
     <summary>This item starts a process when Gmail has received a new message.</summary>
     <summary locale="ja">このアイテムは、Gmail が新しいメールを受信すると、プロセスを開始します。</summary>
     <configs>
-        <config name="conf_auth" required="true" form-type="OAUTH2"
+        <config name="conf_auth" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://www.googleapis.com/auth/gmail.readonly">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -46,11 +47,11 @@ const datetimeFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX
 /**
  * configs から必要な情報の取り出し
  * @returns {Object} setting 設定
- * @returns {string} setting.auth HTTP 認証設定
+ * @returns {AuthSettingWrapper} setting.auth OAuth2 認証設定
  * @returns {Array} setting.labels ラベル一覧
  */
 const prepare = () => {
-    const auth = configs.get('conf_auth');
+    const auth = configs.getObject('conf_auth');
     let label = configs.get('conf_label');
     let labels = [];
     if (label !== null && label !== '') {
@@ -98,7 +99,7 @@ const logMessages = (messages) => {
 
 /**
  * ラベルからラベル ID を取得する
- * @param {String} auth 認証設定
+ * @param {AuthSettingWrapper} auth OAuth2 認証設定
  * @param {Array<String>} labels ラベル一覧
  * @return {Array<String>} ラベル ID の一覧
  */
@@ -130,7 +131,7 @@ function getLabelIds(auth, labels) {
 
 /**
  * Gmail REST API にメール取得の GET リクエストを送信し、メッセージ一覧を返す
- * @param {String} auth 認証設定
+ * @param {AuthSettingWrapper} auth OAuth2 認証設定
  * @param {Array<String>} labelIds ラベル ID の一覧
  * @param {Number} limit 取得上限数
  * @param timestampLowerLimit timestamp の下限
@@ -179,7 +180,7 @@ function getMessages(auth, labelIds, limit, timestampLowerLimit) {
 
 /**
  * Gmail REST API にメール取得の GET リクエストを送信し、internalDate 等を取得する
- * @param auth {String} auth 認証設定
+ * @param {AuthSettingWrapper} auth OAuth2 認証設定
  * @param id {String} メッセージ ID
  * @return {Object} message メッセージ
  * @returns {string} message.id Gmail Message ID
@@ -237,7 +238,17 @@ function getMessage(auth, id) {
  * @param label
  */
 const prepareConfigs = (label) => {
-    configs.put('conf_auth', 'Gmail');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Google',
+        'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force',
+        'https://accounts.google.com/o/oauth2/token',
+        'gmail',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_auth', auth);
     configs.put('conf_label', label);
 };
 
@@ -515,8 +526,6 @@ test('Success - one label', () => {
     const labelIds = ['Label_1234567'];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -568,8 +577,6 @@ test('Success - one label', () => {
 test('Success - no label', () => {
     prepareConfigs('');
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 2;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -642,8 +649,6 @@ test('Success - more than one labels', () => {
     ];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -697,8 +702,6 @@ test('Success - filtered by isProcessStarted', () => {
     const labelIds = ['Label_1234567'];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -752,8 +755,6 @@ test('Success - filtered by timestampLowerLimit', () => {
     const labelIds = ['Label_1234567'];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     // 1 件目のメールのみプロセス開始対象となるように timestampLowerLimit を設定
@@ -795,8 +796,6 @@ test('Success - filtered by timestampLowerLimit', () => {
 test('Fail - 403 error in getting labels', () => {
     prepareConfigs('ラベル 1');
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -824,8 +823,6 @@ test('Fail - label does not exist', () => {
         存在しないラベル 2`;
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -852,8 +849,6 @@ test('Fail - 403 error in getting messages', () => {
     const labelIds = ['Label_1234567'];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');
@@ -886,8 +881,6 @@ test('Fail - 403 error in getting a message', () => {
     const labelIds = ['Label_1234567'];
     prepareConfigs(label);
 
-    // <script> のスクリプトを実行
-    execute();
 
     const limit = 3;
     const timestampLowerLimit = dateFormatter.parse(DATETIME_FORMAT, '2022-08-01T00:00:00+09:00');


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。
addon-version 2 を設定しました。
engine-type を 3 に変更しました。(Google スプレッドシート: 選択肢データの一括取得 以外)

開始: Gmail: メール受信時　の定義ファイルは、
開始: Microsoft 365 OneDrive for Business: ファイルアップロード時　を参考にして修正しました。
https://raw.githubusercontent.com/Questetra/Addon-XML/master/start_event/onedrive-file-uploaded.xml