### PR TITLE
t10226 他 Amazon Bedrock: Anthropic Claude: チャット

### DIFF
--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-01-03</last-modified>
+    <last-modified>2025-01-30</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -74,7 +74,7 @@
             <label>I1: Images to attach to user message</label>
             <label locale="ja">I1: ユーザメッセージに添付する画像</label>
         </config>
-        <config name="conf_Pdfs1" required="false" form-type="SELECT"
+        <config name="conf_Docs1" required="false" form-type="SELECT"
                 select-data-type="FILE">
             <label>D1: PDFs to attach to user message</label>
             <label locale="ja">D1: ユーザメッセージに添付する PDF</label>
@@ -231,7 +231,7 @@ const retrieveUserMessage = () => {
         throw new Error('User Message is empty.');
     }
     const inlineImages = retrieveImages();
-    const inlinePdfs = retrievePdfs();
+    const inlineDocs = retrieveDocs();
     const userMessage = {
         role: 'user',
         content: [
@@ -239,7 +239,7 @@ const retrieveUserMessage = () => {
                 text: message
             },
             ...inlineImages,
-            ...inlinePdfs
+            ...inlineDocs
         ]
     };
     return userMessage;
@@ -247,7 +247,7 @@ const retrieveUserMessage = () => {
 };
 
 const MAX_IMAGE_NUM = 20; // Messages API の制限。1 ユーザメッセージにつき添付画像 20 個まで
-const MAX_IMAGE_SIZE = 3032160; // Messages API の制限。1 ファイルにつき 3.75 MB まで
+const MAX_IMAGE_SIZE = 3932160; // Messages API の制限。1 ファイルにつき 3.75 MB まで
 const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
 /**
@@ -300,8 +300,8 @@ const retrieveImages = () => {
 };
 
 
-const MAX_PDF_NUM = 5; // Messages API の制限。1 ユーザメッセージにつき PDF 5 個まで
-const MAX_PDF_SIZE = 4718592; // Messages API の制限。1 ファイルにつき 4.5 MB まで
+const MAX_DOC_NUM = 5; // Messages API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_DOC_SIZE = 4718592; // Messages API の制限。1 ファイルにつき 4.5 MB まで
 const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
 
 /**
@@ -312,45 +312,50 @@ const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
  * - Content-Type が許可されていない場合
  * @returns {Array<Object>} PDF オブジェクトの配列
  */
-const retrievePdfs = () => {
-    const pdfsDef = configs.getObject('conf_Pdfs1');
-    if (pdfsDef === null) {
+const retrieveDocs = () => {
+    const docsDef = configs.getObject('conf_Docs1');
+    if (docsDef === null) {
         return [];
     }
-    const pdfs = engine.findData(pdfsDef);
-    if (pdfs === null) {
+    const docs = engine.findData(docsDef);
+    if (docs === null) {
         return [];
     }
-    if (pdfs.size() > MAX_PDF_NUM) {
-        throw new Error(`Too many PDFs attached. The maximum number is ${MAX_PDF_NUM}.`);
+    if (docs.size() > MAX_DOC_NUM) {
+        throw new Error(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
     }
 
-    const inlinePdfs = [];
-    pdfs.forEach( (pdf, index ) => {
+    const inlineDocs = [];
 
-        if (pdf.getLength() > MAX_PDF_SIZE) {
-            throw new Error(`Attached file "${pdf.getName()}" is too large. The maximum size is ${MAX_PDF_SIZE} bytes.`);
+    let index = 0;
+
+    docs.forEach( doc => {
+
+        if (doc.getLength() > MAX_DOC_SIZE) {
+            throw new Error(`Attached file "${doc.getName()}" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
         }
 
-        const contentType = pdf.getContentType().split(';')[0];
+        const contentType = doc.getContentType().split(';')[0];
         if (!ALLOWED_DOCUMENT_TYPE.includes(contentType)) {
-            throw new Error(`Content-Type of the attached file "${pdf.getName()}" is not allowed.`);
+            throw new Error(`Content-Type of the attached file "${doc.getName()}" is not allowed.`);
         }
 
         const format = contentType.split('/')[1];
 
-        const inlinePdf = {
+        const inlineDoc = {
             document: {
                 format,
-                name: `PDF${index}`,
+                name: `DOC${index}`,
                 source: {
-                    bytes: base64.encodeToString(fileRepository.readFile(pdf))
+                    bytes: base64.encodeToString(fileRepository.readFile(doc))
                 }
             }
         };
-        inlinePdfs.push(inlinePdf);
+        inlineDocs.push(inlineDoc);
+
+        index++;
     });
-    return inlinePdfs;
+    return inlineDocs;
 };
 
 /**
@@ -382,7 +387,7 @@ const invokeModel = (awsKey, awsSecret, region, model, maxTokens, temperature, s
     if (systemPrompt !== '') {
         Object.assign(payload, {
             system: [
-            {text :`${systemPrompt}`}
+                {text :`${systemPrompt}`}
             ]
         });
     }
@@ -501,11 +506,12 @@ const assertError = (errorMsg) => {
     }
 };
 
-const MODEL_2 = 'anthropic.claude-v2';
-const MODEL_2_1 = 'anthropic.claude-v2:1';
+const MODEL_3_OPUS = 'anthropic.claude-3-opus-20240229-v1:0';
+const MODEL_3_HAIKU = 'anthropic.claude-3-haiku-20240307-v1:0';
 const MODEL_3_SONNET = 'anthropic.claude-3-sonnet-20240229-v1:0';
 const MODEL_3_5_SONNET_V2 = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
 const MODEL_3_5_HAIKU = 'anthropic.claude-3-5-haiku-20241022-v1:0';
+
 
 /**
  * リージョンコードの形式が不正 - ハイフンを含まない
@@ -514,7 +520,7 @@ test('Region Code is invalid - no hyphens', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'invalidregioncode';
-    prepareConfigs(key, secret, region, MODEL_2, false, '', '', '', '', 'Hi. How are you?');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, '', '', '', '', 'Hi. How are you?');
 
     assertError('Region Code is invalid.');
 });
@@ -526,7 +532,7 @@ test('Region Code is invalid - too many characters', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'eu-toomanycharacters-1';
-    prepareConfigs(key, secret, region, MODEL_2, false, '', '', '', '', 'Hi. How are you?');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, '', '', '', '', 'Hi. How are you?');
 
     assertError('Region Code is invalid.');
 });
@@ -562,7 +568,7 @@ test('Region is not supported by cross-region inference', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'ca-sentral-1';
-    prepareConfigs(key, secret, region, MODEL_2, true, '1280', '', '', '', 'Hi. How are you?');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, true, '1280', '', '', '', 'Hi. How are you?');
 
     assertError('Cross-region inference is not supported in ca-sentral-1.');
 });
@@ -574,7 +580,7 @@ test('Maximum number of tokens must be a positive integer - includes a non-numer
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'us-east-1';
-    prepareConfigs(key, secret, region, MODEL_2, false, '1.1', '', '', '', 'Hi. How are you?');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, '1.1', '', '', '', 'Hi. How are you?');
 
     assertError('Maximum number of tokens must be a positive integer.');
 });
@@ -586,7 +592,7 @@ test('Maximum number of tokens must be a positive integer - 0', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'us-east-1';
-    prepareConfigs(key, secret, region, MODEL_2, false, '0', '', '', '', 'Hi. How are you?');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, '0', '', '', '', 'Hi. How are you?');
 
     assertError('Maximum number of tokens must be a positive integer.');
 });
@@ -601,7 +607,7 @@ test('Invalid temperature - includes a non-numeric character', () => {
     const maxTokens = '100';
     const temperature = '-0.1';
     const message = 'Hi. How are you?';
-    prepareConfigs(key, secret, region, MODEL_2, false, maxTokens, temperature, '', message);
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, maxTokens, temperature, '', message);
 
     assertError('Temperature must be a number from 0 to 1.');
 });
@@ -616,7 +622,7 @@ test('Invalid temperature - bigger than 1', () => {
     const maxTokens = '100';
     const temperature = '1.1';
     const message = 'Hi. How are you?';
-    prepareConfigs(key, secret, region, MODEL_2, false, maxTokens, temperature, '', message);
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, maxTokens, temperature, '', message);
 
     assertError('Temperature must be a number from 0 to 1.');
 });
@@ -632,7 +638,7 @@ test('Too many stop sequences', () => {
     const temperature = '1.0';
     const stopSequences = 'a\n'.repeat(MAX_STOP_SEQUENCES_NUM + 1);
     const message = 'Hi. How are you?';
-    prepareConfigs(key, secret, region, MODEL_2, false, maxTokens, temperature, stopSequences, message);
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, maxTokens, temperature, stopSequences, message);
 
     assertError(`Too many stop sequences. The maximum number is ${MAX_STOP_SEQUENCES_NUM}.`);
 });
@@ -644,7 +650,7 @@ test('Message is empty', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'us-east-1';
-    prepareConfigs(key, secret, region, MODEL_2, false, '1280', '', '', '', '');
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, false, '1280', '', '', '', '');
 
     assertError('User Message is empty.');
 });
@@ -684,16 +690,26 @@ const attachImages = (images) => {
 };
 
 /**
- * 添付ファイルの数が多すぎる
+ * PDF を添付
+ * @param {Array<Qfile>} docs
  */
-test('Too many files attached', () => {
+const attachDocs = (docs) => {
+    const docsDef = engine.createDataDefinition('添付 PDF', 3, 'q_docs', 'FILE');
+    engine.setData(docsDef, docs);
+    configs.putObject('conf_Docs1', docsDef);
+};
+
+/**
+ * 添付画像ファイルの数が多すぎる
+ */
+test('Too many images attached', () => {
     const key = 'key-12345';
     const secret = 'secret-67890';
     const region = 'us-east-1';
     const message = 'Describe each image attached.';
-    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', message);
+    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', '', message);
 
-    // 添付ファイルを指定
+    // 添付画像ファイルを指定
     const images = [];
     for (let i = 0; i < MAX_IMAGE_NUM + 1; i++) {
         images.push(createQfile(`画像${i}.png`, 'image/png', 100));
@@ -704,6 +720,26 @@ test('Too many files attached', () => {
 });
 
 /**
+ * 添付 PDF ファイルの数が多すぎる
+ */
+test('Too many pdfs attached', () => {
+    const key = 'key-12345';
+    const secret = 'secret-67890';
+    const region = 'us-east-1';
+    const message = 'Describe each image attached.';
+    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', '', message);
+
+    // 添付 PDF ファイルを指定
+    const docs = [];
+    for (let i = 0; i < MAX_DOC_NUM + 1; i++) {
+        docs.push(createQfile(`DOC${i}.pdf`, 'application/pdf', 100));
+    }
+    attachDocs(docs);
+
+    assertError(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
+});
+
+/**
  * 添付ファイルのサイズが大きすぎる
  */
 test('Attached image is too large', () => {
@@ -711,7 +747,7 @@ test('Attached image is too large', () => {
     const secret = 'secret-67890';
     const region = 'us-east-1';
     const message = 'Describe each image attached.';
-    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', message);
+    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', '', message);
 
     // 添付ファイルを指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
@@ -729,7 +765,7 @@ test('Content-Type of an attached file is not allowed', () => {
     const secret = 'secret-67890';
     const region = 'us-east-1';
     const message = 'Describe each image attached.';
-    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', message);
+    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', '', message);
 
     // 添付ファイルを指定
     const image1 = createQfile('画像1.png', 'image/png;filename="画像1.png"', 100);
@@ -757,32 +793,36 @@ test('Content-Type of an attached file is not allowed', () => {
  * @param {String} systemPrompt
  * @param {String} message
  * @param {Array<Qfile>} images
+ * @param {Array<Qfile>} docs
  */
 const assertRequest = ({
                            url,
                            method,
                            contentType,
                            body
-                       }, region, model, maxTokens, temperature, stopSequences, systemPrompt, message, images = []) => {
+                       }, region, model, maxTokens, temperature, stopSequences, systemPrompt, message, images = [], docs = []) => {
     expect(url).toEqual(`https://bedrock-runtime.${region}.amazonaws.com/model/${model}/converse`);
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     // Authorization ヘッダのテストは省略
     const bodyObj = JSON.parse(body);
     expect(bodyObj.anthropic_version).toEqual(ANTHROPIC_VERSION);
-    expect(bodyObj.max_tokens).toEqual(maxTokens);
-    expect(bodyObj.temperature).toEqual(temperature);
-    expect(bodyObj.stop_sequences).toEqual(stopSequences);
-    expect(bodyObj.system).toEqual(systemPrompt);
+    expect(bodyObj.inferenceConfig.maxTokens).toEqual(maxTokens);
+    expect(bodyObj.inferenceConfig.temperature).toEqual(temperature);
+    expect(bodyObj.inferenceConfig.stopSequences).toEqual(stopSequences);
+    if (systemPrompt !== ''){
+        expect(bodyObj.system[0].text).toEqual(systemPrompt);
+    }
     expect(bodyObj.messages[0].role).toEqual('user');
-    expect(bodyObj.messages[0].content[0].type).toEqual('text');
     expect(bodyObj.messages[0].content[0].text).toEqual(message);
-    expect(bodyObj.messages[0].content.length).toEqual(images.length + 1);
+    expect(bodyObj.messages[0].content.length).toEqual(images.length + docs.length + 1);
     images.forEach((image, i) => {
-        expect(bodyObj.messages[0].content[i + 1].type).toEqual('image');
-        expect(bodyObj.messages[0].content[i + 1].source.type).toEqual('base64');
-        expect(bodyObj.messages[0].content[i + 1].source.media_type).toEqual(image.getContentType().split(';')[0]);
-        expect(bodyObj.messages[0].content[i + 1].source.data).toEqual(base64.encodeToString(fileRepository.readFile(image)));
+        expect(bodyObj.messages[0].content[i + 1].image.format).toEqual(image.getContentType().split(';')[0].split('/')[1]);
+        expect(bodyObj.messages[0].content[i + 1].image.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(image)));
+    });
+    docs.forEach((doc, i) => {
+        expect(bodyObj.messages[0].content[i + images.length + 1].document.format).toEqual(doc.getContentType().split(';')[0].split('/')[1]);
+        expect(bodyObj.messages[0].content[i + images.length + 1].document.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(doc)));
     });
 };
 
@@ -798,10 +838,10 @@ test('Fail to request', () => {
     const temperature = '';
     const stopSequences = '';
     const message = 'Hi. How are you?';
-    prepareConfigs(key, secret, region, MODEL_2, true, '1280', temperature, stopSequences, '', message);
+    prepareConfigs(key, secret, region, MODEL_3_OPUS, true, '1280', temperature, stopSequences, '', message);
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, 'apac.anthropic.claude-v2', 1280, 1, [], '', message);
+        assertRequest(request, region, 'apac.anthropic.claude-3-opus-20240229-v1:0', 1280, 1, [], '', message);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to invoke model. status: 400');
@@ -817,15 +857,16 @@ const createResponse = (model, answerText) => {
     const responseObj = {
         model,
         stop_reason: 'end_turn',
-        content: [
-            {
-                type: 'text',
-                text: answerText
+        output: {
+            message:{
+                content: [
+                    {text: answerText}
+                ]
             }
-        ],
+        },
         usage: {
-            input_tokens: 1024,
-            output_tokens: 2048
+            inputTokens: 1024,
+            outputTokens: 2048
         }
     };
     return JSON.stringify(responseObj);
@@ -844,12 +885,12 @@ test('Success - only with required configs', () => {
     const temperature = '';
     const stopSequences = '';
     const message = 'Hi. How are you?';
-    const answerDef = prepareConfigs(key, secret, region, MODEL_2_1, false, maxTokens, temperature, stopSequences, '', message);
+    const answerDef = prepareConfigs(key, secret, region, MODEL_3_HAIKU, false, maxTokens, temperature, stopSequences, '', message);
 
     const answer = 'Fine, thanks.';
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, MODEL_2_1, MAX_TOKENS_DEFAULT, 1, [], '', message);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_2_1, answer));
+        assertRequest(request, region, MODEL_3_HAIKU, MAX_TOKENS_DEFAULT, 1, [], '', message);
+        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_3_HAIKU, answer));
     });
 
     expect(main()).toEqual(undefined);
@@ -899,12 +940,12 @@ test('Success - with max tokens and temperature', () => {
     const temperature = '0.5';
     const stopSequences = '';
     const message = 'Are you a robot?\n\nHow old are you?';
-    const answerDef = prepareConfigs(key, secret, region, MODEL_2, false, maxTokens, temperature, stopSequences, '', message);
+    const answerDef = prepareConfigs(key, secret, region, MODEL_3_OPUS, false, maxTokens, temperature, stopSequences, '', message);
 
     const answer = "Yes, I'm an AI assistant created by Anthropic.\n\nI don't have an age.";
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, MODEL_2, 500, 0.5, [], '', message);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_2, answer));
+        assertRequest(request, region, MODEL_3_OPUS, 500, 0.5, [], '', message);
+        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_3_OPUS, answer));
     });
 
     expect(main()).toEqual(undefined);
@@ -924,13 +965,13 @@ test('Success - with temperature, stop sequences and system prompt, empty attach
     const stopSequences = 'さようなら\nありがとう\nおやすみなさい';
     const systemPrompt = "You are a translator. Translate the user's input into Japanese.";
     const message = 'Hi. How are you?';
-    const answerDef = prepareConfigs(key, secret, region, MODEL_3_SONNET, false, maxTokens, temperature, stopSequences, systemPrompt, message);
+    const answerDef = prepareConfigs(key, secret, region, MODEL_3_5_SONNET_V2, false, maxTokens, temperature, stopSequences, systemPrompt, message);
     attachImages([]);
 
     const answer = 'こんにちは。お元気ですか？';
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, MODEL_3_SONNET, MAX_TOKENS_DEFAULT, 0, ['さようなら', 'ありがとう', 'おやすみなさい'], systemPrompt, message);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_3_SONNET, answer));
+        assertRequest(request, region, MODEL_3_5_SONNET_V2, MAX_TOKENS_DEFAULT, 0, ['さようなら', 'ありがとう', 'おやすみなさい'], systemPrompt, message);
+        return httpClient.createHttpResponse(200, 'application/json', createResponse(MODEL_3_5_SONNET_V2, answer));
     });
 
     expect(main()).toEqual(undefined);
@@ -938,11 +979,11 @@ test('Success - with temperature, stop sequences and system prompt, empty attach
 });
 
 /**
- * 成功 - 添付画像を最大個数指定
+ * 成功 - 添付画像を最大個数指定 添付 PDF を最大個数指定
  * クロスリージョン推論を利用する
  * 回答を保存するデータ項目に、文字型 Markdown を指定
  */
-test('Success - with attached images - CrossRegionModel - Markdown', () => {
+test('Success - with attached images and pdfs - CrossRegionModel - Markdown', () => {
     const key = 'key-54321';
     const secret = 'secret-99999';
     const region = 'ap-northeast-1';
@@ -957,7 +998,7 @@ test('Success - with attached images - CrossRegionModel - Markdown', () => {
     engine.setData(answerDef, '事前文字列');
     configs.putObject('conf_Answer1', answerDef);
 
-    // 添付ファイルを指定
+    // 添付画像を指定
     const images = [];
     for (let i = 0; i < MAX_IMAGE_NUM - 1; i++) {
         images.push(createQfile(`画像${i}.png`, ALLOWED_MEDIA_TYPES[i % 4], 100));
@@ -965,9 +1006,18 @@ test('Success - with attached images - CrossRegionModel - Markdown', () => {
     images.push(createQfile('最大サイズの画像.jpg', 'image/jpeg;filename="最大サイズの画像.jpg"', MAX_IMAGE_SIZE));
     attachImages(images);
 
+    // 添付 PDF を指定
+    const docs = [];
+    for (let i = 0; i < MAX_DOC_NUM - 1; i++) {
+        docs.push(createQfile(`PDF${i}.pdf`, ALLOWED_DOCUMENT_TYPE, 100));
+    }
+    docs.push(createQfile('最大サイズのPDF.pdf', 'application/pdf;filename="最大サイズのPDF.pdf"', MAX_DOC_SIZE));
+    attachDocs(docs);
+
+
     const answer = 'The 1st image shows a cat. The 2nd image shows a dog.';
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, `apac.${MODEL_3_SONNET}`, MAX_TOKENS_DEFAULT, 1, [], '', message, images);
+        assertRequest(request, region, `apac.${MODEL_3_SONNET}`, MAX_TOKENS_DEFAULT, 1, [], '', message, images, docs);
         return httpClient.createHttpResponse(200, 'application/json', createResponse(`apac.${MODEL_3_SONNET}`, answer));
     });
 

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-01-30</last-modified>
+    <last-modified>2025-01-31</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -110,7 +110,7 @@ function main() {
     const userMessage = retrieveUserMessage(); // 添付画像の取得も含む
 
     ////// == 演算 / Calculating ==
-    const answer = invokeModel(awsKey, awsSecret, region, model, maxTokens, temperature, stopSequences, systemPrompt, userMessage);
+    const answer = converse(awsKey, awsSecret, region, model, maxTokens, temperature, stopSequences, systemPrompt, userMessage);
 
     ////// == ワークフローデータへの代入 / Data Updating ==
     saveData('conf_Answer1', answer);
@@ -230,8 +230,8 @@ const retrieveUserMessage = () => {
     if (message === '') {
         throw new Error('User Message is empty.');
     }
-    const inlineImages = retrieveImages();
-    const inlineDocs = retrieveDocs();
+    const inlineImages = retrieveFiles("conf_Images1");
+    const inlineDocs = retrieveFiles("conf_Docs1");
     const userMessage = {
         role: 'user',
         content: [
@@ -246,117 +246,100 @@ const retrieveUserMessage = () => {
 	
 };
 
-const MAX_IMAGE_NUM = 20; // Messages API の制限。1 ユーザメッセージにつき添付画像 20 個まで
-const MAX_IMAGE_SIZE = 3932160; // Messages API の制限。1 ファイルにつき 3.75 MB まで
+const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
+const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
 const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
+const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
 
 /**
- * config から画像を読み出す
+ * config からファイルを読み出す
  * 以下の場合はエラー
  * - 添付ファイルの総数が多すぎる場合
  * - ファイルサイズが大きすぎる場合
  * - Content-Type が許可されていない場合
  * @returns {Array<Object>} 画像オブジェクトの配列
  */
-const retrieveImages = () => {
-    const imagesDef = configs.getObject('conf_Images1');
-    if (imagesDef === null) {
+const retrieveFiles = (configName) => {
+    const filesDef = configs.getObject(configName);
+    if (filesDef === null) {
         return [];
     }
-    const images = engine.findData(imagesDef);
-    if (images === null) {
+    const files = engine.findData(filesDef);
+    if (files === null) {
         return [];
     }
-    if (images.size() > MAX_IMAGE_NUM) {
-        throw new Error(`Too many images attached. The maximum number is ${MAX_IMAGE_NUM}.`);
-    }
 
-    const inlineImages = [];
-    images.forEach(image => {
+    const inlineFiles = [];
 
-        if (image.getLength() > MAX_IMAGE_SIZE) {
-            throw new Error(`Attached file "${image.getName()}" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
+    if (configName === "conf_Images1"){
+        if (files.size() > MAX_IMAGE_NUM) {
+            throw new Error(`Too many images attached. The maximum number is ${MAX_IMAGE_NUM}.`);
         }
 
-        const contentType = image.getContentType().split(';')[0];
-        if (!ALLOWED_MEDIA_TYPES.includes(contentType)) {
-            throw new Error(`Content-Type of the attached file "${image.getName()}" is not allowed.`);
-        }
+        
+        files.forEach(file => {
 
-        const format = contentType.split('/')[1];
-
-        const inlineImage = {
-            image: {
-                format,
-                source: {
-                    bytes: base64.encodeToString(fileRepository.readFile(image))
-                }
+            if (file.getLength() > MAX_IMAGE_SIZE) {
+                throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
             }
-        };
 
-        inlineImages.push(inlineImage);
-    });
-    return inlineImages;
+            const contentType = file.getContentType().split(';')[0];
+            if (!ALLOWED_MEDIA_TYPES.includes(contentType)) {
+                throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
+            }
+            const format = contentType.split('/')[1];
+
+            const inlineFile = {
+                image: {
+                    format,
+                    source: {
+                        bytes: base64.encodeToString(fileRepository.readFile(file))
+                    }
+                }
+            };
+
+            inlineFiles.push(inlineFile);
+        });
+    } else {
+        if (files.size() > MAX_DOC_NUM) {
+            throw new Error(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
+        }
+
+        let index = 0;
+
+        files.forEach( file => {
+
+            if (file.getLength() > MAX_DOC_SIZE) {
+                throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
+            }
+
+            const contentType = file.getContentType().split(';')[0];
+            if (!ALLOWED_DOCUMENT_TYPE.includes(contentType)) {
+                throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
+            }
+
+            const format = contentType.split('/')[1];
+
+            const inlineFile = {
+                document: {
+                    format,
+                    name: `DOC${index}`,
+                    source: {
+                        bytes: base64.encodeToString(fileRepository.readFile(file))
+                    }
+                }
+            };
+            inlineFiles.push(inlineFile);
+
+            index++;
+        });
+    }
+
+    return inlineFiles;
 };
 
-
-const MAX_DOC_NUM = 5; // Messages API の制限。1 ユーザメッセージにつき PDF 5 個まで
-const MAX_DOC_SIZE = 4718592; // Messages API の制限。1 ファイルにつき 4.5 MB まで
-const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
-
-/**
- * config から PDF を読み出す
- * 以下の場合はエラー
- * - 添付ファイルの総数が多すぎる場合
- * - ファイルサイズが大きすぎる場合
- * - Content-Type が許可されていない場合
- * @returns {Array<Object>} PDF オブジェクトの配列
- */
-const retrieveDocs = () => {
-    const docsDef = configs.getObject('conf_Docs1');
-    if (docsDef === null) {
-        return [];
-    }
-    const docs = engine.findData(docsDef);
-    if (docs === null) {
-        return [];
-    }
-    if (docs.size() > MAX_DOC_NUM) {
-        throw new Error(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
-    }
-
-    const inlineDocs = [];
-
-    let index = 0;
-
-    docs.forEach( doc => {
-
-        if (doc.getLength() > MAX_DOC_SIZE) {
-            throw new Error(`Attached file "${doc.getName()}" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
-        }
-
-        const contentType = doc.getContentType().split(';')[0];
-        if (!ALLOWED_DOCUMENT_TYPE.includes(contentType)) {
-            throw new Error(`Content-Type of the attached file "${doc.getName()}" is not allowed.`);
-        }
-
-        const format = contentType.split('/')[1];
-
-        const inlineDoc = {
-            document: {
-                format,
-                name: `DOC${index}`,
-                source: {
-                    bytes: base64.encodeToString(fileRepository.readFile(doc))
-                }
-            }
-        };
-        inlineDocs.push(inlineDoc);
-
-        index++;
-    });
-    return inlineDocs;
-};
 
 /**
  * モデルの実行
@@ -371,7 +354,7 @@ const retrieveDocs = () => {
  * @param userMessage
  * @returns {String} answer
  */
-const invokeModel = (awsKey, awsSecret, region, model, maxTokens, temperature, stopSequences, systemPrompt, userMessage) => {
+const converse = (awsKey, awsSecret, region, model, maxTokens, temperature, stopSequences, systemPrompt, userMessage) => {
     const URL = `https://bedrock-runtime.${region}.amazonaws.com/model/${model}/converse`;
     const payload = {
         anthropic_version: ANTHROPIC_VERSION,
@@ -402,7 +385,7 @@ const invokeModel = (awsKey, awsSecret, region, model, maxTokens, temperature, s
     const respTxt = response.getResponseAsString();
     if (status !== 200) {
         engine.log(respTxt);
-        throw new Error(`Failed to invoke model. status: ${status}`);
+        throw new Error(`Failed to converse. status: ${status}`);
     }
     const {output, stopReason, usage} = JSON.parse(respTxt);
     engine.log(`Stop Reason: ${stopReason}`);
@@ -740,7 +723,7 @@ test('Too many pdfs attached', () => {
 });
 
 /**
- * 添付ファイルのサイズが大きすぎる
+ * 添付画像ファイルのサイズが大きすぎる
  */
 test('Attached image is too large', () => {
     const key = 'key-12345';
@@ -755,6 +738,24 @@ test('Attached image is too large', () => {
     attachImages([image1, image2]);
 
     assertError(`Attached file "画像2.jpg" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
+});
+
+/**
+ * 添付 PDF ファイルのサイズが大きすぎる
+ */
+test('Attached pdf is too large', () => {
+    const key = 'key-12345';
+    const secret = 'secret-67890';
+    const region = 'us-east-1';
+    const message = 'Describe each image attached.';
+    prepareConfigs(key, secret, region, MODEL_3_SONNET, false, '', '', '', '', message);
+
+    // 添付ファイルを指定
+    const doc1 = createQfile('PDF1.pdf', 'application/pdf', 100);
+    const doc2 = createQfile('PDF2.pdf', 'application/pdf', MAX_DOC_SIZE + 1);
+    attachDocs([doc1, doc2]);
+
+    assertError(`Attached file "PDF2.pdf" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
 });
 
 /**
@@ -822,6 +823,7 @@ const assertRequest = ({
     });
     docs.forEach((doc, i) => {
         expect(bodyObj.messages[0].content[i + images.length + 1].document.format).toEqual(doc.getContentType().split(';')[0].split('/')[1]);
+        expect(bodyObj.messages[0].content[i + images.length + 1].document.name).toEqual(`DOC${i}`);
         expect(bodyObj.messages[0].content[i + images.length + 1].document.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(doc)));
     });
 };
@@ -844,7 +846,7 @@ test('Fail to request', () => {
         assertRequest(request, region, 'apac.anthropic.claude-3-opus-20240229-v1:0', 1280, 1, [], '', message);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
-    assertError('Failed to invoke model. status: 400');
+    assertError('Failed to converse. status: 400');
 });
 
 /**
@@ -856,7 +858,7 @@ test('Fail to request', () => {
 const createResponse = (model, answerText) => {
     const responseObj = {
         model,
-        stop_reason: 'end_turn',
+        stopReason: 'end_turn',
         output: {
             message:{
                 content: [

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -215,6 +215,14 @@ const retrieveStopSequences = () => {
     return stopSequences;
 };
 
+
+const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
+const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
+const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
+const ALLOWED_DOCUMENT_TYPES = ['application/pdf'];
+
 /**
  * config からユーザメッセージ（添付画像、添付 PDF を含む）を読み出す
  * ユーザメッセージが空の場合、添付画像や添付 PDF が不正な場合はエラー
@@ -225,8 +233,14 @@ const retrieveUserMessage = () => {
     if (message === '') {
         throw new Error('User Message is empty.');
     }
-    const inlineImages = retrieveImages();
-    const inlineDocs = retrieveDocs();
+
+const {imageFiles, docFiles} = retrieveFiles(); // Content-Type による振り分けと、どちらにも該当しない場合はエラー
+validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
+validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
+const inlineImages = imageFiles.map(({format, source}) => ({image: {format, source}}));
+const inlineDocs = docFiles.map(({format, source}, index) => ({document: {format, name: `DOC${index}`,source}}));
+
+
     const userMessage = {
         role: 'user',
         content: [
@@ -242,56 +256,13 @@ const retrieveUserMessage = () => {
 };
 
 
-const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
-const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
-const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
-const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
-const ALLOWED_DOCUMENT_TYPES = ['application/pdf'];
-const ALL_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf'];
-
-
-
 /**
- * 画像オブジェクトの配列を作成する
- * @returns {Array<Object>} 画像オブジェクトの配列
- */
-const retrieveImages = () => {
-
-    const inlineFiles = retrieveFiles("image", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES, ALL_ALLOWED_TYPES);
-    const inlineImages = inlineFiles.map(({format, source}) => ({image: {format, source}}));
-
-    return inlineImages;
-};
-
-
-/**
- * PDF オブジェクトの配列を作成する
- * @returns {Array<Object>} PDF オブジェクトの配列
- */
-const retrieveDocs = () => {
-
-    const inlineFiles = retrieveFiles("PDF", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPES, ALL_ALLOWED_TYPES);
-    const inlineDocs = inlineFiles.map(({format, source}, index) => ({document: {format, name: `DOC${index}`,source}}));
-
-    return inlineDocs;
-};
-
-
-/**
- * config からファイルを読み出す
+ * config からファイルを読み出し、画像と PDF に振り分ける
  * 以下の場合はエラー
- * - 添付ファイルの総数が多すぎる場合
- * - ファイルサイズが大きすぎる場合
  * - Content-Type が許可されていない場合
- * @param errorLabel
- * @param maxNum
- * @param maxSize
- * @param allowedTypes
- * @param allAllowedTypes
- * @returns {Array<Object>} ファイルオブジェクトの配列
+ * @returns {Array<Object>, Array<Object>} ファイルオブジェクトの配列
  */
-const retrieveFiles = (errorLabel, maxNum, maxSize, allowedTypes, allAllowedTypes) => {
+const retrieveFiles = () => {
     const filesDef = configs.getObject('conf_Images1');
     if (filesDef === null) {
         return [];
@@ -301,39 +272,53 @@ const retrieveFiles = (errorLabel, maxNum, maxSize, allowedTypes, allAllowedType
         return [];
     }
 
-    const filesArray = [];
-        
+    const imageFiles = [];
+    const docFiles = [];
+
     files.forEach(file => {
 
         const contentType = file.getContentType().split(';')[0];
-        if (!allAllowedTypes.includes(contentType)) {
-            throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
-        }
-
-        if (allowedTypes.includes(contentType)){
-            filesArray.push({file,contentType});
-        }
-    });
-
-    if (filesArray.length > maxNum) {
-        throw new Error(`Too many ${errorLabel}s attached. The maximum number is ${maxNum}.`);
-    }
-
-    const inlineFiles = [];
-
-    filesArray.forEach(({file,contentType}) => {
-
-        if (file.getLength() > maxSize) {
-            throw new Error(`Attached ${errorLabel} file "${file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
-        }
         const format = contentType.split('/')[1];
         const source = {bytes: base64.encodeToString(fileRepository.readFile(file))}
 
-        inlineFiles.push({format, source});
+        if (ALLOWED_MEDIA_TYPES.includes(contentType)){
+            imageFiles.push({file, contentType, format, source});
+        } else if (ALLOWED_DOCUMENT_TYPES.includes(contentType)){
+            docFiles.push({file, contentType, format, source});
+        } else {
+            throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
+        }
+
     });
 
-    return inlineFiles;
+    return {imageFiles, docFiles};
 };
+
+
+/**
+ * 振り分けられた画像配列と PDF 配列をチェックする
+ * 以下の場合はエラー
+ * - 添付ファイルの総数が多すぎる場合
+ * - ファイルサイズが大きすぎる場合
+ * @param {Array<Object>} ファイルオブジェクトの配列
+ * @param errorLabel
+ * @param maxNum
+ * @param maxSize
+ */
+function validateFiles(files, errorLabel, maxNum, maxSize) {
+
+    if (files.length > maxNum) {
+        throw new Error(`Too many ${errorLabel}s attached. The maximum number is ${maxNum}.`);
+    }
+
+    files.forEach(file => {
+
+        if (file.file.getLength() > maxSize) {
+            throw new Error(`Attached ${errorLabel} file "${file.file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
+        }
+    });
+
+}
 
 
 /**

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-10</last-modified>
+    <last-modified>2025-02-12</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -237,8 +237,18 @@ const retrieveUserMessage = () => {
     const {imageFiles, docFiles} = retrieveFiles(); // Content-Type による振り分けと、どちらにも該当しない場合はエラー
     validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
     validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
-    const inlineImages = imageFiles.map(file => ({image: {format: file.getContentType().split('/')[1], source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
-    const inlineDocs = docFiles.map((file, index) => ({document: {format: file.getContentType().split('/')[1], name: `DOC${index}`,source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
+
+    const inlineImages = imageFiles.map(file => ({
+        image: fileToObj(file)
+    }));
+
+    const inlineDocs = docFiles.map((file, index) => ({
+        document: {
+        name: `DOC${index}`,
+        ...fileToObj(file)
+    }
+    }));
+
 
     const userMessage = {
         role: 'user',
@@ -253,7 +263,6 @@ const retrieveUserMessage = () => {
     return userMessage;
 	
 };
-
 
 /**
  * config からファイルを読み出し、画像と PDF に振り分ける
@@ -290,7 +299,6 @@ const retrieveFiles = () => {
     return {imageFiles, docFiles};
 };
 
-
 /**
  * 振り分けられた画像配列と PDF 配列をチェックする
  * 以下の場合はエラー
@@ -315,6 +323,17 @@ const validateFiles = (files, errorLabel, maxNum, maxSize) => {
     });
 
 }
+
+/**
+ * 振り分けられたファイル配列から inline コンテンツに必要な source, format を読み出す（画像、PDF 共通部分）
+ * @param {Array<Qfile>} ファイルオブジェクトの配列
+ */
+const fileToObj = file => ({
+    format : file.getContentType().split('/')[1],
+    source: {
+        bytes: base64.encodeToString(fileRepository.readFile(file))
+    }
+});
 
 
 /**

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-01-31</last-modified>
+    <last-modified>2025-02-03</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -220,6 +220,15 @@ const retrieveStopSequences = () => {
     return stopSequences;
 };
 
+
+const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
+const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
+const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
+const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
+
+
 /**
  * config からユーザメッセージ（添付画像、添付 PDF を含む）を読み出す
  * ユーザメッセージが空の場合、添付画像や添付 PDF が不正な場合はエラー
@@ -230,8 +239,8 @@ const retrieveUserMessage = () => {
     if (message === '') {
         throw new Error('User Message is empty.');
     }
-    const inlineImages = retrieveFiles("conf_Images1");
-    const inlineDocs = retrieveFiles("conf_Docs1");
+    const inlineImages = retrieveImages(retrieveFiles("conf_Images1", "images", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES));
+    const inlineDocs = retrieveDocs(retrieveFiles("conf_Docs1", "PDFs", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPE));
     const userMessage = {
         role: 'user',
         content: [
@@ -246,22 +255,20 @@ const retrieveUserMessage = () => {
 	
 };
 
-const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
-const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
-const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
-const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
-const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
-
 /**
  * config からファイルを読み出す
  * 以下の場合はエラー
  * - 添付ファイルの総数が多すぎる場合
  * - ファイルサイズが大きすぎる場合
  * - Content-Type が許可されていない場合
- * @returns {Array<Object>} 画像オブジェクトの配列
+ * @param configName
+ * @param errorLabel
+ * @param maxNum
+ * @param maxSize
+ * @param allowedTypes
+ * @returns {Array<Object>} ファイルオブジェクトの配列
  */
-const retrieveFiles = (configName) => {
+const retrieveFiles = (configName, errorLabel, maxNum, maxSize, allowedTypes) => {
     const filesDef = configs.getObject(configName);
     if (filesDef === null) {
         return [];
@@ -273,71 +280,71 @@ const retrieveFiles = (configName) => {
 
     const inlineFiles = [];
 
-    if (configName === "conf_Images1"){
-        if (files.size() > MAX_IMAGE_NUM) {
-            throw new Error(`Too many images attached. The maximum number is ${MAX_IMAGE_NUM}.`);
-        }
-
-        
-        files.forEach(file => {
-
-            if (file.getLength() > MAX_IMAGE_SIZE) {
-                throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
-            }
-
-            const contentType = file.getContentType().split(';')[0];
-            if (!ALLOWED_MEDIA_TYPES.includes(contentType)) {
-                throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
-            }
-            const format = contentType.split('/')[1];
-
-            const inlineFile = {
-                image: {
-                    format,
-                    source: {
-                        bytes: base64.encodeToString(fileRepository.readFile(file))
-                    }
-                }
-            };
-
-            inlineFiles.push(inlineFile);
-        });
-    } else {
-        if (files.size() > MAX_DOC_NUM) {
-            throw new Error(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
-        }
-
-        let index = 0;
-
-        files.forEach( file => {
-
-            if (file.getLength() > MAX_DOC_SIZE) {
-                throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
-            }
-
-            const contentType = file.getContentType().split(';')[0];
-            if (!ALLOWED_DOCUMENT_TYPE.includes(contentType)) {
-                throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
-            }
-
-            const format = contentType.split('/')[1];
-
-            const inlineFile = {
-                document: {
-                    format,
-                    name: `DOC${index}`,
-                    source: {
-                        bytes: base64.encodeToString(fileRepository.readFile(file))
-                    }
-                }
-            };
-            inlineFiles.push(inlineFile);
-
-            index++;
-        });
+    if (files.size() > maxNum) {
+        throw new Error(`Too many ${errorLabel} attached. The maximum number is ${maxNum}.`);
     }
+        
+    files.forEach(file => {
+
+        if (file.getLength() > maxSize) {
+            throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
+        }
+
+        const contentType = file.getContentType().split(';')[0];
+        if (!allowedTypes.includes(contentType)) {
+            throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
+        }
+        const format = contentType.split('/')[1];
+        const source = {bytes: base64.encodeToString(fileRepository.readFile(file))}
+
+        inlineFiles.push({format, source});
+    });
 
     return inlineFiles;
+};
+
+
+/**
+ * inlineFiles から画像オブジェクトの配列を作成する
+ * @returns {Array<Object>} 画像オブジェクトの配列
+ */
+const retrieveImages = (inlineFiles) => {
+
+    const inlineImages = [];
+    inlineFiles.forEach( inlineFile => {
+        const inlineImage = {
+            image: {
+                format: inlineFile.format,
+                source: inlineFile.source
+            }
+        };
+
+        inlineImages.push(inlineImage);
+    });
+    return inlineImages;
+};
+
+
+/**
+ * inlineFiles から PDF オブジェクトの配列を作成する
+ * @returns {Array<Object>} PDF オブジェクトの配列
+ */
+const retrieveDocs = (inlineFiles) => {
+
+    const inlineDocs = [];
+
+    inlineFiles.forEach( (inlineFile, index) => {
+
+        const inlineDoc = {
+            document: {
+                format: inlineFile.format,
+                name: `DOC${index}`,
+                source: inlineFile.source
+            }
+        };
+        inlineDocs.push(inlineDoc);
+    });
+    return inlineDocs;
 };
 
 

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-13</last-modified>
+    <last-modified>2025-02-14</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -244,9 +244,9 @@ const retrieveUserMessage = () => {
 
     const inlineDocs = docFiles.map((file, index) => ({
         document: {
-        name: `DOC${index}`,
-        ...fileToObj(file)
-    }
+            name: `DOC${index}`,
+            ...fileToObj(file)
+        }
     }));
 
 
@@ -326,7 +326,7 @@ const validateFiles = (files, errorLabel, maxNum, maxSize) => {
 
 /**
  * 振り分けられたファイル配列から inline コンテンツに必要な source, format を読み出す（画像、PDF 共通部分）
- * @param {Array<Qfile>} ファイルオブジェクトの配列
+ * @param {Qfile} file  ファイルオブジェクト
  */
 const fileToObj = file => ({
     format : file.getContentType().split('/')[1],

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-12</last-modified>
+    <last-modified>2025-02-13</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2024-12-16</last-modified>
+    <last-modified>2025-01-03</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -27,15 +27,6 @@
         <config name="conf_Model" required="true" form-type="SELECT_ITEM" editable="true">
             <label>C4: Model</label>
             <label locale="ja">C4: モデル</label>
-            <item value="anthropic.claude-v2">
-                <label>Claude 2</label>
-            </item>
-            <item value="anthropic.claude-v2:1">
-                <label>Claude 2.1</label>
-            </item>
-            <item value="anthropic.claude-3-sonnet-20240229-v1:0">
-                <label>Claude 3 Sonnet</label>
-            </item>
             <item value="anthropic.claude-3-haiku-20240307-v1:0">
                 <label>Claude 3 Haiku</label>
             </item>
@@ -82,6 +73,11 @@
                 select-data-type="FILE">
             <label>I1: Images to attach to user message</label>
             <label locale="ja">I1: ユーザメッセージに添付する画像</label>
+        </config>
+        <config name="conf_Pdfs1" required="false" form-type="SELECT"
+                select-data-type="FILE">
+            <label>D1: PDFs to attach to user message</label>
+            <label locale="ja">D1: ユーザメッセージに添付する PDF</label>
         </config>
         <config name="conf_Answer1" required="true" form-type="SELECT"
                 select-data-type="STRING_MULTILINE">
@@ -225,8 +221,8 @@ const retrieveStopSequences = () => {
 };
 
 /**
- * config からユーザメッセージ（添付画像を含む）を読み出す
- * ユーザメッセージが空の場合、添付画像が不正な場合はエラー
+ * config からユーザメッセージ（添付画像、添付 PDF を含む）を読み出す
+ * ユーザメッセージが空の場合、添付画像や添付 PDF が不正な場合はエラー
  * @returns {Object} ユーザメッセージオブジェクト
  */
 const retrieveUserMessage = () => {
@@ -235,17 +231,19 @@ const retrieveUserMessage = () => {
         throw new Error('User Message is empty.');
     }
     const inlineImages = retrieveImages();
+    const inlinePdfs = retrievePdfs();
     const userMessage = {
         role: 'user',
         content: [
             {
-                type: 'text',
                 text: message
             },
-            ...inlineImages
+            ...inlineImages,
+            ...inlinePdfs
         ]
     };
     return userMessage;
+	
 };
 
 const MAX_IMAGE_NUM = 20; // Messages API の制限。1 ユーザメッセージにつき添付画像 20 個まで
@@ -272,26 +270,87 @@ const retrieveImages = () => {
     if (images.size() > MAX_IMAGE_NUM) {
         throw new Error(`Too many images attached. The maximum number is ${MAX_IMAGE_NUM}.`);
     }
+
     const inlineImages = [];
     images.forEach(image => {
+
         if (image.getLength() > MAX_IMAGE_SIZE) {
             throw new Error(`Attached file "${image.getName()}" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
         }
+
         const contentType = image.getContentType().split(';')[0];
         if (!ALLOWED_MEDIA_TYPES.includes(contentType)) {
             throw new Error(`Content-Type of the attached file "${image.getName()}" is not allowed.`);
         }
+
+        const format = contentType.split('/')[1];
+
         const inlineImage = {
-            type: 'image',
-            source: {
-                type: 'base64',
-                media_type: contentType,
-                data: base64.encodeToString(fileRepository.readFile(image))
+            image: {
+                format,
+                source: {
+                    bytes: base64.encodeToString(fileRepository.readFile(image))
+                }
             }
         };
+
         inlineImages.push(inlineImage);
     });
     return inlineImages;
+};
+
+
+const MAX_PDF_NUM = 5; // Messages API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_PDF_SIZE = 4718592; // Messages API の制限。1 ファイルにつき 4.5 MB まで
+const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
+
+/**
+ * config から PDF を読み出す
+ * 以下の場合はエラー
+ * - 添付ファイルの総数が多すぎる場合
+ * - ファイルサイズが大きすぎる場合
+ * - Content-Type が許可されていない場合
+ * @returns {Array<Object>} PDF オブジェクトの配列
+ */
+const retrievePdfs = () => {
+    const pdfsDef = configs.getObject('conf_Pdfs1');
+    if (pdfsDef === null) {
+        return [];
+    }
+    const pdfs = engine.findData(pdfsDef);
+    if (pdfs === null) {
+        return [];
+    }
+    if (pdfs.size() > MAX_PDF_NUM) {
+        throw new Error(`Too many PDFs attached. The maximum number is ${MAX_PDF_NUM}.`);
+    }
+
+    const inlinePdfs = [];
+    pdfs.forEach( (pdf, index ) => {
+
+        if (pdf.getLength() > MAX_PDF_SIZE) {
+            throw new Error(`Attached file "${pdf.getName()}" is too large. The maximum size is ${MAX_PDF_SIZE} bytes.`);
+        }
+
+        const contentType = pdf.getContentType().split(';')[0];
+        if (!ALLOWED_DOCUMENT_TYPE.includes(contentType)) {
+            throw new Error(`Content-Type of the attached file "${pdf.getName()}" is not allowed.`);
+        }
+
+        const format = contentType.split('/')[1];
+
+        const inlinePdf = {
+            document: {
+                format,
+                name: `PDF${index}`,
+                source: {
+                    bytes: base64.encodeToString(fileRepository.readFile(pdf))
+                }
+            }
+        };
+        inlinePdfs.push(inlinePdf);
+    });
+    return inlinePdfs;
 };
 
 /**
@@ -308,15 +367,26 @@ const retrieveImages = () => {
  * @returns {String} answer
  */
 const invokeModel = (awsKey, awsSecret, region, model, maxTokens, temperature, stopSequences, systemPrompt, userMessage) => {
-    const URL = `https://bedrock-runtime.${region}.amazonaws.com/model/${model}/invoke`;
+    const URL = `https://bedrock-runtime.${region}.amazonaws.com/model/${model}/converse`;
     const payload = {
         anthropic_version: ANTHROPIC_VERSION,
-        max_tokens: maxTokens,
-        temperature,
-        stop_sequences: stopSequences,
-        system: systemPrompt,
+        inferenceConfig: {
+            maxTokens,
+            stopSequences,
+            temperature
+        },
+
         messages: [userMessage]
     };
+
+    if (systemPrompt !== '') {
+        Object.assign(payload, {
+            system: [
+            {text :`${systemPrompt}`}
+            ]
+        });
+    }
+
 
     const response = httpClient.begin()
         .awsSignV4(awsKey, awsSecret, region, SERVICE)
@@ -329,11 +399,11 @@ const invokeModel = (awsKey, awsSecret, region, model, maxTokens, temperature, s
         engine.log(respTxt);
         throw new Error(`Failed to invoke model. status: ${status}`);
     }
-    const {content, stop_reason, usage} = JSON.parse(respTxt);
-    engine.log(`Stop Reason: ${stop_reason}`);
-    engine.log(`Input Tokens: ${usage.input_tokens}`);
-    engine.log(`Output Tokens: ${usage.output_tokens}`);
-    return content[0].text;
+    const {output, stopReason, usage} = JSON.parse(respTxt);
+    engine.log(`Stop Reason: ${stopReason}`);
+    engine.log(`Input Tokens: ${usage.inputTokens}`);
+    engine.log(`Output Tokens: ${usage.outputTokens}`);
+    return output.message.content[0].text;
 };
 
 /**
@@ -694,7 +764,7 @@ const assertRequest = ({
                            contentType,
                            body
                        }, region, model, maxTokens, temperature, stopSequences, systemPrompt, message, images = []) => {
-    expect(url).toEqual(`https://bedrock-runtime.${region}.amazonaws.com/model/${model}/invoke`);
+    expect(url).toEqual(`https://bedrock-runtime.${region}.amazonaws.com/model/${model}/converse`);
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     // Authorization ヘッダのテストは省略

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-04</last-modified>
+    <last-modified>2025-02-06</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -71,13 +71,8 @@
         </config>
         <config name="conf_Images1" required="false" form-type="SELECT"
                 select-data-type="FILE">
-            <label>I1: Images to attach to user message</label>
-            <label locale="ja">I1: ユーザメッセージに添付する画像</label>
-        </config>
-        <config name="conf_Docs1" required="false" form-type="SELECT"
-                select-data-type="FILE">
-            <label>D1: PDFs to attach to user message</label>
-            <label locale="ja">D1: ユーザメッセージに添付する PDF</label>
+            <label>I1: Images / PDFs to attach to user message</label>
+            <label locale="ja">I1: ユーザメッセージに添付する画像／PDF</label>
         </config>
         <config name="conf_Answer1" required="true" form-type="SELECT"
                 select-data-type="STRING_MULTILINE">
@@ -220,15 +215,6 @@ const retrieveStopSequences = () => {
     return stopSequences;
 };
 
-
-const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
-const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
-const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
-const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
-const ALLOWED_DOCUMENT_TYPES = ['application/pdf'];
-
-
 /**
  * config からユーザメッセージ（添付画像、添付 PDF を含む）を読み出す
  * ユーザメッセージが空の場合、添付画像や添付 PDF が不正な場合はエラー
@@ -256,13 +242,23 @@ const retrieveUserMessage = () => {
 };
 
 
+const MAX_IMAGE_NUM = 20; // Bedrock Converse API の制限。1 ユーザメッセージにつき添付画像 20 個まで
+const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイルにつき 3.75 MB まで
+const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
+const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
+const ALLOWED_DOCUMENT_TYPES = ['application/pdf'];
+const ALL_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf'];
+
+
+
 /**
  * 画像オブジェクトの配列を作成する
  * @returns {Array<Object>} 画像オブジェクトの配列
  */
 const retrieveImages = () => {
 
-    const inlineFiles = retrieveFiles("conf_Images1", "images", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES);
+    const inlineFiles = retrieveFiles("image", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES, ALL_ALLOWED_TYPES);
     const inlineImages = inlineFiles.map(({format, source}) => ({image: {format, source}}));
 
     return inlineImages;
@@ -275,7 +271,7 @@ const retrieveImages = () => {
  */
 const retrieveDocs = () => {
 
-    const inlineFiles = retrieveFiles("conf_Docs1", "PDFs", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPES);
+    const inlineFiles = retrieveFiles("PDF", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPES, ALL_ALLOWED_TYPES);
     const inlineDocs = inlineFiles.map(({format, source}, index) => ({document: {format, name: `DOC${index}`,source}}));
 
     return inlineDocs;
@@ -288,15 +284,15 @@ const retrieveDocs = () => {
  * - 添付ファイルの総数が多すぎる場合
  * - ファイルサイズが大きすぎる場合
  * - Content-Type が許可されていない場合
- * @param configName
  * @param errorLabel
  * @param maxNum
  * @param maxSize
  * @param allowedTypes
+ * @param allAllowedTypes
  * @returns {Array<Object>} ファイルオブジェクトの配列
  */
-const retrieveFiles = (configName, errorLabel, maxNum, maxSize, allowedTypes) => {
-    const filesDef = configs.getObject(configName);
+const retrieveFiles = (errorLabel, maxNum, maxSize, allowedTypes, allAllowedTypes) => {
+    const filesDef = configs.getObject('conf_Images1');
     if (filesDef === null) {
         return [];
     }
@@ -305,21 +301,30 @@ const retrieveFiles = (configName, errorLabel, maxNum, maxSize, allowedTypes) =>
         return [];
     }
 
-    const inlineFiles = [];
-
-    if (files.size() > maxNum) {
-        throw new Error(`Too many ${errorLabel} attached. The maximum number is ${maxNum}.`);
-    }
+    const filesArray = [];
         
     files.forEach(file => {
 
-        if (file.getLength() > maxSize) {
-            throw new Error(`Attached file "${file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
+        const contentType = file.getContentType().split(';')[0];
+        if (!allAllowedTypes.includes(contentType)) {
+            throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
         }
 
-        const contentType = file.getContentType().split(';')[0];
-        if (!allowedTypes.includes(contentType)) {
-            throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
+        if (allowedTypes.includes(contentType)){
+            filesArray.push({file,contentType});
+        }
+    });
+
+    if (filesArray.length > maxNum) {
+        throw new Error(`Too many ${errorLabel}s attached. The maximum number is ${maxNum}.`);
+    }
+
+    const inlineFiles = [];
+
+    filesArray.forEach(({file,contentType}) => {
+
+        if (file.getLength() > maxSize) {
+            throw new Error(`Attached ${errorLabel} file "${file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
         }
         const format = contentType.split('/')[1];
         const source = {bytes: base64.encodeToString(fileRepository.readFile(file))}
@@ -653,24 +658,15 @@ const createQfile = (name, contentType, size) => {
 };
 
 /**
- * 画像を添付
- * @param {Array<Qfile>} images
+ * 画像、 PDF を添付
+ * @param {Array<Qfile>} files
  */
-const attachImages = (images) => {
-    const imagesDef = engine.createDataDefinition('添付画像', 2, 'q_images', 'FILE');
-    engine.setData(imagesDef, images);
-    configs.putObject('conf_Images1', imagesDef);
+const attachFiles = (files) => {
+    const filesDef = engine.createDataDefinition('添付画像', 2, 'q_files', 'FILE');
+    engine.setData(filesDef, files);
+    configs.putObject('conf_Images1', filesDef);
 };
 
-/**
- * PDF を添付
- * @param {Array<Qfile>} docs
- */
-const attachDocs = (docs) => {
-    const docsDef = engine.createDataDefinition('添付 PDF', 3, 'q_docs', 'FILE');
-    engine.setData(docsDef, docs);
-    configs.putObject('conf_Docs1', docsDef);
-};
 
 /**
  * 添付画像ファイルの数が多すぎる
@@ -687,7 +683,7 @@ test('Too many images attached', () => {
     for (let i = 0; i < MAX_IMAGE_NUM + 1; i++) {
         images.push(createQfile(`画像${i}.png`, 'image/png', 100));
     }
-    attachImages(images);
+    attachFiles(images);
 
     assertError(`Too many images attached. The maximum number is ${MAX_IMAGE_NUM}.`);
 });
@@ -707,7 +703,7 @@ test('Too many pdfs attached', () => {
     for (let i = 0; i < MAX_DOC_NUM + 1; i++) {
         docs.push(createQfile(`DOC${i}.pdf`, 'application/pdf', 100));
     }
-    attachDocs(docs);
+    attachFiles(docs);
 
     assertError(`Too many PDFs attached. The maximum number is ${MAX_DOC_NUM}.`);
 });
@@ -725,9 +721,9 @@ test('Attached image is too large', () => {
     // 添付ファイルを指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
     const image2 = createQfile('画像2.jpg', 'image/jpeg', MAX_IMAGE_SIZE + 1);
-    attachImages([image1, image2]);
+    attachFiles([image1, image2]);
 
-    assertError(`Attached file "画像2.jpg" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
+    assertError(`Attached image file "画像2.jpg" is too large. The maximum size is ${MAX_IMAGE_SIZE} bytes.`);
 });
 
 /**
@@ -743,9 +739,9 @@ test('Attached pdf is too large', () => {
     // 添付ファイルを指定
     const doc1 = createQfile('PDF1.pdf', 'application/pdf', 100);
     const doc2 = createQfile('PDF2.pdf', 'application/pdf', MAX_DOC_SIZE + 1);
-    attachDocs([doc1, doc2]);
+    attachFiles([doc1, doc2]);
 
-    assertError(`Attached file "PDF2.pdf" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
+    assertError(`Attached PDF file "PDF2.pdf" is too large. The maximum size is ${MAX_DOC_SIZE} bytes.`);
 });
 
 /**
@@ -764,7 +760,7 @@ test('Content-Type of an attached file is not allowed', () => {
     const image3 = createQfile('画像3.gif', 'image/gif', 300);
     const image4 = createQfile('画像4.webp', 'image/webp', 100);
     const imageNotAllowed = createQfile('許可されていない画像.svg', 'image/svg+xml', 200);
-    attachImages([image1, image2, image3, image4, imageNotAllowed]);
+    attachFiles([image1, image2, image3, image4, imageNotAllowed]);
 
     assertError('Content-Type of the attached file "許可されていない画像.svg" is not allowed.');
 });
@@ -783,15 +779,14 @@ test('Content-Type of an attached file is not allowed', () => {
  * @param {Array<String>} stopSequences
  * @param {String} systemPrompt
  * @param {String} message
- * @param {Array<Qfile>} images
- * @param {Array<Qfile>} docs
+ * @param {Array<Qfile>} files
  */
 const assertRequest = ({
                            url,
                            method,
                            contentType,
                            body
-                       }, region, model, maxTokens, temperature, stopSequences, systemPrompt, message, images = [], docs = []) => {
+                       }, region, model, maxTokens, temperature, stopSequences, systemPrompt, message, files = []) => {
     expect(url).toEqual(`https://bedrock-runtime.${region}.amazonaws.com/model/${model}/converse`);
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
@@ -806,16 +801,19 @@ const assertRequest = ({
     }
     expect(bodyObj.messages[0].role).toEqual('user');
     expect(bodyObj.messages[0].content[0].text).toEqual(message);
-    expect(bodyObj.messages[0].content.length).toEqual(images.length + docs.length + 1);
-    images.forEach((image, i) => {
-        expect(bodyObj.messages[0].content[i + 1].image.format).toEqual(image.getContentType().split(';')[0].split('/')[1]);
-        expect(bodyObj.messages[0].content[i + 1].image.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(image)));
+    expect(bodyObj.messages[0].content.length).toEqual(files.length + 1);
+
+    files.forEach((file, i) => {
+        if(file.getContentType().split(';')[0] === "image"){
+            expect(bodyObj.messages[0].content[i + 1].image.format).toEqual(file.getContentType().split(';')[0].split('/')[1]);
+            expect(bodyObj.messages[0].content[i + 1].image.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(file)));
+        } else if (file.getContentType().split(';')[0] === "pdf"){
+            expect(bodyObj.messages[0].content[i + 1].document.format).toEqual(file.getContentType().split(';')[0].split('/')[1]);
+            expect(bodyObj.messages[0].content[i + 1].document.name).toEqual(`DOC${i}`);
+            expect(bodyObj.messages[0].content[i + 1].document.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(file)));
+        }
     });
-    docs.forEach((doc, i) => {
-        expect(bodyObj.messages[0].content[i + images.length + 1].document.format).toEqual(doc.getContentType().split(';')[0].split('/')[1]);
-        expect(bodyObj.messages[0].content[i + images.length + 1].document.name).toEqual(`DOC${i}`);
-        expect(bodyObj.messages[0].content[i + images.length + 1].document.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(doc)));
-    });
+
 };
 
 /**
@@ -958,7 +956,7 @@ test('Success - with temperature, stop sequences and system prompt, empty attach
     const systemPrompt = "You are a translator. Translate the user's input into Japanese.";
     const message = 'Hi. How are you?';
     const answerDef = prepareConfigs(key, secret, region, MODEL_3_5_SONNET_V2, false, maxTokens, temperature, stopSequences, systemPrompt, message);
-    attachImages([]);
+    attachFiles([]);
 
     const answer = 'こんにちは。お元気ですか？';
     httpClient.setRequestHandler((request) => {
@@ -991,25 +989,25 @@ test('Success - with attached images and pdfs - CrossRegionModel - Markdown', ()
     configs.putObject('conf_Answer1', answerDef);
 
     // 添付画像を指定
-    const images = [];
+    const files = [];
     for (let i = 0; i < MAX_IMAGE_NUM - 1; i++) {
-        images.push(createQfile(`画像${i}.png`, ALLOWED_MEDIA_TYPES[i % 4], 100));
+        files.push(createQfile(`画像${i}.png`, ALLOWED_MEDIA_TYPES[i % 4], 100));
     }
-    images.push(createQfile('最大サイズの画像.jpg', 'image/jpeg;filename="最大サイズの画像.jpg"', MAX_IMAGE_SIZE));
-    attachImages(images);
+    files.push(createQfile('最大サイズの画像.jpg', 'image/jpeg;filename="最大サイズの画像.jpg"', MAX_IMAGE_SIZE));
 
     // 添付 PDF を指定
-    const docs = [];
     for (let i = 0; i < MAX_DOC_NUM - 1; i++) {
-        docs.push(createQfile(`PDF${i}.pdf`, ALLOWED_DOCUMENT_TYPES[0], 100));
+        files.push(createQfile(`PDF${i}.pdf`, ALLOWED_DOCUMENT_TYPES[0], 100));
     }
-    docs.push(createQfile('最大サイズのPDF.pdf', 'application/pdf;filename="最大サイズのPDF.pdf"', MAX_DOC_SIZE));
-    attachDocs(docs);
+    files.push(createQfile('最大サイズのPDF.pdf', 'application/pdf;filename="最大サイズのPDF.pdf"', MAX_DOC_SIZE));
+
+    // 画像、 PDF を添付
+    attachFiles(files);
 
 
     const answer = 'The 1st image shows a cat. The 2nd image shows a dog.';
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, `apac.${MODEL_3_SONNET}`, MAX_TOKENS_DEFAULT, 1, [], '', message, images, docs);
+        assertRequest(request, region, `apac.${MODEL_3_SONNET}`, MAX_TOKENS_DEFAULT, 1, [], '', message, files);
         return httpClient.createHttpResponse(200, 'application/json', createResponse(`apac.${MODEL_3_SONNET}`, answer));
     });
 

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-06</last-modified>
+    <last-modified>2025-02-10</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -87,7 +87,7 @@
 const SERVICE = 'bedrock';
 const ANTHROPIC_VERSION = 'bedrock-2023-05-31';
 
-function main() {
+const main = () => {
     ////// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const awsKey = configs.getObject('conf_AccessKey').getToken();
     const awsSecret = configs.getObject('conf_SecretKey').getToken();
@@ -116,7 +116,7 @@ function main() {
  * リージョンコードの形式として不正な場合はエラー
  * @return {String}
  */
-function retrieveRegion() {
+const retrieveRegion = () => {
     const region = configs.get('conf_Region');
     // 今後リージョンが増えることも考えて、中央の最大文字数には余裕をみている
     const reg = new RegExp('^[a-z]{2}-[a-z]{4,16}-[1-9]$');
@@ -131,7 +131,7 @@ function retrieveRegion() {
  * モデル ID として不正な場合はエラー
  * @return {String}
  */
-function retrieveModel() {
+const retrieveModel = () => {
     const model = configs.get('conf_Model');
     const reg = new RegExp('^[a-z0-9.:-]+$');
     if (!reg.test(model)) {
@@ -149,7 +149,7 @@ function retrieveModel() {
  * C3 のリージョンがクロスリージョン推論の対象でない場合はエラー
  * @return {String}
  */
-function decideCrossRegionModel(model, region) {
+const decideCrossRegionModel = (model, region) => {
     if (region.startsWith('us-')){
         return `us.${model}`;
     } else if(region.startsWith('eu-')){
@@ -234,12 +234,16 @@ const retrieveUserMessage = () => {
         throw new Error('User Message is empty.');
     }
 
-const {imageFiles, docFiles} = retrieveFiles(); // Content-Type による振り分けと、どちらにも該当しない場合はエラー
-validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
-validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
-const inlineImages = imageFiles.map(({format, source}) => ({image: {format, source}}));
-const inlineDocs = docFiles.map(({format, source}, index) => ({document: {format, name: `DOC${index}`,source}}));
+    const {imageFiles, docFiles} = retrieveFiles(); // Content-Type による振り分けと、どちらにも該当しない場合はエラー
+    if (imageFiles !== []){
+        validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
+    }
+    if (docFiles !== []){
+        validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
+    }
 
+    const inlineImages = imageFiles.map(file => ({image: {format: file.getContentType().split('/')[1], source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
+    const inlineDocs = docFiles.map((file, index) => ({document: {format: file.getContentType().split('/')[1], name: `DOC${index}`,source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
 
     const userMessage = {
         role: 'user',
@@ -263,32 +267,29 @@ const inlineDocs = docFiles.map(({format, source}, index) => ({document: {format
  * @returns {Array<Object>, Array<Object>} ファイルオブジェクトの配列
  */
 const retrieveFiles = () => {
+    const imageFiles = [];
+    const docFiles = [];
+
     const filesDef = configs.getObject('conf_Images1');
     if (filesDef === null) {
-        return [];
+        return {imageFiles, docFiles};
     }
     const files = engine.findData(filesDef);
     if (files === null) {
-        return [];
+        return {imageFiles, docFiles};
     }
-
-    const imageFiles = [];
-    const docFiles = [];
 
     files.forEach(file => {
 
         const contentType = file.getContentType().split(';')[0];
-        const format = contentType.split('/')[1];
-        const source = {bytes: base64.encodeToString(fileRepository.readFile(file))}
 
         if (ALLOWED_MEDIA_TYPES.includes(contentType)){
-            imageFiles.push({file, contentType, format, source});
+            imageFiles.push(file);
         } else if (ALLOWED_DOCUMENT_TYPES.includes(contentType)){
-            docFiles.push({file, contentType, format, source});
+            docFiles.push(file);
         } else {
             throw new Error(`Content-Type of the attached file "${file.getName()}" is not allowed.`);
         }
-
     });
 
     return {imageFiles, docFiles};
@@ -305,7 +306,7 @@ const retrieveFiles = () => {
  * @param maxNum
  * @param maxSize
  */
-function validateFiles(files, errorLabel, maxNum, maxSize) {
+const validateFiles = (files, errorLabel, maxNum, maxSize) => {
 
     if (files.length > maxNum) {
         throw new Error(`Too many ${errorLabel}s attached. The maximum number is ${maxNum}.`);
@@ -313,8 +314,8 @@ function validateFiles(files, errorLabel, maxNum, maxSize) {
 
     files.forEach(file => {
 
-        if (file.file.getLength() > maxSize) {
-            throw new Error(`Attached ${errorLabel} file "${file.file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
+        if (file.getLength() > maxSize) {
+            throw new Error(`Attached ${errorLabel} file "${file.getName()}" is too large. The maximum size is ${maxSize} bytes.`);
         }
     });
 
@@ -786,7 +787,10 @@ const assertRequest = ({
     }
     expect(bodyObj.messages[0].role).toEqual('user');
     expect(bodyObj.messages[0].content[0].text).toEqual(message);
+
     expect(bodyObj.messages[0].content.length).toEqual(files.length + 1);
+
+
 
     files.forEach((file, i) => {
         if(file.getContentType().split(';')[0] === "image"){
@@ -798,6 +802,8 @@ const assertRequest = ({
             expect(bodyObj.messages[0].content[i + 1].document.source.bytes).toEqual(base64.encodeToString(fileRepository.readFile(file)));
         }
     });
+
+
 
 };
 

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Anthropic Claude: Chat</label>
     <label locale="ja">Amazon Bedrock: Anthropic Claude: チャット</label>
-    <last-modified>2025-02-03</last-modified>
+    <last-modified>2025-02-04</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to an Anthropic Claude model on Amazon Bedrock
         and stores the response in the specified data item.</summary>
@@ -226,7 +226,7 @@ const MAX_IMAGE_SIZE = 3932160; // Bedrock Converse API の制限。1 ファイ�
 const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 const MAX_DOC_NUM = 5; // Bedrock Converse API の制限。1 ユーザメッセージにつき PDF 5 個まで
 const MAX_DOC_SIZE = 4718592; // Bedrock Converse API の制限。1 ファイルにつき 4.5 MB まで
-const ALLOWED_DOCUMENT_TYPE = 'application/pdf';
+const ALLOWED_DOCUMENT_TYPES = ['application/pdf'];
 
 
 /**
@@ -239,8 +239,8 @@ const retrieveUserMessage = () => {
     if (message === '') {
         throw new Error('User Message is empty.');
     }
-    const inlineImages = retrieveImages(retrieveFiles("conf_Images1", "images", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES));
-    const inlineDocs = retrieveDocs(retrieveFiles("conf_Docs1", "PDFs", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPE));
+    const inlineImages = retrieveImages();
+    const inlineDocs = retrieveDocs();
     const userMessage = {
         role: 'user',
         content: [
@@ -254,6 +254,33 @@ const retrieveUserMessage = () => {
     return userMessage;
 	
 };
+
+
+/**
+ * 画像オブジェクトの配列を作成する
+ * @returns {Array<Object>} 画像オブジェクトの配列
+ */
+const retrieveImages = () => {
+
+    const inlineFiles = retrieveFiles("conf_Images1", "images", MAX_IMAGE_NUM, MAX_IMAGE_SIZE, ALLOWED_MEDIA_TYPES);
+    const inlineImages = inlineFiles.map(({format, source}) => ({image: {format, source}}));
+
+    return inlineImages;
+};
+
+
+/**
+ * PDF オブジェクトの配列を作成する
+ * @returns {Array<Object>} PDF オブジェクトの配列
+ */
+const retrieveDocs = () => {
+
+    const inlineFiles = retrieveFiles("conf_Docs1", "PDFs", MAX_DOC_NUM, MAX_DOC_SIZE, ALLOWED_DOCUMENT_TYPES);
+    const inlineDocs = inlineFiles.map(({format, source}, index) => ({document: {format, name: `DOC${index}`,source}}));
+
+    return inlineDocs;
+};
+
 
 /**
  * config からファイルを読み出す
@@ -301,50 +328,6 @@ const retrieveFiles = (configName, errorLabel, maxNum, maxSize, allowedTypes) =>
     });
 
     return inlineFiles;
-};
-
-
-/**
- * inlineFiles から画像オブジェクトの配列を作成する
- * @returns {Array<Object>} 画像オブジェクトの配列
- */
-const retrieveImages = (inlineFiles) => {
-
-    const inlineImages = [];
-    inlineFiles.forEach( inlineFile => {
-        const inlineImage = {
-            image: {
-                format: inlineFile.format,
-                source: inlineFile.source
-            }
-        };
-
-        inlineImages.push(inlineImage);
-    });
-    return inlineImages;
-};
-
-
-/**
- * inlineFiles から PDF オブジェクトの配列を作成する
- * @returns {Array<Object>} PDF オブジェクトの配列
- */
-const retrieveDocs = (inlineFiles) => {
-
-    const inlineDocs = [];
-
-    inlineFiles.forEach( (inlineFile, index) => {
-
-        const inlineDoc = {
-            document: {
-                format: inlineFile.format,
-                name: `DOC${index}`,
-                source: inlineFile.source
-            }
-        };
-        inlineDocs.push(inlineDoc);
-    });
-    return inlineDocs;
 };
 
 
@@ -1018,7 +1001,7 @@ test('Success - with attached images and pdfs - CrossRegionModel - Markdown', ()
     // 添付 PDF を指定
     const docs = [];
     for (let i = 0; i < MAX_DOC_NUM - 1; i++) {
-        docs.push(createQfile(`PDF${i}.pdf`, ALLOWED_DOCUMENT_TYPE, 100));
+        docs.push(createQfile(`PDF${i}.pdf`, ALLOWED_DOCUMENT_TYPES[0], 100));
     }
     docs.push(createQfile('最大サイズのPDF.pdf', 'application/pdf;filename="最大サイズのPDF.pdf"', MAX_DOC_SIZE));
     attachDocs(docs);

--- a/aws-bedrock-anthropic-claude-chat.xml
+++ b/aws-bedrock-anthropic-claude-chat.xml
@@ -235,13 +235,8 @@ const retrieveUserMessage = () => {
     }
 
     const {imageFiles, docFiles} = retrieveFiles(); // Content-Type による振り分けと、どちらにも該当しない場合はエラー
-    if (imageFiles !== []){
-        validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
-    }
-    if (docFiles !== []){
-        validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
-    }
-
+    validateFiles(imageFiles, 'image', MAX_IMAGE_NUM, MAX_IMAGE_SIZE);
+    validateFiles(docFiles, 'PDF', MAX_DOC_NUM, MAX_DOC_SIZE);
     const inlineImages = imageFiles.map(file => ({image: {format: file.getContentType().split('/')[1], source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
     const inlineDocs = docFiles.map((file, index) => ({document: {format: file.getContentType().split('/')[1], name: `DOC${index}`,source: {bytes: base64.encodeToString(fileRepository.readFile(file))}}}));
 
@@ -264,7 +259,7 @@ const retrieveUserMessage = () => {
  * config からファイルを読み出し、画像と PDF に振り分ける
  * 以下の場合はエラー
  * - Content-Type が許可されていない場合
- * @returns {Array<Object>, Array<Object>} ファイルオブジェクトの配列
+ * @returns {Array<Qfile>, Array<Qfile>} ファイルオブジェクトの配列
  */
 const retrieveFiles = () => {
     const imageFiles = [];
@@ -301,7 +296,7 @@ const retrieveFiles = () => {
  * 以下の場合はエラー
  * - 添付ファイルの総数が多すぎる場合
  * - ファイルサイズが大きすぎる場合
- * @param {Array<Object>} ファイルオブジェクトの配列
+ * @param {Array<Qfile>} ファイルオブジェクトの配列
  * @param errorLabel
  * @param maxNum
  * @param maxSize


### PR DESCRIPTION
@tatsumiQ さん

PDF ファイルを複数添付する処理で行き詰ってしまったので教えてください

D1: ユーザメッセージに添付する PDF の設定項目を設けました
PDF ファイルは、以下のように "name" プロパティの設定が必要になります

```
        {
            "document": {
                "format": "pdf",
                "name": "string",
                "source": {
                    "bytes": "document in bytes"
                }
            }
        }
```
"name" プロパティは、重複するドキュメント名を設定することができません

```
        const inlinePdf = {
            document: {
                format,
                name: `PDF${index}`,
                source: {
                    bytes: base64.encodeToString(fileRepository.readFile(pdf))
                }
            }
        };

```
上記の処理で、
"Messages can’t contain duplicate document names. Rename the document and retry your request."
というエラーになり、名前が重複している旨のエラーになります。
どの部分の処理が問題でしょうか