### PR TITLE
T10554　Google Vertex AI: Gemini: チャット　応答が空の場合の対応

### DIFF
--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Google Vertex AI: Gemini: Chat</label>
     <label locale="ja">Google Vertex AI: Gemini: チャット</label>
-    <last-modified>2024-11-12</last-modified>
+    <last-modified>2025-04-22</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to a Gemini model on Google Vertex AI
         and stores the response in the specified data item.</summary>
@@ -29,14 +29,11 @@
         <config name="conf_Model" required="true" form-type="SELECT_ITEM" editable="true">
             <label>C4: Model</label>
             <label locale="ja">C4: モデル</label>
-            <item value="gemini-1.0-pro">
-                <label>Gemini 1.0 Pro</label>
+            <item value="gemini-2.0-flash">
+                <label>Gemini 2.0 Flash</label>
             </item>
-            <item value="gemini-1.5-pro">
-                <label>Gemini 1.5 Pro</label>
-            </item>
-            <item value="gemini-1.5-flash">
-                <label>Gemini 1.5 Flash</label>
+            <item value="gemini-2.0-flash-lite">
+                <label>Gemini 2.0 Flash Lite</label>
             </item>
         </config>
         <config name="conf_MaxTokens" required="false" form-type="TEXTFIELD">

--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -328,15 +328,18 @@ const invokeModel = (auth, region, projectId, model, maxTokens, temperature, sto
     const json = JSON.parse(respTxt);
     let answers = [];
     for (const {candidates, usageMetadata} of json) {
-        if (candidates[0].content === undefined) {
-            engine.log('No content in the candidate.');
-        } else {
-            answers.push(candidates[0].content.parts[0].text);
-        }
         const finishReason = candidates[0].finishReason;
         if (finishReason !== undefined) {
             engine.log(`Finish Reason: ${finishReason}`);
         }
+        if (finishReason === "FINISH_REASON_MAX_TOKENS" && candidates[0].content === undefined) {
+            throw new Error(`No response content generated. Finish Reason: ${finishReason}`);
+        } else if (finishReason !== "FINISH_REASON_MAX_TOKENS" &&candidates[0].content === undefined) {
+            engine.log('No content in the candidate.');
+        } else {
+            answers.push(candidates[0].content.parts[0].text);
+        }
+
         if (usageMetadata !== undefined) {
             if (usageMetadata.promptTokenCount !== undefined) {
                 engine.log(`Prompt Token Count: ${usageMetadata.promptTokenCount}`);
@@ -346,6 +349,7 @@ const invokeModel = (auth, region, projectId, model, maxTokens, temperature, sto
             }
         }
     }
+
     return answers.join('');
 };
 
@@ -502,7 +506,7 @@ test('Region Code is invalid - no hyphens', () => {
     const privateKeyId = 'key-12345';
     const region = 'invalidregioncode';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const serviceAccount = 'service@questetra.com';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
@@ -518,7 +522,7 @@ test('Region Code is invalid - too many characters', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'northamerica-northamericatoooomany1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -548,7 +552,7 @@ test('Maximum number of tokens must be a positive integer - includes a non-numer
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const maxTokens = '1.1';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, '', '', message);
@@ -564,7 +568,7 @@ test('Maximum number of tokens must be a positive integer - 0', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const maxTokens = '0';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, '', '', message);
@@ -580,7 +584,7 @@ test('Invalid temperature - includes a non-numeric character', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const maxTokens = '100';
     const temperature = '-0.1';
     const message = 'Hi. How are you?';
@@ -597,7 +601,7 @@ test('Invalid temperature - bigger than 2', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const maxTokens = '100';
     const temperature = '2.1';
     const message = 'Hi. How are you?';
@@ -614,7 +618,7 @@ test('Too many stop sequences', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const maxTokens = '100';
     const temperature = '1.0';
     const stopSequences = 'a\n'.repeat(6);
@@ -632,7 +636,7 @@ test('Message is empty', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', '');
 
     assertError('User Message is empty.');
@@ -647,7 +651,7 @@ test('Scope is empty', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const message = 'Hi. How are you?';
     prepareConfigs(scope, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -664,7 +668,7 @@ test('Required scope is missing', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const message = 'Hi. How are you?';
     prepareConfigs(ANOTHER_SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -679,7 +683,7 @@ test('Private Key ID is empty', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -695,7 +699,7 @@ test('Service Account is empty', () => {
     const serviceAccount = '';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -744,7 +748,7 @@ test('Attached file is too large', () => {
     const serviceAccount = 'service@example.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash-lite';
     const message = 'Please describe each image attached.';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -764,7 +768,7 @@ test('Attached file is neither an image, video nor audio', () => {
     const serviceAccount = 'service@example.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash';
     const message = 'Please describe each image attached.';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -890,7 +894,7 @@ test('Fail to request', () => {
     const serviceAccount = 'service@questetra.com';
     const region = 'asia-northeast1';
     const projectId = 'project-67890';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash-lite';
     const message = 'Hi. How are you?';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
 
@@ -910,6 +914,105 @@ test('Fail to request', () => {
 });
 
 /**
+ * API リクエストが 200 レスポンスを返すが、トークン切れで回答が空の場合
+ * text フィールドを持つ content がない場合
+ */
+test('No response content generated - no content with text field', () => {
+    const privateKeyId = 'key-12345';
+    const serviceAccount = 'service@questetra.com';
+    const region = 'asia-northeast1';
+    const projectId = 'project-67890';
+    const model = 'gemini-2.0-flash';
+    const maxTokens = '100';
+    const temperature = '1';
+    const message = 'Hi. How are you?';
+    prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, temperature, '', message);
+
+
+    const token = 'token';
+    let reqCount = 0;
+    httpClient.setRequestHandler((request) => {
+        if (reqCount++ === 0) {
+            assertTokenRequest(request, SCOPE, serviceAccount);
+            return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({
+                'access_token': token
+            }));
+        }
+        assertRequest(request, token, region, projectId, model, 100, 1, [], message);
+
+        const responseObj = {
+            "candidates": [{
+                "content": {
+                    "parts": [
+                    ]
+                },
+                "finishReason": "FINISH_REASON_MAX_TOKENS",
+                "safetyRatings": [],
+                "citationMetadata": {
+                    "citations": []
+                }
+            }]
+    };
+
+
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    assertError('No response content generated. Finish Reason: FINISH_REASON_MAX_TOKENS');
+});
+
+/**
+ * API リクエストが 200 レスポンスを返すが、トークン切れで回答が空の場合
+ * text フィールドの値が空の場合
+ */
+test('No response content generated - text field is blank', () => {
+    const privateKeyId = 'key-12345';
+    const serviceAccount = 'service@questetra.com';
+    const region = 'asia-northeast1';
+    const projectId = 'project-67890';
+    const model = 'gemini-2.0-flash-lite';
+    const maxTokens = '100';
+    const temperature = '1';
+    const message = 'Hi. How are you?';
+    prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, maxTokens, temperature, '', message);
+
+
+    const token = 'token';
+    let reqCount = 0;
+    httpClient.setRequestHandler((request) => {
+        if (reqCount++ === 0) {
+            assertTokenRequest(request, SCOPE, serviceAccount);
+            return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({
+                'access_token': token
+            }));
+        }
+        assertRequest(request, token, region, projectId, model, 100, 1, [], message);
+
+        const responseObj = {
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {
+                            "text": ''
+                        }
+                ]
+                },
+                "finishReason": "FINISH_REASON_MAX_TOKENS",
+                "safetyRatings": [],
+                "citationMetadata": {
+                    "citations": []
+                }
+            }]
+    };
+
+
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
+    });
+
+    assertError('No response content generated. Finish Reason: FINISH_REASON_MAX_TOKENS');
+});
+
+/**
  * 成功
  * gemini-1.0-pro
  * 必須スコープのみ
@@ -921,7 +1024,7 @@ test('Success - with max tokens, no attached files', () => {
     const region = 'asia-northeast1';
     const projectId = 'project-12345';
     const serviceAccount = 'service@example.com';
-    const model = 'gemini-1.0-pro';
+    const model = 'gemini-2.0-flash';
     const maxTokens = '2048';
     const temperature = '0.5';
     const stopSequences = 'a\nb\nc\nd\ne\n';
@@ -959,7 +1062,7 @@ test('Success - withmax tokens, empty attached files', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash-lite';
     const maxTokens = '1024';
     const temperature = '0';
     const message = 'こんにちは。';
@@ -996,7 +1099,7 @@ test('Success - with default tokens, with a number of attached images', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-flash';
+    const model = 'gemini-2.0-flash';
     const message = 'Please describe each image attached.';
     const answerDef = prepareConfigs(scope, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', '', '', message);
     
@@ -1037,7 +1140,7 @@ test('Success - with default tokens, with an attached video', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash-lite';
     const temperature = '1.00';
     const message = 'Please describe the video attached.';
     const answerDef = prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', temperature, '', message);
@@ -1076,7 +1179,7 @@ test('Success - with default tokens, with a video and an audio', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash';
     const temperature = '2.00';
     const message = 'Please describe the video attached.';
     const answerDef = prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', temperature, '', message);
@@ -1117,7 +1220,7 @@ test('Success - includes candidate without content', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash-lite';
     const temperature = '';
     const message = 'Hi. How are you?';
     const answerDef = prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', temperature, '', message);
@@ -1169,7 +1272,7 @@ test('Success - with default tokens, with a image and an PDF', () => {
     const region = 'asia-southeast1';
     const projectId = 'project-67890';
     const serviceAccount = 'service@questetra.com';
-    const model = 'gemini-1.5-pro';
+    const model = 'gemini-2.0-flash';
     const temperature = '1.00';
     const message = 'Please describe the image and pdf attached.';
     prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, region, projectId, model, '', temperature, '', message);

--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -338,8 +338,12 @@ const invokeModel = (auth, region, projectId, model, maxTokens, temperature, sto
             engine.log(`Finish Reason: ${finishReason}`);
         }
         if (usageMetadata !== undefined) {
-            engine.log(`Prompt Token Count: ${usageMetadata.promptTokenCount !== undefined ? usageMetadata.promptTokenCount : 0}`);
-            engine.log(`Candidates Token Count: ${usageMetadata.candidatesTokenCount !== undefined ? usageMetadata.candidatesTokenCount : 0}`);
+            if (usageMetadata.promptTokenCount !== undefined) {
+                engine.log(`Prompt Token Count: ${usageMetadata.promptTokenCount}`);
+            }
+            if (usageMetadata.candidatesTokenCount !== undefined) {
+                engine.log(`Candidates Token Count: ${usageMetadata.candidatesTokenCount}`);
+            }
         }
     }
     return answers.join('');


### PR DESCRIPTION
@tatsumiQ さん
Google Vertex AI: Gemini: チャット　推論でトークン切れになり、応答が空の場合、異常終了となるように対応したのですが、
テストコードのビルドで、

javax.script.ScriptException: expected: <No response content generated. Finish Reason: FINISH_REASON_MAX_TOKENS> but was: <{candidates: [{content: {...}, finishReason: "FINISH_REASON_MAX_TOKENS", safetyRatings: [], citationMetadata: {...}}]} is not iterable>

のエラーが出ます。

対応した箇所は、331 ～ 340 行あたり
対応したテストコードは　915 ～ 1013 行あたりです。

330 行目の
for (const {candidates, usageMetadata} of json)
とは、 for 文とは異なる処理ですか？以下を参照したのですが、違いがよく分かりません。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Statements/for...of
