### PR TITLE
t7099 コンバータ（ファイルコピー）の作成

### DIFF
--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-09</last-modified>
+    <last-modified>2024-07-11</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -24,7 +24,7 @@
             <label>C1: Source File type data item</label>
             <label locale="ja">C1: コピー元ファイル型データ項目</label>
         </config>
-        <config name="conf_CopyToFileDataId" required="true" form-type="SELECT" select-data-type="FILE">
+        <config name="conf_DestinationFileDataId" required="true" form-type="SELECT" select-data-type="FILE">
             <label>C2: File type data item to copy to</label>
             <label locale="ja">C2: コピー先ファイル型データ項目</label>
         </config>
@@ -45,11 +45,12 @@
 function main() {
     //// == 自動工程コンフィグの参照 / Config Retrieving ==
     const sourceFileDef = configs.getObject("conf_SourceFileDataId"); // (returns ProcessDataDefinitionView)
-    const copyToFileDef = configs.getObject("conf_CopyToFileDataId"); // (returns ProcessDataDefinitionView)
+    const destinationFileDef = configs.getObject("conf_DestinationFileDataId"); // (returns ProcessDataDefinitionView)
 
     const deleteOtherFiles = configs.getObject("conf_DeleteOtherFiles");
+    // ワークフローデータからファイル型データの配列を取得。
     const sourceFiles = engine.findData(sourceFileDef);
-    const copyToFiles = engine.findData(copyToFileDef);
+    const destinationFiles = engine.findData(destinationFileDef);
 
     // コピー元のファイルがない場合
     if (sourceFiles === null) {
@@ -59,38 +60,37 @@ function main() {
     let fileName = configs.get("conf_FileName");
     if (fileName !== "" && fileName !== null) {
         if (sourceFiles.size() > 1) {
-    // ファイル名が指定されていて、コピー元のファイル型データに複数添付されている場合、エラー
+            // ファイル名が指定されていて、コピー元のファイル型データに複数添付されている場合、エラー
             throw new Error("Attachment of multiple files can not be named.");
         }
     }
 
-    copyFiles = copyFile(sourceFiles, deleteOtherFiles, fileName, copyToFiles);
+    let myFiles = new java.util.ArrayList();
+    if (deleteOtherFiles === false) {
+        if (destinationFiles !== null) {
+            myFiles.addAll(destinationFiles);
+        }
+    }
+
+    const newFiles = copyFile(sourceFiles, fileName, myFiles);
 
     //// == ワークフローデータへの代入 / Data Updating ==
-    engine.setData(copyToFileDef, copyFiles);
+    engine.setData(destinationFileDef, newFiles);
 }
 
 /**
   * ファイルをコピーする
   * @param {Qfile} sourceFiles コピー元ファイル
-  * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
   * @param {String} filename 保存ファイル名
-  * @param {Qfile} copyToFile コピー先ファイル
+  * @param {java.util.ArrayList<QfileView>} myFiles （ワークフローデータから取得した）ファイル型データの配列
+  * @return {java.util.ArrayList<QfileView>} myFiles コピーファイルを追加した配列
   */
-function copyFile(sourceFiles, deleteOtherFiles, fileName, copyToFiles) {
-
-    let myFiles = new java.util.ArrayList();
-    if (deleteOtherFiles === false) {
-        // ワークフローデータからファイル型データの配列を取得。
-        if (copyToFiles !== null) {
-            myFiles.addAll(copyToFiles);
-        }
-    }
+function copyFile(sourceFiles, fileName, myFiles) {
 
     let qfile;
-    for(let i = 0; i < sourceFiles.size(); i ++){
+    for (let i = 0; i < sourceFiles.size(); i++) {
         let sourceFilesInfo = sourceFiles.get(i);
-        if(fileName !== "" && fileName !== null) {
+        if (fileName !== "" && fileName !== null) {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFilesInfo.getContentType(), sourceFilesInfo);
         } else {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(sourceFilesInfo.getName(), sourceFilesInfo.getContentType(), sourceFilesInfo); //ファイルデータをそのまま複製保存する
@@ -125,18 +125,18 @@ function copyFile(sourceFiles, deleteOtherFiles, fileName, copyToFiles) {
  * @param sourceFiles コピー元ファイル
  * @param deleteOtherFiles
  * @param fileName
- * @param copyToFiles コピー先ファイル
+ * @param destinationFiles コピー先ファイル
  * @return fileDef: {Object}
  */
-const prepareConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) => {
+const prepareConfigs = (sourceFiles, deleteOtherFiles, fileName, destinationFiles) => {
     // ファイル型データ項目を準備して、config に指定
     const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
     configs.putObject('conf_SourceFileDataId', sourceFileDef);
     engine.setData(sourceFileDef, sourceFiles);
 
-    const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
-    configs.putObject('conf_CopyToFileDataId', copyToFileDef);
-    engine.setData(copyToFileDef, copyToFiles);
+    const destinationFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
+    configs.putObject('conf_DestinationFileDataId', destinationFileDef);
+    engine.setData(destinationFileDef, destinationFiles);
 
     configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
 
@@ -145,7 +145,7 @@ const prepareConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) =>
 
     return {
         sourceFileDef,
-        copyToFileDef
+        destinationFileDef
     };
 };
 
@@ -156,18 +156,18 @@ const prepareConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) =>
  * @param sourceFiles コピー元ファイル
  * @param deleteOtherFiles
  * @param fileName
- * @param copyToFiles コピー先ファイル
+ * @param destinationFiles コピー先ファイル
  * @return fileDef: {Object}
  */
-const prepareSameConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) => {
+const prepareSameConfigs = (sourceFiles, deleteOtherFiles, fileName, destinationFiles) => {
     // ファイル型データ項目を準備して、config に指定
     const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
     configs.putObject('conf_SourceFileDataId', sourceFileDef);
     engine.setData(sourceFileDef, sourceFiles);
 
-    const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
-    configs.putObject('conf_CopyToFileDataId', copyToFileDef);
-    engine.setData(copyToFileDef, sourceFiles);
+    const destinationFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
+    configs.putObject('conf_DestinationFileDataId', destinationFileDef);
+    engine.setData(destinationFileDef, sourceFiles);
 
     configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
 
@@ -176,7 +176,7 @@ const prepareSameConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles
 
     return {
         sourceFileDef,
-        copyToFileDef
+        destinationFileDef
     };
 };
 
@@ -220,7 +220,7 @@ test('Attachment of multiple files can not be nameed', () => {
 
     const {
         sourceFileDef,
-        copyToFileDef
+        destinationFileDef
     } = prepareConfigs(sourceFiles, true, 'test.txt', null);
 
     assertError(main, 'Attachment of multiple files can not be named.');
@@ -250,18 +250,18 @@ test('success - 1file - deleteOtherFiles - 2 attachments ', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('test.pdf', 'application/pdf', 'test'));
 
-    let copyToFiles = new java.util.ArrayList();
-    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
-    copyToFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+    let destinationFiles = new java.util.ArrayList();
+    destinationFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    destinationFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
 
     const {
         sourceFileDef,
-        copyToFileDef
-    } = prepareConfigs(sourceFiles, true, '', copyToFiles);
+        destinationFileDef
+    } = prepareConfigs(sourceFiles, true, '', destinationFiles);
 
     main();   
 
-    const files = engine.findData(copyToFileDef);
+    const files = engine.findData(destinationFileDef);
     expect(files.size()).toEqual(1);
     const file = files.get(0);
     assertFile(file, 'test.pdf','application/pdf');
@@ -279,18 +279,18 @@ test('success - 1file - 2 attachments - with name', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
 
-    let copyToFiles = new java.util.ArrayList();
-    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
-    copyToFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+    let destinationFiles = new java.util.ArrayList();
+    destinationFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    destinationFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
 
     const {
         sourceFileDef,
-        copyToFileDef
-    } = prepareConfigs(sourceFiles, false, 'testqqq.txt', copyToFiles);
+        destinationFileDef
+    } = prepareConfigs(sourceFiles, false, 'testqqq.txt', destinationFiles);
 
     main();   
 
-    const files = engine.findData(copyToFileDef);
+    const files = engine.findData(destinationFileDef);
     expect(files.size()).toEqual(3);
     let file = files.get(0);
     assertFile(file, '事前ファイル.txt','text/plain; charset=UTF-8');
@@ -313,17 +313,17 @@ test('success - 2files - 1 attachment - with name', () => {
     sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
     sourceFiles.add(engine.createQfile('test.png', 'image/png', 'test\n'));
 
-    let copyToFiles = new java.util.ArrayList();
-    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    let destinationFiles = new java.util.ArrayList();
+    destinationFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
 
     const {
         sourceFileDef,
-        copyToFileDef
-    } = prepareConfigs(sourceFiles, false, '', copyToFiles);
+        destinationFileDef
+    } = prepareConfigs(sourceFiles, false, '', destinationFiles);
 
     main();   
 
-    const files = engine.findData(copyToFileDef);
+    const files = engine.findData(destinationFileDef);
     expect(files.size()).toEqual(3);
     let file = files.get(0);
     assertFile(file, '事前ファイル.txt','text/plain; charset=UTF-8');
@@ -348,12 +348,12 @@ test('success - 2files - Same File type data ', () => {
 
     const {
         sourceFileDef,
-        copyToFileDef
+        destinationFileDef
     } = prepareSameConfigs(sourceFiles, false, '', sourceFiles);
 
     main();   
 
-    const files = engine.findData(copyToFileDef);
+    const files = engine.findData(destinationFileDef);
     expect(files.size()).toEqual(4);
     let file = files.get(0);
     assertFile(file, 'test.png','image/png');
@@ -379,12 +379,12 @@ test('success - 1file - Same File type data - deleteOtherFiles - with name', () 
 
     const {
         sourceFileDef,
-        copyToFileDef
+        destinationFileDef
     } = prepareSameConfigs(sourceFiles, true, 'qqq.txt', sourceFiles);
 
     main();   
 
-    const files = engine.findData(copyToFileDef);
+    const files = engine.findData(destinationFileDef);
     expect(files.size()).toEqual(1);
     const file = files.get(0);
     assertFile(file, 'qqq.txt', 'text/plain; charset=UTF-8');

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -49,7 +49,7 @@ function main() {
 
     const deleteOtherFiles = configs.getObject("conf_DeleteOtherFiles");
     const sourceFiles = engine.findData(sourceFileDef);
-    const copyToFile = engine.findData(copyToFileDef);
+    const copyToFiles = engine.findData(copyToFileDef);
 
     // コピー元のファイルがない場合
     if (sourceFiles === null) {
@@ -64,7 +64,7 @@ function main() {
         }
     }
 
-    copyFiles = copyFile(sourceFiles, deleteOtherFiles, sourceFiles.size(), fileName, copyToFile);
+    copyFiles = copyFile(sourceFiles, deleteOtherFiles, fileName, copyToFiles);
 
     //// == ワークフローデータへの代入 / Data Updating ==
     engine.setData(copyToFileDef, copyFiles);
@@ -74,24 +74,21 @@ function main() {
   * ファイルをコピーする
   * @param {Qfile} sourceFiles コピー元ファイル
   * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
-  * @param {String} num コピー元ファイル数
   * @param {String} filename 保存ファイル名
   * @param {Qfile} copyToFile コピー先ファイル
   */
-function copyFile(sourceFiles, deleteOtherFiles, num, fileName, copyToFile) {
-    let myFiles;
-    if (deleteOtherFiles === true) {
-        myFiles = new java.util.ArrayList();
-    } else {
-        // ワークフローデータからファイル型データの配列を取得
-        myFiles = copyToFile;
-        if (myFiles === null) {
-            myFiles = new java.util.ArrayList();
+function copyFile(sourceFiles, deleteOtherFiles, fileName, copyToFiles) {
+
+    let myFiles = new java.util.ArrayList();
+    if (deleteOtherFiles === false) {
+        // ワークフローデータからファイル型データの配列を取得。
+        if (copyToFiles !== null) {
+            myFiles.addAll(copyToFiles);
         }
     }
 
     let qfile;
-    for(let i = 0; i < num; i ++){
+    for(let i = 0; i < sourceFiles.size(); i ++){
         let sourceFilesInfo = sourceFiles.get(i);
         if(fileName !== "" && fileName !== null) {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFilesInfo.getContentType(), sourceFilesInfo);

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-05</last-modified>
+    <last-modified>2024-07-08</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -48,36 +48,35 @@ function main() {
     const copyToFileDef = configs.getObject("conf_CopyToFileDataId"); // (returns ProcessDataDefinitionView)
 
     const deleteOtherFiles = configs.getObject("conf_DeleteOtherFiles");
-    const sourceFile = engine.findData(sourceFileDef);
-    const copyToFile = engine.findData(copyToFileDef);
+    const sourceFiles = engine.findData(sourceFileDef);
 
     // コピー元のファイルがない場合
-    if (sourceFile === null) {
+    if (sourceFiles === null) {
         throw new Error('Source file is empty.');
     }
 
     let fileName = configs.get("conf_FileName");
     if (fileName !== "" && fileName !== null) {
-        if (sourceFile !== null && sourceFile.size() > 1) {
+        if (sourceFiles.size() > 1) {
     // ファイル名が指定されていて、コピー元のファイル型データに複数添付されている場合、エラー
             throw new Error("Attachment of multiple files can not be named.");
         }
     }
 
-    copyFile = copyFile(sourceFile, deleteOtherFiles, sourceFile.size(), fileName);
+    copyFiles = copyFile(sourceFiles, deleteOtherFiles, sourceFiles.size(), fileName);
 
     //// == ワークフローデータへの代入 / Data Updating ==
-    engine.setData(copyToFileDef, copyFile);
+    engine.setData(copyToFileDef, copyFiles);
 }
 
 /**
   * ファイルをコピーする
-  * @param {Qfile} sourceFile コピー元ファイル
+  * @param {Qfile} sourceFiles コピー元ファイル
   * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
-  * @param {num} sourceFile.size() コピー元ファイル数
+  * @param {String} num コピー元ファイル数
   * @param {String} filename 保存ファイル名
   */
-function copyFile(sourceFile, deleteOtherFiles, num, fileName) {
+function copyFile(sourceFiles, deleteOtherFiles, num, fileName) {
     let myFiles;
     if (deleteOtherFiles === true) {
         myFiles = new java.util.ArrayList();
@@ -91,10 +90,11 @@ function copyFile(sourceFile, deleteOtherFiles, num, fileName) {
 
     let qfile;
     for(let i = 0; i < num; i ++){
+        let sourceFilesInfo = sourceFiles.get(i);
         if(fileName !== "" && fileName !== null) {
-            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFile.get(i).getContentType(), sourceFile.get(i));
+            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFilesInfo.getContentType(), sourceFilesInfo);
         } else {
-            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(sourceFile.get(i).getName(), sourceFile.get(i).getContentType(), sourceFile.get(i)); //ファイルデータをそのまま複製保存する
+            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(sourceFilesInfo.getName(), sourceFilesInfo.getContentType(), sourceFilesInfo); //ファイルデータをそのまま複製保存する
         }
         myFiles.add(qfile);
     }
@@ -123,21 +123,21 @@ function copyFile(sourceFile, deleteOtherFiles, num, fileName) {
     <test><![CDATA[
 /**
  * 設定の準備
- * @param sourceFile コピー元ファイル
+ * @param sourceFiles コピー元ファイル
  * @param deleteOtherFiles
  * @param fileName
- * @param copyToFile コピー先ファイル
+ * @param copyToFiles コピー先ファイル
  * @return fileDef: {Object}
  */
-const prepareConfigs = (sourceFile, deleteOtherFiles, fileName, copyToFile) => {
+const prepareConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) => {
     // ファイル型データ項目を準備して、config に指定
     const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
     configs.putObject('conf_SourceFileDataId', sourceFileDef);
-    engine.setData(sourceFileDef, sourceFile);
+    engine.setData(sourceFileDef, sourceFiles);
 
     const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
     configs.putObject('conf_CopyToFileDataId', copyToFileDef);
-    engine.setData(copyToFileDef, copyToFile);
+    engine.setData(copyToFileDef, copyToFiles);
 
     configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
 
@@ -154,21 +154,21 @@ const prepareConfigs = (sourceFile, deleteOtherFiles, fileName, copyToFile) => {
 /**
  * 設定の準備
  * コピー元ファイル、コピー先ファイルのデータ項目が同一
- * @param sourceFile コピー元ファイル
+ * @param sourceFiles コピー元ファイル
  * @param deleteOtherFiles
  * @param fileName
- * @param copyToFile コピー先ファイル
+ * @param copyToFiles コピー先ファイル
  * @return fileDef: {Object}
  */
-const prepareSameConfigs = (sourceFile, deleteOtherFiles, fileName, copyToFile) => {
+const prepareSameConfigs = (sourceFiles, deleteOtherFiles, fileName, copyToFiles) => {
     // ファイル型データ項目を準備して、config に指定
     const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
     configs.putObject('conf_SourceFileDataId', sourceFileDef);
-    engine.setData(sourceFileDef, sourceFile);
+    engine.setData(sourceFileDef, sourceFiles);
 
     const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
     configs.putObject('conf_CopyToFileDataId', copyToFileDef);
-    engine.setData(copyToFileDef, sourceFile);
+    engine.setData(copyToFileDef, sourceFiles);
 
     configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
 
@@ -366,6 +366,7 @@ test('success - 2files - Same File type data ', () => {
     assertFile(file, 'test.txt', 'text/plain; charset=UTF-8');
 });
 
+
 /**
  * コピー成功
  * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
@@ -390,10 +391,6 @@ test('success - 1file - Same File type data - deleteOtherFiles - with name', () 
     assertFile(file, 'qqq.txt', 'text/plain; charset=UTF-8');
 });
 
-
-
 ]]></test>
-
-
 
 </service-task-definition>

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service-task-definition>
+
+    <label>Converter (Copy File)</label>
+    <label locale="ja">コンバータ（ファイルコピー）</label>
+
+    <last-modified>2024-07-02</last-modified>
+    <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
+    </help-page-url>
+    <help-page-url locale="ja">
+        https://support.questetra.com/ja/bpmn-icons/service-task-converter-file-copy/
+    </help-page-url>
+
+    <summary>This item copies the attachment file of the File type data item to the specified File type data item. If there is only one target file, the file name can also be changed.
+    </summary>
+    <summary locale="ja">この工程は、ファイル型データ項目の添付ファイルを、指定したファイル型データ項目に複製します。対象ファイルが１つなら、ファイル名を変更することも可能です。
+    </summary>
+
+    <license>(C) Questetra, Inc. (MIT License)</license>
+
+
+    <configs>
+        <config name="conf_SourceFileDataId" required="true" form-type="SELECT" select-data-type="FILE">
+            <label>C1: Source File type data item</label>
+            <label locale="ja">C1: コピー元ファイル型データ項目</label>
+        </config>
+        <config name="conf_CopyToFileDataId" required="true" form-type="SELECT" select-data-type="FILE">
+            <label>C2: File type data item to copy to</label>
+            <label locale="ja">C2: コピー先ファイル型データ項目</label>
+        </config>
+        <config name="conf_DeleteOtherFiles" form-type="TOGGLE">
+            <label>C3: Delete other files when saving</label>
+            <label locale="ja">C3: 保存時に他のファイルを削除する</label>
+        </config>>
+        <config name="conf_FileName" form-type="TEXTFIELD" required="false" el-enabled="true">
+            <label>C4: File name (named with the source file if blank)</label>
+            <label locale="ja">C4: 保存ファイル名 (空白の場合、コピー元のファイル名で保存されます。)</label>
+        </config>
+    </configs>
+
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
+
+    <script><![CDATA[
+function main() {
+    //// == 自動工程コンフィグの参照 / Config Retrieving ==
+    const sourceFileDef = configs.getObject("conf_SourceFileDataId"); // (returns ProcessDataDefinitionView)
+    const copyToFileDef = configs.getObject("conf_CopyToFileDataId"); // (returns ProcessDataDefinitionView)
+
+    const deleteOtherFiles = configs.getObject("conf_DeleteOtherFiles");
+    const sourceFile = engine.findData(sourceFileDef);
+    const copyToFile = engine.findData(copyToFileDef);
+
+    // コピー元のファイル型データに複数添付されている場合、エラー
+    if (sourceFile !== null && sourceFile.size() > 1) {
+        throw new Error("Attachment of multiple files can not be supported.");
+    }
+    // コピー元のファイルがない場合
+    if (sourceFile === null) {
+        throw new Error('Source file is empty.');
+    }
+
+    let fileName = configs.get("conf_FileName");
+    if (fileName === "" || fileName === null) {
+        // コピー元ファイルの名前を取得する
+        fileName = sourceFile.get(0).getName();
+    }
+
+    // コピー元のファイル型データ項目にファイルが1つ添付されている場合
+    copyFile = copyFile(sourceFile, deleteOtherFiles, fileName);
+
+    //// == ワークフローデータへの代入 / Data Updating ==
+    engine.setData(copyToFileDef, copyFile);
+}
+
+/**
+  * ファイルをコピーする
+  * @param {Qfile} sourceFile コピー元ファイル
+  * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
+  * @param {String} filename 保存ファイル名
+  */
+function copyFile(sourceFile, deleteOtherFiles, fileName) {
+    let myFiles;
+    if (deleteOtherFiles === true) {
+        myFiles = new java.util.ArrayList();
+    } else {
+        // ワークフローデータからファイル型データの配列を取得
+        myFiles = engine.findData(configs.getObject("conf_CopyToFileDataId"));
+        if (myFiles === null) {
+            myFiles = new java.util.ArrayList();
+        }
+    }
+
+    const qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFile.get(0).getContentType(), sourceFile.get(0)) //ファイルデータをそのまま複製保存する
+    myFiles.add(qfile);
+
+    return myFiles;
+}
+
+]]></script>
+
+    <test><![CDATA[
+/**
+ * 設定の準備
+ * @param sourceFile コピー元ファイル
+ * @param deleteOtherFiles
+ * @param fileName
+ * @param copyToFile コピー先ファイル
+ * @return fileDef: {Object}
+ */
+const prepareConfigs = (sourceFile, deleteOtherFiles, fileName, copyToFile) => {
+    // ファイル型データ項目を準備して、config に指定
+    const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
+    configs.putObject('conf_SourceFileDataId', sourceFileDef);
+    engine.setData(sourceFileDef, sourceFile);
+
+    const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
+    configs.putObject('conf_CopyToFileDataId', copyToFileDef);
+    engine.setData(copyToFileDef, copyToFile);
+
+    configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
+
+    // ファイル名を config に指定
+    configs.put('conf_FileName', fileName);
+
+    return {
+        sourceFileDef,
+        copyToFileDef
+    };
+};
+
+
+/**
+ * 設定の準備
+ * コピー元ファイル、コピー先ファイルのデータ項目が同一
+ * @param sourceFile コピー元ファイル
+ * @param deleteOtherFiles
+ * @param fileName
+ * @param copyToFile コピー先ファイル
+ * @return fileDef: {Object}
+ */
+const prepareSameConfigs = (sourceFile, deleteOtherFiles, fileName, copyToFile) => {
+    // ファイル型データ項目を準備して、config に指定
+    const sourceFileDef = engine.createDataDefinition('コピー元ファイル', 1, 'q_file', 'FILE');
+    configs.putObject('conf_SourceFileDataId', sourceFileDef);
+    engine.setData(sourceFileDef, sourceFile);
+
+    const copyToFileDef = engine.createDataDefinition('コピー先ファイル', 2, 'q_file2', 'FILE');
+    configs.putObject('conf_CopyToFileDataId', copyToFileDef);
+    engine.setData(copyToFileDef, sourceFile);
+
+    configs.putObject('conf_DeleteOtherFiles', deleteOtherFiles);
+
+    // ファイル名を config に指定
+    configs.put('conf_FileName', fileName);
+
+    return {
+        sourceFileDef,
+        copyToFileDef
+    };
+};
+
+
+/**
+ * 異常系のテスト
+ * @param func
+ * @param errorMsg
+ */
+const assertError = (func, errorMsg) => {
+    let failed = false;
+    try {
+        main();
+    } catch (e) {
+        failed = true;
+        expect(e.message).toEqual(errorMsg);
+    }
+    if (!failed) {
+        fail();
+    }
+};
+
+/**
+ * コピー元ファイルが添付されていない場合
+ */
+test('Source file is empty', () => {
+    prepareConfigs(null, true, '', null);
+
+    assertError(main, 'Source file is empty.');
+});
+
+
+/**
+ * コピー元にファイルが複数添付されている場合
+ */
+test('Attachment of multiple files can not be supported', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    sourceFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareConfigs(sourceFiles, true, '', null);
+
+    assertError(main, 'Attachment of multiple files can not be supported.');
+});
+
+
+/**
+ * ファイルのテスト
+ * @param file
+ * @param name
+ * @param contentType
+ */
+const assertFile = (file, name, contentType) => {
+    expect(file.getName()).toEqual(name);
+    expect(file.getContentType()).toEqual(contentType);
+};
+
+
+/**
+ * コピー成功
+ * コピー元のファイル型データには 1 ファイル添付
+ * 他のファイルを削除する
+ * ファイル名指定無し
+ * コピー先のファイル型データには 2 ファイル添付
+ */
+test('success - deleteOtherFiles - 2 attachments ', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.pdf', 'application/pdf', 'test'));
+
+    let copyToFiles = new java.util.ArrayList();
+    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    copyToFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareConfigs(sourceFiles, true, '', copyToFiles);
+
+    main();   
+
+    const files = engine.findData(copyToFileDef);
+    expect(files.size()).toEqual(1);
+    const file = files.get(0);
+    assertFile(file, 'test.pdf','application/pdf');
+});
+
+
+/**
+ * コピー成功
+ * コピー元のファイル型データには 1 ファイル添付
+ * 他のファイルを削除しない
+ * ファイル名を指定
+ * コピー先のファイル型データには 2 ファイル添付
+ */
+test('success - 2 attachments - with name', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
+
+    let copyToFiles = new java.util.ArrayList();
+    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
+    copyToFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareConfigs(sourceFiles, false, 'testqqq.txt', copyToFiles);
+
+    main();   
+
+    const files = engine.findData(copyToFileDef);
+    expect(files.size()).toEqual(3);
+    let file = files.get(0);
+    assertFile(file, '事前ファイル.txt','text/plain; charset=UTF-8');
+    file = files.get(1);
+    assertFile(file, 'test.html','text/html; charset=UTF-8');
+    file = files.get(2);
+    assertFile(file, 'testqqq.txt','text/plain; charset=UTF-8');
+});
+
+
+/**
+ * コピー成功
+ * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
+ * コピー元のファイル型データには 1 ファイル添付
+ * 他のファイルを削除しない
+ * ファイル名を指定しない
+ */
+test('success - Same File type data ', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.png', 'image/png', 'test\n'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareSameConfigs(sourceFiles, false, 'qqq.png', sourceFiles);
+
+    main();   
+
+    const files = engine.findData(sourceFileDef);
+    expect(files.size()).toEqual(2);
+    let file = files.get(0);
+    assertFile(file, 'test.png','image/png');
+    file = files.get(1);
+    assertFile(file, 'qqq.png','image/png');
+});
+
+/**
+ * コピー成功
+ * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
+ * コピー元のファイル型データには 1 ファイル添付
+ * 他のファイルを削除する
+ * ファイル名を指定
+ */
+test('success - Same File type data - deleteOtherFiles - with name', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareSameConfigs(sourceFiles, true, 'qqq.txt', sourceFiles);
+
+    main();   
+
+    const files = engine.findData(sourceFileDef);
+    expect(files.size()).toEqual(1);
+    const file = files.get(0);
+    assertFile(file, 'qqq.txt', 'text/plain; charset=UTF-8');
+});
+
+
+
+]]></test>
+
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACx0lEQVRYR8WXz0sUYRjHP5O0CLX+
+        uHTIQ7sHIby0BdIh0EU6hwmd20Vx9mb9AUvlQQSRVhBq0WW3gxcFKzx4000kBKO2QNgSssgS6uDu
+        oQQJJt4ZZ3ecH+s4O+kLyy7s+z7fz/PM87zPMxKnvKRj6afpBbpRiCDRAkQOzhdQKCEhvvMkeOnW
+        7tEAWVrYZwi4B6qom1UCUgSYII747bhqAzwhxhkeH0PYLCTE48i8cCJwBnhKCkn13I+VQua+nSF7
+        gDQ54K4fyhUbCjkSxM02rQD+en5YT2GChJpLlXUYQHvmWV89txq7bcyJKoCW7Vt1JJxb7hIBwnp1
+        VAHSPAQeuLVSa99U1xTzW/Msflt02vYIWdXDCCBKptkPgI07GzQFmhhcGXSCKCHTWgXQbrjnRvGe
+        iz20nWvzxJO8lqS9uZ3t39u1INRc0CJgk/nCi47WDk8AxkOOEAcVoQGkyat3vGH5BbD3d4/RwijD
+        b4fNzrxCJqoDfAEuGXdMd03TeaHTUwRC50NqDgjx8Q/jJN8k7ewUkLmqAyielBwOieiFg+Fa4tpJ
+        GelIgODZIJnuDDt/dhh67a41rN5aZfnHspPnVWwDgOURiF1CPBvN0hvqJfcxx8DKgH+BUnhPgohj
+        EhrFG6QG1n6usVne9ASw9H2J3CfR3w4tQxLalOHszVn6wn0I8XpXppixRs9UhpaLaPLGJP2X+2ls
+        aKxXH1sAMFxE2l1guYqNEHOf51j4uuAJplgqsv5r3Xi2jKyNd0c2Ix1iZnPGzyS0aUZaOxbVYGlI
+        Y9fH2N3fZeTdiKcImA6VCRCytmOx61QHEh3zf45kUAm9LndyQyk8QyZmfoYnNZZbPK8dAf1fbVAR
+        V5jXSakMxLy9mOgQWnWIUVp83IIIYfFqlqrv1cz8wEREFKJIRFBoQeKKukU0FokSCgUk8rU8dp8D
+        flS8Cxv/AFp57iGwqv7bAAAAAElFTkSuQmCC
+    </icon>
+
+</service-task-definition>

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-12</last-modified>
+    <last-modified>2024-07-17</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -81,22 +81,22 @@ function main() {
   * ファイルをコピーする
   * @param {Qfile} sourceFiles コピー元ファイル
   * @param {String} filename 保存ファイル名
-  * @return {java.util.ArrayList<QfileView>} myFiles コピーファイルを追加した配列
+  * @return {java.util.ArrayList<QfileView>} files コピーファイルを追加した配列
   */
 function copyFiles(sourceFiles, fileName) {
 
-    let myFiles = new java.util.ArrayList();
+    const files = new java.util.ArrayList();
     for (let i = 0; i < sourceFiles.size(); i++) {
-	    let qfile;
+        let qfile;
         let sourceFilesInfo = sourceFiles.get(i);
         if (fileName !== "" && fileName !== null) {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFilesInfo.getContentType(), sourceFilesInfo);
         } else {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(sourceFilesInfo.getName(), sourceFilesInfo.getContentType(), sourceFilesInfo); //ファイルデータをそのまま複製保存する
         }
-        myFiles.add(qfile);
+        files.add(qfile);
     }
-    return myFiles;
+    return files;
 }
 
 ]]></script>

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-02</last-modified>
+    <last-modified>2024-07-05</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -51,23 +51,20 @@ function main() {
     const sourceFile = engine.findData(sourceFileDef);
     const copyToFile = engine.findData(copyToFileDef);
 
-    // コピー元のファイル型データに複数添付されている場合、エラー
-    if (sourceFile !== null && sourceFile.size() > 1) {
-        throw new Error("Attachment of multiple files can not be supported.");
-    }
     // コピー元のファイルがない場合
     if (sourceFile === null) {
         throw new Error('Source file is empty.');
     }
 
     let fileName = configs.get("conf_FileName");
-    if (fileName === "" || fileName === null) {
-        // コピー元ファイルの名前を取得する
-        fileName = sourceFile.get(0).getName();
+    if (fileName !== "" && fileName !== null) {
+        if (sourceFile !== null && sourceFile.size() > 1) {
+    // ファイル名が指定されていて、コピー元のファイル型データに複数添付されている場合、エラー
+            throw new Error("Attachment of multiple files can not be named.");
+        }
     }
 
-    // コピー元のファイル型データ項目にファイルが1つ添付されている場合
-    copyFile = copyFile(sourceFile, deleteOtherFiles, fileName);
+    copyFile = copyFile(sourceFile, deleteOtherFiles, sourceFile.size(), fileName);
 
     //// == ワークフローデータへの代入 / Data Updating ==
     engine.setData(copyToFileDef, copyFile);
@@ -77,9 +74,10 @@ function main() {
   * ファイルをコピーする
   * @param {Qfile} sourceFile コピー元ファイル
   * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
+  * @param {num} sourceFile.size() コピー元ファイル数
   * @param {String} filename 保存ファイル名
   */
-function copyFile(sourceFile, deleteOtherFiles, fileName) {
+function copyFile(sourceFile, deleteOtherFiles, num, fileName) {
     let myFiles;
     if (deleteOtherFiles === true) {
         myFiles = new java.util.ArrayList();
@@ -91,13 +89,36 @@ function copyFile(sourceFile, deleteOtherFiles, fileName) {
         }
     }
 
-    const qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFile.get(0).getContentType(), sourceFile.get(0)) //ファイルデータをそのまま複製保存する
-    myFiles.add(qfile);
-
+    let qfile;
+    for(let i = 0; i < num; i ++){
+        if(fileName !== "" && fileName !== null) {
+            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFile.get(i).getContentType(), sourceFile.get(i));
+        } else {
+            qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(sourceFile.get(i).getName(), sourceFile.get(i).getContentType(), sourceFile.get(i)); //ファイルデータをそのまま複製保存する
+        }
+        myFiles.add(qfile);
+    }
     return myFiles;
 }
 
 ]]></script>
+
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACx0lEQVRYR8WXz0sUYRjHP5O0CLX+
+        uHTIQ7sHIby0BdIh0EU6hwmd20Vx9mb9AUvlQQSRVhBq0WW3gxcFKzx4000kBKO2QNgSssgS6uDu
+        oQQJJt4ZZ3ecH+s4O+kLyy7s+z7fz/PM87zPMxKnvKRj6afpBbpRiCDRAkQOzhdQKCEhvvMkeOnW
+        7tEAWVrYZwi4B6qom1UCUgSYII747bhqAzwhxhkeH0PYLCTE48i8cCJwBnhKCkn13I+VQua+nSF7
+        gDQ54K4fyhUbCjkSxM02rQD+en5YT2GChJpLlXUYQHvmWV89txq7bcyJKoCW7Vt1JJxb7hIBwnp1
+        VAHSPAQeuLVSa99U1xTzW/Msflt02vYIWdXDCCBKptkPgI07GzQFmhhcGXSCKCHTWgXQbrjnRvGe
+        iz20nWvzxJO8lqS9uZ3t39u1INRc0CJgk/nCi47WDk8AxkOOEAcVoQGkyat3vGH5BbD3d4/RwijD
+        b4fNzrxCJqoDfAEuGXdMd03TeaHTUwRC50NqDgjx8Q/jJN8k7ewUkLmqAyielBwOieiFg+Fa4tpJ
+        GelIgODZIJnuDDt/dhh67a41rN5aZfnHspPnVWwDgOURiF1CPBvN0hvqJfcxx8DKgH+BUnhPgohj
+        EhrFG6QG1n6usVne9ASw9H2J3CfR3w4tQxLalOHszVn6wn0I8XpXppixRs9UhpaLaPLGJP2X+2ls
+        aKxXH1sAMFxE2l1guYqNEHOf51j4uuAJplgqsv5r3Xi2jKyNd0c2Ix1iZnPGzyS0aUZaOxbVYGlI
+        Y9fH2N3fZeTdiKcImA6VCRCytmOx61QHEh3zf45kUAm9LndyQyk8QyZmfoYnNZZbPK8dAf1fbVAR
+        V5jXSakMxLy9mOgQWnWIUVp83IIIYfFqlqrv1cz8wEREFKJIRFBoQeKKukU0FokSCgUk8rU8dp8D
+        flS8Cxv/AFp57iGwqv7bAAAAAElFTkSuQmCC
+    </icon>
 
     <test><![CDATA[
 /**
@@ -190,9 +211,10 @@ test('Source file is empty', () => {
 
 
 /**
- * コピー元にファイルが複数添付されている場合
+ * コピー元にファイルが複数添付されている
+ * ファイル名が設定されている
  */
-test('Attachment of multiple files can not be supported', () => {
+test('Attachment of multiple files can not be nameed', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
     sourceFiles.add(engine.createQfile('test.html', 'text/html; charset=UTF-8', '<html lang="ja"></html>'));
@@ -200,9 +222,9 @@ test('Attachment of multiple files can not be supported', () => {
     const {
         sourceFileDef,
         copyToFileDef
-    } = prepareConfigs(sourceFiles, true, '', null);
+    } = prepareConfigs(sourceFiles, true, 'test.txt', null);
 
-    assertError(main, 'Attachment of multiple files can not be supported.');
+    assertError(main, 'Attachment of multiple files can not be named.');
 });
 
 
@@ -225,7 +247,7 @@ const assertFile = (file, name, contentType) => {
  * ファイル名指定無し
  * コピー先のファイル型データには 2 ファイル添付
  */
-test('success - deleteOtherFiles - 2 attachments ', () => {
+test('success - 1file - deleteOtherFiles - 2 attachments ', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('test.pdf', 'application/pdf', 'test'));
 
@@ -254,7 +276,7 @@ test('success - deleteOtherFiles - 2 attachments ', () => {
  * ファイル名を指定
  * コピー先のファイル型データには 2 ファイル添付
  */
-test('success - 2 attachments - with name', () => {
+test('success - 1file - 2 attachments - with name', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
 
@@ -282,28 +304,66 @@ test('success - 2 attachments - with name', () => {
 
 /**
  * コピー成功
- * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
- * コピー元のファイル型データには 1 ファイル添付
+ * コピー元のファイル型データには 2 ファイル添付
  * 他のファイルを削除しない
  * ファイル名を指定しない
+ * コピー先のファイル型データには 1 ファイル添付
  */
-test('success - Same File type data ', () => {
+test('success - 2files - 1 attachment - with name', () => {
     let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
     sourceFiles.add(engine.createQfile('test.png', 'image/png', 'test\n'));
+
+    let copyToFiles = new java.util.ArrayList();
+    copyToFiles.add(engine.createQfile('事前ファイル.txt', 'text/plain; charset=UTF-8', '事前ファイル\n'));
 
     const {
         sourceFileDef,
         copyToFileDef
-    } = prepareSameConfigs(sourceFiles, false, 'qqq.png', sourceFiles);
+    } = prepareConfigs(sourceFiles, false, '', copyToFiles);
 
     main();   
 
-    const files = engine.findData(sourceFileDef);
-    expect(files.size()).toEqual(2);
+    const files = engine.findData(copyToFileDef);
+    expect(files.size()).toEqual(3);
+    let file = files.get(0);
+    assertFile(file, '事前ファイル.txt','text/plain; charset=UTF-8');
+    file = files.get(1);
+    assertFile(file, 'test.txt','text/plain; charset=UTF-8');
+    file = files.get(2);
+    assertFile(file, 'test.png','image/png');
+});
+
+
+/**
+ * コピー成功
+ * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
+ * コピー元のファイル型データには 2 ファイル添付
+ * 他のファイルを削除しない
+ * ファイル名を指定しない
+ */
+test('success - 2files - Same File type data ', () => {
+    let sourceFiles = new java.util.ArrayList();
+    sourceFiles.add(engine.createQfile('test.png', 'image/png', 'test\n'));
+    sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
+
+    const {
+        sourceFileDef,
+        copyToFileDef
+    } = prepareSameConfigs(sourceFiles, false, '', sourceFiles);
+
+    main();   
+
+    const files = engine.findData(copyToFileDef);
+    expect(files.size()).toEqual(4);
     let file = files.get(0);
     assertFile(file, 'test.png','image/png');
     file = files.get(1);
-    assertFile(file, 'qqq.png','image/png');
+    assertFile(file, 'test.txt', 'text/plain; charset=UTF-8');
+    file = files.get(2);
+    assertFile(file, 'test.png','image/png');
+    file = files.get(3);
+    assertFile(file, 'test.txt', 'text/plain; charset=UTF-8');
 });
 
 /**
@@ -313,7 +373,7 @@ test('success - Same File type data ', () => {
  * 他のファイルを削除する
  * ファイル名を指定
  */
-test('success - Same File type data - deleteOtherFiles - with name', () => {
+test('success - 1file - Same File type data - deleteOtherFiles - with name', () => {
     let sourceFiles = new java.util.ArrayList();
     sourceFiles.add(engine.createQfile('test.txt', 'text/plain; charset=UTF-8', 'test\n'));
 
@@ -324,7 +384,7 @@ test('success - Same File type data - deleteOtherFiles - with name', () => {
 
     main();   
 
-    const files = engine.findData(sourceFileDef);
+    const files = engine.findData(copyToFileDef);
     expect(files.size()).toEqual(1);
     const file = files.get(0);
     assertFile(file, 'qqq.txt', 'text/plain; charset=UTF-8');
@@ -334,21 +394,6 @@ test('success - Same File type data - deleteOtherFiles - with name', () => {
 
 ]]></test>
 
-    <icon>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACx0lEQVRYR8WXz0sUYRjHP5O0CLX+
-        uHTIQ7sHIby0BdIh0EU6hwmd20Vx9mb9AUvlQQSRVhBq0WW3gxcFKzx4000kBKO2QNgSssgS6uDu
-        oQQJJt4ZZ3ecH+s4O+kLyy7s+z7fz/PM87zPMxKnvKRj6afpBbpRiCDRAkQOzhdQKCEhvvMkeOnW
-        7tEAWVrYZwi4B6qom1UCUgSYII747bhqAzwhxhkeH0PYLCTE48i8cCJwBnhKCkn13I+VQua+nSF7
-        gDQ54K4fyhUbCjkSxM02rQD+en5YT2GChJpLlXUYQHvmWV89txq7bcyJKoCW7Vt1JJxb7hIBwnp1
-        VAHSPAQeuLVSa99U1xTzW/Msflt02vYIWdXDCCBKptkPgI07GzQFmhhcGXSCKCHTWgXQbrjnRvGe
-        iz20nWvzxJO8lqS9uZ3t39u1INRc0CJgk/nCi47WDk8AxkOOEAcVoQGkyat3vGH5BbD3d4/RwijD
-        b4fNzrxCJqoDfAEuGXdMd03TeaHTUwRC50NqDgjx8Q/jJN8k7ewUkLmqAyielBwOieiFg+Fa4tpJ
-        GelIgODZIJnuDDt/dhh67a41rN5aZfnHspPnVWwDgOURiF1CPBvN0hvqJfcxx8DKgH+BUnhPgohj
-        EhrFG6QG1n6usVne9ASw9H2J3CfR3w4tQxLalOHszVn6wn0I8XpXppixRs9UhpaLaPLGJP2X+2ls
-        aKxXH1sAMFxE2l1guYqNEHOf51j4uuAJplgqsv5r3Xi2jKyNd0c2Ix1iZnPGzyS0aUZaOxbVYGlI
-        Y9fH2N3fZeTdiKcImA6VCRCytmOx61QHEh3zf45kUAm9LndyQyk8QyZmfoYnNZZbPK8dAf1fbVAR
-        V5jXSakMxLy9mOgQWnWIUVp83IIIYfFqlqrv1cz8wEREFKJIRFBoQeKKukU0FokSCgUk8rU8dp8D
-        flS8Cxv/AFp57iGwqv7bAAAAAElFTkSuQmCC
-    </icon>
+
 
 </service-task-definition>

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-11</last-modified>
+    <last-modified>2024-07-12</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -65,14 +65,13 @@ function main() {
         }
     }
 
-    let myFiles = new java.util.ArrayList();
-    if (deleteOtherFiles === false) {
-        if (destinationFiles !== null) {
-            myFiles.addAll(destinationFiles);
-        }
-    }
+    // コピー元データ項目にあるファイルをコピー
+    const newFiles = copyFiles(sourceFiles, fileName);
 
-    const newFiles = copyFile(sourceFiles, fileName, myFiles);
+    if (deleteOtherFiles === false && destinationFiles !== null) {
+        // コピー先データ項目に元からあるファイルを残す場合、リストに、残すファイルを追加する
+        newFiles.addAll(0, destinationFiles); //「先にコピー前から存在するファイル、後にコピーされたファイル」の順番
+    }
 
     //// == ワークフローデータへの代入 / Data Updating ==
     engine.setData(destinationFileDef, newFiles);
@@ -82,13 +81,13 @@ function main() {
   * ファイルをコピーする
   * @param {Qfile} sourceFiles コピー元ファイル
   * @param {String} filename 保存ファイル名
-  * @param {java.util.ArrayList<QfileView>} myFiles （ワークフローデータから取得した）ファイル型データの配列
   * @return {java.util.ArrayList<QfileView>} myFiles コピーファイルを追加した配列
   */
-function copyFile(sourceFiles, fileName, myFiles) {
+function copyFiles(sourceFiles, fileName) {
 
-    let qfile;
+    let myFiles = new java.util.ArrayList();
     for (let i = 0; i < sourceFiles.size(); i++) {
+	    let qfile;
         let sourceFilesInfo = sourceFiles.get(i);
         if (fileName !== "" && fileName !== null) {
             qfile = new com.questetra.bpms.core.event.scripttask.NewQfile(fileName, sourceFilesInfo.getContentType(), sourceFilesInfo);

--- a/converter-file-copy.xml
+++ b/converter-file-copy.xml
@@ -4,7 +4,7 @@
     <label>Converter (Copy File)</label>
     <label locale="ja">コンバータ（ファイルコピー）</label>
 
-    <last-modified>2024-07-08</last-modified>
+    <last-modified>2024-07-09</last-modified>
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-converter-file-copy/
     </help-page-url>
     <help-page-url locale="ja">
@@ -49,6 +49,7 @@ function main() {
 
     const deleteOtherFiles = configs.getObject("conf_DeleteOtherFiles");
     const sourceFiles = engine.findData(sourceFileDef);
+    const copyToFile = engine.findData(copyToFileDef);
 
     // コピー元のファイルがない場合
     if (sourceFiles === null) {
@@ -63,7 +64,7 @@ function main() {
         }
     }
 
-    copyFiles = copyFile(sourceFiles, deleteOtherFiles, sourceFiles.size(), fileName);
+    copyFiles = copyFile(sourceFiles, deleteOtherFiles, sourceFiles.size(), fileName, copyToFile);
 
     //// == ワークフローデータへの代入 / Data Updating ==
     engine.setData(copyToFileDef, copyFiles);
@@ -75,14 +76,15 @@ function main() {
   * @param {boolean} deleteOtherFiles 保存時に他のファイルを削除するかどうか
   * @param {String} num コピー元ファイル数
   * @param {String} filename 保存ファイル名
+  * @param {Qfile} copyToFile コピー先ファイル
   */
-function copyFile(sourceFiles, deleteOtherFiles, num, fileName) {
+function copyFile(sourceFiles, deleteOtherFiles, num, fileName, copyToFile) {
     let myFiles;
     if (deleteOtherFiles === true) {
         myFiles = new java.util.ArrayList();
     } else {
         // ワークフローデータからファイル型データの配列を取得
-        myFiles = engine.findData(configs.getObject("conf_CopyToFileDataId"));
+        myFiles = copyToFile;
         if (myFiles === null) {
             myFiles = new java.util.ArrayList();
         }


### PR DESCRIPTION
@hatanaka-akihiro  さん

テストコードについて教えてください。

最後のテストケース　success - Same File type data - deleteOtherFiles - with name　について
 * コピー成功
 * コピー元のファイル型データ項目とコピー先のファイル型データ項目が同一
 * コピー元のファイル型データには 1 ファイル添付
 * 他のファイルを削除する
 * ファイル名を指定
 
ビルドが失敗します。ファイル名を指定していますが、ファイル名が変更されていないというエラーが出ます。
expected:<[qqq].txt> but was:<[test].txt>
もともと、test.txt　の名前のファイルを、別名 qqq.txt にするテストなのですが、上記のエラーになります。

テストの書き方、設定の準備の書き方で、よくないところがあったら教えてください。