### PR TITLE
T9890 Slack アイテム engine-type の変更／廃止予定の authSetting(String) の使用をやめる／廃止予定の設定を削除する

### DIFF
--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2022-07-29</last-modified>
+    <last-modified>2024-04-18</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <engine-type>2</engine-type>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
     <label>Slack: Post Chat (Bots)</label>
     <label locale="ja">Slack: チャット投稿 (Bots)</label>
     <summary>This item sends a message to Slack with Bots.</summary>
     <summary locale="ja">この工程は、Bots 機能を使って Slack にメッセージを投稿します。</summary>
     <configs>
-        <config name="conf_OAuth2" deprecated="true" form-type="OAUTH2"
-                oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
-            <label>C1-deprecated: OAuth2 Setting (To change scopes)</label>
-            <label locale="ja">C1-deprecated: OAuth2 設定 (スコープ変更のため)</label>
-        </config>
-        <config name="conf_OAuth2_V2" required="true" form-type="OAUTH2"
+        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -54,10 +50,9 @@
     <help-page-url>https://support.questetra.com/bpmn-icons/slack-chat-post-bots/</help-page-url>
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/slack-chat-post-bots/</help-page-url>
     <script><![CDATA[
-main();
 
 function main() {
-    const oauth2 = decideOAuth2Setting();
+    const oauth2 = configs.getObject("conf_OAuth2");
     let text = "";
     if (configs.get("Text") !== "" && configs.get("Text") !== null) {
         text = configs.get("Text");
@@ -88,16 +83,6 @@ function main() {
     sendMessage(oauth2, channel, text, attachment);
 }
 
-/**
- * @return 使用する OAuth2 設定
- */
-function decideOAuth2Setting() {
-    const v1 = configs.get("conf_OAuth2");
-    if (v1 !== null && v1 !== "") {
-        return v1;
-    }
-    return configs.get("conf_OAuth2_V2");
-}
 
 /**
  * メンション相手のメールアドレス（Slack アカウント）をconfigから読み出す
@@ -134,7 +119,7 @@ function decideSlackIdNum(oauth2) {
 /**
  * メールアドレスから Slack ID を取得する
  * users.lookupByEmail https://api.slack.com/methods/users.lookupByEmail
- * @param {String} oauth2
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} email
  * @return {String} responseJson.user.id  Slack ID
  */
@@ -170,7 +155,7 @@ function usersLookupByEmail(oauth2, email) {
 
 /**
  * Send Message with Bots  チャット投稿
- * @param {String} oauth2
+ * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
  * @param {String} channel
  * @param {String} text
  * @param {String} attachment
@@ -261,7 +246,17 @@ function attachAdd(attachment, config, attachName) {
  * @return attachment
  */
 const prepareConfigs = (configs, channelName, text, mention, fallback, color, title, titleLink, attachText) => {
-  configs.put('conf_OAuth2_V2', 'Slack');
+  const auth = httpClient.createAuthSettingOAuth2(
+    'Slack',
+    'https://slack.com/oauth/v2/authorize',
+    'https://slack.com/api/oauth.v2.access',
+    'chat:write,users:read,users:read.email',
+    'consumer_key',
+    'consumer_secret',
+    'access_token'
+  );
+
+  configs.putObject('conf_OAuth2', auth);
   configs.put('ChannelName', channelName);
   configs.put('Text', text);
 
@@ -333,7 +328,22 @@ const assertPostRequest = ({url, method, contentType, body}, channel, text, atta
     expect(bodyObj.attachments).toEqual(attachArray);
 };
 
-
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
 
 /**
  * チャット投稿失敗の場合
@@ -345,7 +355,7 @@ test('Message to send isn\'t set', () => {
 
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Message to send isn\'t set.`);
+  assertError(main, 'Message to send isn\'t set.');
 });
 
 
@@ -389,7 +399,6 @@ const preparePostResponse = (channel,text) => {
 };
 
 
-
 /**
  * POST API リクエストでエラーになる場合（Slack ID 取得）
  */
@@ -402,7 +411,7 @@ test('POST GetId Failed', () => {
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
+  assertError(main, 'Failed to send');
 });
 
 
@@ -425,7 +434,7 @@ test('Not Slack account email address', () => {
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
+  assertError(main, 'Failed to send');
 });
 
 
@@ -448,7 +457,7 @@ test('POST Failed', () => {
     });
 
    // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
+  assertError(main, 'Failed to send');
 });
 
 
@@ -472,7 +481,7 @@ test('Success - Mention is a string data item', () => {
     });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -505,7 +514,7 @@ test('Success - Mention is a fixed value', () => {
     });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -530,7 +539,7 @@ test('Success - Channel and Attachment-text ', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -558,7 +567,7 @@ test('Success - Channel and Attachment-title ', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -595,7 +604,7 @@ test('Success - Mention is a user-type data items - Invalid color setting and In
     });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -619,7 +628,7 @@ test('Success - Mention is a empty for user-type data items', () => {
     });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -648,7 +657,7 @@ test('Failed - Mention is a empty for user-type data items - Non-existent channe
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);  
+  assertError(main, 'Failed to send');  
  });
  
 
@@ -677,7 +686,7 @@ test('Failed - Mention is a empty for user-type data items - Channel that bot is
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-   expect(execute).toThrow(`Failed to send`);
+  assertError(main, 'Failed to send');
 });
 
 ]]></test>

--- a/slack-chat-post-bots.xml
+++ b/slack-chat-post-bots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-    <last-modified>2024-04-18</last-modified>
+    <last-modified>2024-04-19</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -9,7 +9,7 @@
     <summary>This item sends a message to Slack with Bots.</summary>
     <summary locale="ja">この工程は、Bots 機能を使って Slack にメッセージを投稿します。</summary>
     <configs>
-        <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
+        <config name="conf_OAuth2_V2" required="true" form-type="OAUTH2" auth-type="OAUTH2"
                 oauth2-setting-name="https://slack.com/oauth2/chat:write,users:read,users:read.email">
             <label>C1: OAuth2 Setting</label>
             <label locale="ja">C1: OAuth2 設定</label>
@@ -52,7 +52,7 @@
     <script><![CDATA[
 
 function main() {
-    const oauth2 = configs.getObject("conf_OAuth2");
+    const oauth2 = configs.getObject("conf_OAuth2_V2");
     let text = "";
     if (configs.get("Text") !== "" && configs.get("Text") !== null) {
         text = configs.get("Text");
@@ -256,7 +256,7 @@ const prepareConfigs = (configs, channelName, text, mention, fallback, color, ti
     'access_token'
   );
 
-  configs.putObject('conf_OAuth2', auth);
+  configs.putObject('conf_OAuth2_V2', auth);
   configs.put('ChannelName', channelName);
   configs.put('Text', text);
 

--- a/slack-chat-post-webhook.xml
+++ b/slack-chat-post-webhook.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-08-16</last-modified>
+<last-modified>2024-04-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Slack: Post Chat (Incoming Webhook)</label>
 <label locale="ja">Slack: チャット投稿 (Incoming Webhook)</label>
 <summary>This item sends a message to Slack with Incoming Webhook.</summary>
@@ -40,7 +41,6 @@
 <help-page-url>https://support.questetra.com/bpmn-icons/slack-chat-post-webhook/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/slack-chat-post-webhook/</help-page-url>
 <script><![CDATA[
-main();
 function main() {
   let jsonReq = {};
 if (configs.get("Text") !== "" && configs.get("Text") !== null){
@@ -160,6 +160,24 @@ const assertPostRequest = ({url, method, contentType, body}, webhookUrl, text, a
 
 
 /**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+  let failed = false;
+  try {
+    main();
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    fail();
+  }
+};
+
+
+/**
  * チャット投稿失敗の場合
  * テキストが空、attachment タイトル未入力、attachment テキスト未入力
  *「テキスト」「Attachment タイトル」「Attachment テキスト」のいずれかが設定されていないと、投稿失敗する
@@ -168,7 +186,7 @@ test('Message to send isn\'t set', () => {
   prepareConfigs(configs, 'https://hooks.slack.com/services/ABCDE', '', 'fallback1', '#ff0000', '', 'https://titleLink1', '');
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow(`Message to send isn\'t set.`);
+  assertError(main, 'Message to send isn\'t set.');
 });
 
 
@@ -214,7 +232,7 @@ test('POST Failed', () => {
   });
 
   // <script> のスクリプトを実行し、エラーがスローされることを確認
-  expect(execute).toThrow(`Failed to send. status: 400`);
+  assertError(main, 'Failed to send. status: 400');
 });
 
 
@@ -240,7 +258,7 @@ test('Success', () => {
     });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -269,7 +287,7 @@ test('Success - text', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -296,7 +314,7 @@ test('Success - Attachment-text ', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 
@@ -330,7 +348,7 @@ test('Success - Attachment-title ', () => {
   });
 
   // <script> のスクリプトを実行
-  execute();
+  main();
 });
 
 

--- a/slack-file-upload-bots.xml
+++ b/slack-file-upload-bots.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2022-05-31</last-modified>
+<last-modified>2024-04-18</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>2</engine-type>
+<engine-type>3</engine-type>
+<addon-version>2</addon-version>
 <label>Slack: Upload File (Bots)</label>
 <label locale="ja">Slack: ファイルアップロード (Bots)</label>
 <summary>This item uploads files to Slack with Bots.</summary>
 <summary locale="ja">この工程は、Bots 機能を使って Slack にファイルをアップロードします。</summary>
 <configs>
-  <config name="conf_OAuth2" required="true" form-type="OAUTH2" oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
+  <config name="conf_OAuth2" required="true" form-type="OAUTH2" auth-type="OAUTH2" oauth2-setting-name="https://slack.com/oauth2/chat:write,files:write">
     <label>C1: OAuth2 Setting</label>
     <label locale="ja">C1: OAuth2 設定</label>
   </config>
@@ -24,9 +25,8 @@
 <help-page-url>https://support.questetra.com/bpmn-icons/slack-file-upload-bots</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/slack-file-upload-bots</help-page-url>
 <script><![CDATA[
-main();
 function main() {
-  const oauth2 = configs.get("conf_OAuth2");
+  const oauth2 = configs.getObject("conf_OAuth2");
   const channel = configs.get("ChannelName");
   const filesDef = configs.getObject("File");
 //check whether files exist or not
@@ -48,7 +48,7 @@ function main() {
 }
 /**
   * Upload File
-  * @param {String} oauth2
+  * @param {AuthSettingWrapper} oauth2  OAuth2 認証設定
   * @param {String} token 
   * @param {QfileView} file
   * @param {String} channel
@@ -114,7 +114,17 @@ aSZNpSX7OH3QjFcr9w829dcwn81r2gAAAABJRU5ErkJggg==</icon>
  * @param File
  */
 const prepareConfigs = (configs, channelName, file) => {
-    configs.put('conf_OAuth2', 'Slack');
+    const auth = httpClient.createAuthSettingOAuth2(
+        'Slack',
+        'https://slack.com/oauth/v2/authorize',
+        'https://slack.com/api/oauth.v2.access',
+        'files:write',
+        'consumer_key',
+        'consumer_secret',
+        'access_token'
+    );
+
+    configs.putObject('conf_OAuth2', auth);
     configs.put('ChannelName', channelName);
 
     const fileDef = engine.createDataDefinition('ファイル', 1, 'q_files', 'FILE');
@@ -141,7 +151,22 @@ const createQfile = (name, size) => {
     return engine.createQfile(name, 'text/plain; charset=US-ASCII', text);
 };
 
-
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    let failed = false;
+    try {
+        main();
+    } catch (e) {
+        failed = true;
+    }
+    if (!failed) {
+        fail();
+    }
+};
 
 /**
  * ファイルが添付されていない場合（正常終了）
@@ -149,7 +174,7 @@ const createQfile = (name, size) => {
 test('No File to upload', () => {
     prepareConfigs(configs, 'channel1', null);
 
-    execute();
+    main();
 });
 
 
@@ -164,7 +189,7 @@ test('Number of Files is over the limit.', () => {
     }
     prepareConfigs(configs, 'channel1', files);
 
-    expect(execute).toThrow('Number of Files is over the limit.');
+    assertError(main, 'Number of Files is over the limit.');
 });
 
 
@@ -204,7 +229,7 @@ test('POST Failed', () => {
       return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
 
-    expect(execute).toThrow(`Failed to upload\n filename: file2.txt`);
+    assertError(main, 'Failed to upload\n filename: file2.txt');
 });
 
 
@@ -229,7 +254,7 @@ test('Success - 1 file　2 channels', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 });
 
 
@@ -256,7 +281,7 @@ test('Success - fileRequestingLimit', () => {
     });
 
     // <script> のスクリプトを実行
-    execute();
+    main();
 
     // リクエスト数をチェック
     expect(requestCount).toEqual(httpClient.getRequestingLimit());
@@ -282,7 +307,7 @@ test('Failed - One of the channels does not exist', () => {
       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    expect(execute).toThrow(`Failed to upload\n filename: file9.txt error: channel_not_found`);
+    assertError(main, 'Failed to upload\n filename: file9.txt error: channel_not_found');
 });
 
 
@@ -305,7 +330,7 @@ test('Failed - Not joined to any channel', () => {
       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    expect(execute).toThrow(`Failed to upload\n filename: file10.txt error: not_in_channel`);
+    assertError(main, 'Failed to upload\n filename: file10.txt error: not_in_channel');
 });
 
 
@@ -328,7 +353,7 @@ test('Failed - no data file', () => {
       return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
 
-    expect(execute).toThrow(`Failed to upload\n filename: kara.txt error: no_file_data`);
+    assertError(main, 'Failed to upload\n filename: kara.txt error: no_file_data');
 });
 ]]></test>    
 </service-task-definition>


### PR DESCRIPTION
@hatanaka-akihiro さん

レビューをお願いします。

engine-type を 3 に変更しました。
addon-version 2 を設定しました。
auth-type を指定し、認証設定で AuthSettingWrapper を利用するように修正しました。(Slack: ファイルアップロード (Bots)、Slack: チャット投稿 (Bots))
廃止予定の設定を削除しました。(Slack: チャット投稿 (Bots))
