### PR TITLE
t10470 DeepL: テキスト翻訳　認証キーを URL クエリに含めないように

### DIFF
--- a/deepl-text-translate.xml
+++ b/deepl-text-translate.xml
@@ -2,7 +2,7 @@
 <service-task-definition>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
-    <last-modified>2023-08-07</last-modified>
+    <last-modified>2025-01-16</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <label>DeepL: Translate Text</label>
     <label locale="ja">DeepL: テキスト翻訳</label>
@@ -101,7 +101,7 @@ const main = () => {
     const sourceLangCode = configs.get('conf_SourceLangCode'); // NotRequired
     const sourceText = configs.get('conf_SourceText'); /// REQUIRED
     if (sourceText === '') {
-        throw 'Source Text is empty.';
+        throw new Error('Source Text is empty.');
     }
     const sourceFormat = configs.get('conf_SourceFormat'); /// REQUIRED
     const targetLangCode = configs.get('conf_TargetLangCode'); /// REQUIRED
@@ -132,14 +132,14 @@ const translate = (authSetting, sourceLangCode, sourceText, sourceFormat, target
     const url = decideUrl(authKey);
     const body = buildBody(sourceLangCode, sourceText, sourceFormat, targetLangCode, formality);
     const response = httpClient.begin() // HttpRequestWrapper
-        .queryParam('auth_key', authKey)
+        .authorization("DeepL-Auth-Key", authKey)
         .body(body, 'application/json')
         .post(url); // HttpResponseWrapper
     const status = response.getStatusCode();
     const responseStr = response.getResponseAsString();
     if (status !== 200) {
         engine.log(responseStr);
-        throw `Failed to translate. status: ${status}`;
+        throw new Error(`Failed to translate. status: ${status}`);
     }
     const responseObj = JSON.parse(responseStr);
     const detectedSourceLangCode = responseObj.translations[0].detected_source_language;
@@ -244,15 +244,18 @@ const prepareConfigs = (authKey, sourceLangCode, sourceText, sourceFormat, targe
 
 /**
  * 異常系のテスト
- * @param func
  * @param errorMsg
  */
-const assertError = (func, errorMsg) => {
+const assertError = (errorMsg) => {
+    let failed = false;
     try {
-        func();
-        fail();
+        main();
     } catch (e) {
-        expect(e.toString()).toEqual(errorMsg);
+        failed = true;
+        expect(e.message).toEqual(errorMsg);
+    }
+    if (!failed) {
+        fail('No error was thrown.');
     }
 };
 
@@ -261,7 +264,7 @@ const assertError = (func, errorMsg) => {
  */
 test('Source Text is empty', () => {
     prepareConfigs(AUTH_KEY_PRO, 'EN', '', 'text', 'JA', '');
-    assertError(main, 'Source Text is empty.');
+    assertError('Source Text is empty.');
 });
 
 /**
@@ -280,7 +283,7 @@ test('Source Text is empty', () => {
  * @param {String} formality
  */
 const assertRequest = ({url, method, contentType, body}, expectedUrl, authKey, sourceLangCode, sourceText, tagHandling, targetLangCode, formality) => {
-    expect(url).toEqual(`${expectedUrl}?auth_key=${encodeURIComponent(authKey)}`);
+    expect(url).toEqual(`${expectedUrl}`);
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     const bodyObj = JSON.parse(body);
@@ -307,7 +310,7 @@ test('Fail to translate', () => {
         assertRequest(request, API_URL_PRO, AUTH_KEY_PRO, 'EN', 'Hello.', null, 'JA', null);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
-    assertError(main, 'Failed to translate. status: 400');
+    assertError('Failed to translate. status: 400');
 });
 
 /**

--- a/deepl-text-translate.xml
+++ b/deepl-text-translate.xml
@@ -274,6 +274,7 @@ test('Source Text is empty', () => {
  * @param request.method
  * @param request.contentType
  * @param request.body
+ * @param request.headers
  * @param {String} expectedUrl
  * @param {String} authKey
  * @param {String} sourceLangCode
@@ -282,8 +283,9 @@ test('Source Text is empty', () => {
  * @param {String} targetLangCode
  * @param {String} formality
  */
-const assertRequest = ({url, method, contentType, body}, expectedUrl, authKey, sourceLangCode, sourceText, tagHandling, targetLangCode, formality) => {
+const assertRequest = ({url, method, contentType, body, headers}, expectedUrl, authKey, sourceLangCode, sourceText, tagHandling, targetLangCode, formality) => {
     expect(url).toEqual(`${expectedUrl}`);
+    expect(headers.Authorization).toEqual(`DeepL-Auth-Key ${authKey}`);
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     const bodyObj = JSON.parse(body);


### PR DESCRIPTION
@hatanaka-akihiro  さん

レビューをお願いします。
異常系のテストコードについても修正しました。