### PR TITLE
t9973 テーブル型データ項目の値を書き換えるビルトインアイテム　ScriptListArray のチェック強化に関して単体テストの改修

### DIFF
--- a/converter-excelcsv-to-table.xml
+++ b/converter-excelcsv-to-table.xml
@@ -4,7 +4,7 @@
     <label>Converter (Excel-CSV FILE to Table type data)</label>
     <label locale="ja">コンバータ (Excel-CSV ファイル to テーブル型データ)</label>
 
-    <last-modified>2024-04-26</last-modified>
+    <last-modified>2024-05-14</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/converter-excelcsv-to-table/
     </help-page-url>
     <help-page-url locale="ja">
@@ -301,7 +301,7 @@ test("success-1row-multicolumns", () => {
     expect(numOfCols).toEqual(4);
     // テーブル型データ項目の各カラムの値
     expect(myTable.get(0, 0)).toEqual("hogehoge");
-    expect(myTable.get(0, 1)).toEqual("123.45");
+    expect(myTable.get(0, 1)).toEqual("123.450");
     expect(myTable.get(0, 2)).toEqual("2021-10-21");
     expect(myTable.get(0, 3)).toEqual("false");
 });
@@ -351,7 +351,7 @@ test("success-multirows-multicolumns", () => {
     expect(numOfCols1).toEqual(4);
     // テーブル型データ項目の各カラムの値
     expect(myTable.get(0, 0)).toEqual("hogehoge");
-    expect(myTable.get(0, 1)).toEqual("123.45");
+    expect(myTable.get(0, 1)).toEqual("123.450");
     expect(myTable.get(0, 2)).toEqual("2021-10-21");
     expect(myTable.get(0, 3)).toEqual("false");
     expect(myTable.get(1, 0)).toEqual("piyopiyo");
@@ -359,6 +359,24 @@ test("success-multirows-multicolumns", () => {
     expect(myTable.get(1, 2)).toEqual("2022-10-21");
     expect(myTable.get(1, 3)).toEqual("true");
 });
+
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    let failed = false;
+    try {
+        main();
+    } catch (e) {
+        failed = true;
+        expect(e.message).toEqual(errorMsg);
+    }
+    if (!failed) {
+        fail();
+    }
+};
 
 /**
  * テーブル型データ項目よりも少ない列数
@@ -389,11 +407,8 @@ test("few-column", () => {
     // テーブル型データ項目に null を指定
     //engine.setData(tableDef, null);
 
-    try {
-        main();
-    } catch (e) {
-        expect(e.toString()).toEqual(`Error: Incorrect number of rows at line 1`);
-    }
+    assertError(main, 'Incorrect number of rows at line 1');
+
 });
 
 /**
@@ -425,11 +440,8 @@ test("over-columns", () => {
     // テーブル型データ項目に null を指定
     engine.setData(tableDef, null);
 
-    try {
-        main();
-    } catch (e) {
-        expect(e.toString()).toEqual(`Error: Incorrect number of rows at line 2`);
-    }
+    assertError(main, 'Incorrect number of rows at line 2');
+
 });
 
 /**
@@ -456,11 +468,8 @@ test("multiple files", () => {
     files.add(file2);
     engine.setData(fileDef, files);
 
-    try {
-        main();
-    } catch (e) {
-        expect(e.toString()).toEqual(`Error: Attachment of multiple files can not be supported.`);
-    }
+    assertError(main, 'Attachment of multiple files can not be supported.');
+
 });
 ]]></test>
 

--- a/converter-excelcsv-to-table.xml
+++ b/converter-excelcsv-to-table.xml
@@ -4,7 +4,7 @@
     <label>Converter (Excel-CSV FILE to Table type data)</label>
     <label locale="ja">コンバータ (Excel-CSV ファイル to テーブル型データ)</label>
 
-    <last-modified>2023-06-14</last-modified>
+    <last-modified>2024-04-26</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/converter-excelcsv-to-table/
     </help-page-url>
     <help-page-url locale="ja">
@@ -107,11 +107,11 @@ const prepareTableDefMultiColumn = () => {
     // 1列目を文字型データ項目にする
     multiColumnTableDef.addSubDataDefinition("文字", "string", "STRING");
     // 2列目を数値型データ項目にする
-    multiColumnTableDef.addSubDataDefinition("数値", "decimal", "DECIMAL");
+    multiColumnTableDef.addDecimalSubDataDefinition("数値", "decimal", 3, true, true);
     // 3列目を日付型データ項目にする
     multiColumnTableDef.addSubDataDefinition("日付", "date", "DATE_YMD");
     // 4列目を選択型データ項目にする
-    multiColumnTableDef.addSubDataDefinition("選択", "select", "SELECT");
+    multiColumnTableDef.addSelectSubDataDefinition("選択", "select", 'true', 'false');
     return multiColumnTableDef;
 };
 

--- a/converter-table-to-excelcsv.xml
+++ b/converter-table-to-excelcsv.xml
@@ -2,7 +2,7 @@
 <service-task-definition>
     <label>Converter (Table type data to Excel-CSV File)</label>
     <label locale="ja">コンバータ (テーブル型データ to Excel-CSV ファイル)</label>
-    <last-modified>2024-04-26</last-modified>
+    <last-modified>2024-05-14</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/converter-tabletoexcelcsv/</help-page-url>
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/converter-tabletoexcelcsv/</help-page-url>
 
@@ -138,6 +138,7 @@ const assertError = (func, errorMsg) => {
         main();
     } catch (e) {
         failed = true;
+        expect(e.message).toEqual(errorMsg);
     }
     if (!failed) {
         fail();

--- a/converter-table-to-excelcsv.xml
+++ b/converter-table-to-excelcsv.xml
@@ -116,9 +116,9 @@ function tableToTsv(myTable) {
 const prepareTableDef = () => {
     const tableDef = engine.createDataDefinition('テーブル', 10, 'q_table', 'LIST');
     tableDef.addSubDataDefinition('文字', 'string', 'STRING');
-    tableDef.addSubDataDefinition('数値', 'decimal', 'DECIMAL');
+    tableDef.addDecimalSubDataDefinition('数値', 'decimal', 2, true, true);
     tableDef.addSubDataDefinition('日付', 'date', 'DATE_YMD');
-    tableDef.addSubDataDefinition('選択', 'select', 'SELECT');
+    tableDef.addSelectSubDataDefinition('選択', 'select', 'true', 'false');
     return tableDef;
 };
 

--- a/converter-table-to-excelcsv.xml
+++ b/converter-table-to-excelcsv.xml
@@ -2,7 +2,7 @@
 <service-task-definition>
     <label>Converter (Table type data to Excel-CSV File)</label>
     <label locale="ja">コンバータ (テーブル型データ to Excel-CSV ファイル)</label>
-    <last-modified>2024-04-16</last-modified>
+    <last-modified>2024-04-26</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/converter-tabletoexcelcsv/</help-page-url>
     <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/converter-tabletoexcelcsv/</help-page-url>
 

--- a/google-sheets-row-append-by-table.xml
+++ b/google-sheets-row-append-by-table.xml
@@ -6,7 +6,7 @@
 <label locale="ja">Google スプレッドシート: 行追加 (テーブル型データ)</label>
 <summary>This item appends values of a Table type data item at the last of the sheet.</summary>
 <summary locale="ja">この工程は、シート末尾にテーブル型データの値を入力します。</summary>
-<last-modified>2024-03-19</last-modified>
+<last-modified>2024-04-26</last-modified>
 <help-page-url>https://support.questetra.com/bpmn-icons/googlesheets-appendtable/</help-page-url>
 <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/googlesheets-appendtable/</help-page-url>
 
@@ -721,10 +721,10 @@ const prepareConfigsWithVariousDataTypes = (spreadSheetId, sheetTitle) => {
     tableDef.addSubDataDefinition('C列のサブデータ', 'q_SubDataC', 'DECIMAL');
     tableDef.addSubDataDefinition('D列のサブデータ', 'q_SubDataD', 'DECIMAL');
     // E列は設定しない
-    tableDef.addSubDataDefinition('F列のサブデータ', 'q_SubDataF', 'SELECT');
-    tableDef.addSubDataDefinition('G列のサブデータ', 'q_SubDataG', 'SELECT');
-    tableDef.addSubDataDefinition('H列のサブデータ', 'q_SubDataH', 'DATE');
-    tableDef.addSubDataDefinition('I列のサブデータ', 'q_SubDataI', 'DATE');
+    tableDef.addSelectSubDataDefinition('F列のサブデータ', 'q_SubDataF', '選択肢1');
+    tableDef.addSelectSubDataDefinition('G列のサブデータ', 'q_SubDataG', '選択肢2');
+    tableDef.addSubDataDefinition('H列のサブデータ', 'q_SubDataH', 'DATE_YMD');
+    tableDef.addSubDataDefinition('I列のサブデータ', 'q_SubDataI', 'DATE_YMD');
     // J列は設定しない
 
     // config にフィールド名をセット（E列, J列は設定しない）


### PR DESCRIPTION
@hatanaka-akihiro  さん

こちらのブランチに、
converter-excelcsv-to-table.xml
converter-table-to-excelcsv.xml
の定義ファイルをそのまま引き継いで改良しました。レビューをお願いします。

google-sheets-row-append-by-table.xml
については、t9553 のブランチで対応していますので、こちらのブランチでは未対応です。
