### PR TITLE
t10387 Amazon Bedrock: Stability AI: 画像生成　画像形式未設定の処理を修正

### DIFF
--- a/aws-bedrock-stability-ai-image-generate.xml
+++ b/aws-bedrock-stability-ai-image-generate.xml
@@ -3,7 +3,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Stability AI: Generate Image</label>
     <label locale="ja">Amazon Bedrock: Stability AI: 画像生成</label>
-    <last-modified>2025-03-06</last-modified>
+    <last-modified>2025-03-07</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item generates an image using Stability AI's model on Amazon Bedrock.</summary>
     <summary locale="ja">この工程は、Amazon Bedrock 上で動作する Stability AI の モデルを用いて、画像を生成します。</summary>
@@ -574,6 +574,8 @@ const assertRequest = ({
     }
     if (format !== undefined) {
         expect(bodyObj.output_format).toEqual(format);
+    } else {
+        expect(bodyObj.output_format).toEqual('png');
     }
     expect(bodyObj.seed).toEqual(seedNum);
 };

--- a/aws-bedrock-stability-ai-image-generate.xml
+++ b/aws-bedrock-stability-ai-image-generate.xml
@@ -3,7 +3,7 @@
     <addon-version>2</addon-version>
     <label>Amazon Bedrock: Stability AI: Generate Image</label>
     <label locale="ja">Amazon Bedrock: Stability AI: 画像生成</label>
-    <last-modified>2025-01-23</last-modified>
+    <last-modified>2025-03-06</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item generates an image using Stability AI's model on Amazon Bedrock.</summary>
     <summary locale="ja">この工程は、Amazon Bedrock 上で動作する Stability AI の モデルを用いて、画像を生成します。</summary>
@@ -192,12 +192,13 @@ const buildPayload = () => {
         });
     }
 
-    const format = configs.get("conf_Format");
-    if (format !== '') {
-        Object.assign(payload, {
-            output_format: format
-        });
+    let format = 'png'
+    if (configs.get("conf_Format") === 'jpg') {
+        format = 'jpg'
     }
+    Object.assign(payload, {
+        output_format: format
+    });
 
     engine.log(JSON.stringify(payload));
     return payload;

--- a/aws-bedrock-stability-ai-image-generate.xml
+++ b/aws-bedrock-stability-ai-image-generate.xml
@@ -572,11 +572,7 @@ const assertRequest = ({
     if (aspect !== undefined) {
         expect(bodyObj.aspect_ratio).toEqual(aspect);
     }
-    if (format !== undefined) {
-        expect(bodyObj.output_format).toEqual(format);
-    } else {
-        expect(bodyObj.output_format).toEqual('png');
-    }
+    expect(bodyObj.output_format).toEqual(format);
     expect(bodyObj.seed).toEqual(seedNum);
 };
 
@@ -628,7 +624,7 @@ test('Success - only required params', () => {
 
     const seedNum = 1234567890;
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, MODEL_ULTRA_1_1, prompt, undefined, undefined, undefined, undefined);
+        assertRequest(request, region, MODEL_ULTRA_1_1, prompt, undefined, undefined, 'png', undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse(seedNum, base64.encodeToString('aaaaaaaa')));
     });
 
@@ -660,7 +656,7 @@ test('Success - only required params, data item for seed is not selected', () =>
 
     const seedNum = 1234567890;
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, region, MODEL_D3_5_LARGE, prompt, undefined, undefined, undefined, undefined);
+        assertRequest(request, region, MODEL_D3_5_LARGE, prompt, undefined, undefined, 'png', undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse(seedNum, base64.encodeToString('123')));
     });
 


### PR DESCRIPTION
@tatsumiQ さん

アイテムにとってのデフォルト値を png としました。
未指定の場合、リクエストボディの output_format に png をセットするよう修正しました。
ご確認をお願いします。