### PR TITLE
T9942: Google ドライブ: フォルダ検索　サービスアカウント形式を導入する／既存の OAuth2 設定は廃止予定とする

### DIFF
--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2024-04-23</last-modified>
+<last-modified>2024-04-25</last-modified>
 <license>(C) Questetra, Inc. (MIT License)</license>
 <engine-type>3</engine-type>
 <addon-version>2</addon-version>
@@ -19,7 +19,7 @@
     <label>C1: Service Account Setting</label>
     <label locale="ja">C1: サービスアカウント設定</label>
   </config>
-  <config name="ParentFolderId" el-enabled="true">
+  <config name="ParentFolderId" required="true" el-enabled="true">
     <label>C2: Parent Folder ID</label>
     <label locale="ja">C2: 検索するフォルダの親フォルダの ID</label>
   </config>
@@ -40,8 +40,13 @@
 <script><![CDATA[
 function main() {
     //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
+    const oauth = configs.getObject("OAuth");
+    const oauthV2 = configs.getObject("OAuth_V2");
     let parentFolderId = configs.get("ParentFolderId");
-    if (parentFolderId === "" || parentFolderId === null) {
+    if (oauthV2 !== null && parentFolderId === "") {
+        throw new Error("Parent Folder ID is blank.");
+    }
+    if (parentFolderId === "") { // 従来の OAuth 設定を使用する場合
         parentFolderId = "root";
     }
     const folderName = configs.get("FolderName");
@@ -53,11 +58,6 @@ function main() {
     // If neither C4 nor C5 are set, throw error
     if (idDataDef === null && urlDataDef === null) {
         throw new Error("Neither of Data Items to save result are set.");
-    }
-    const oauth = configs.getObject("OAuth");
-    const oauthV2 = configs.getObject("OAuth_V2");
-    if (oauthV2 !== null && parentFolderId === "root") {
-        throw new Error("When using Service Account Setting, Parent Folder ID must be set.");
     }
 
     //// == 演算 / Calculating ==
@@ -442,12 +442,12 @@ test('Neither of Data Items to save result are set.', () => {
 /**
  * サービスアカウント設定を使用する場合、親フォルダ ID が設定されていないとエラー
  */
-test('When using Service Account Setting, Parent Folder ID must be set.', () => {
+test('Parent Folder ID is blank.', () => {
     const privateKeyId = 'key-12345';
     const serviceAccount = 'service@questetra.com';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, '', 'フォルダ1');
 
-    assertError('When using Service Account Setting, Parent Folder ID must be set.');
+    assertError('Parent Folder ID is blank.');
 });
 
 /**


### PR DESCRIPTION
C2 の親フォルダ ID を required に変更し、エラーメッセージも併せて変更しました。