### PR TITLE
t10690 OpenAI DALL-E: 画像生成　GPT Image1 モデルを追加する  アイテム名の変更、gpt-image-1モデルを追加

### DIFF
--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2024-07-22</last-modified>
+    <last-modified>2025-07-17</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
-    <label>OpenAI DALL-E: Generate Image</label>
-    <label locale="ja">OpenAI DALL-E: 画像生成</label>
+    <label>OpenAI: Generate Image</label>
+    <label locale="ja">OpenAI: 画像生成</label>
 
     <help-page-url>https://support.questetra.com/bpmn-icons/service-task-openai-dalle-image-generate/
     </help-page-url>
@@ -36,6 +36,9 @@
             <item value="dall-e-3">
                 <label>dall-e-3</label>
             </item>
+            <item value="gpt-image-1">
+                <label>gpt-image-1</label>
+            </item>
         </config>
         <config name="conf_Prompt" required="true" el-enabled="true" form-type="TEXTFIELD">
             <label>C3: Prompt</label>
@@ -48,21 +51,40 @@
                 <label>1024x1024</label>
             </item>
             <item value="1792x1024">
-                <label>1792x1024</label>
+                <label>1792x1024 (dall-e-3)</label>
             </item>
             <item value="1024x1792">
-                <label>1024x1792</label>
+                <label>1024x1792 (dall-e-3)</label>
+            </item>
+            <item value="1536x1024">
+                <label>1536x1024 (gpt-image-1)</label>
+            </item>
+            <item value="1024x1536">
+                <label>1024x1536 (gpt-image-1)</label>
             </item>
             <item value="512x512">
-                <label>512x512</label>
+                <label>512x512 (dall-e-2)</label>
             </item>
             <item value="256x256">
-                <label>256x256</label>
+                <label>256x256 (dall-e-2)</label>
+            </item>
+        </config>
+        <config name="conf_Format" form-type="SELECT_ITEM">
+            <label>C5: Image Format (gpt-image-1 only / PNG if not selected)</label>
+            <label locale="ja">C5: 画像形式 (gpt-image-1 のみ／未設定の場合、PNG)</label>
+            <item value="png">
+                <label>PNG</label>
+            </item>
+            <item value="jpg">
+                <label>JPEG</label>
+            </item>
+            <item value="webp">
+                <label>WEBP</label>
             </item>
         </config>
         <config name="conf_Style" form-type="SELECT_ITEM">
-            <label>C5: Image Style</label>
-            <label locale="ja">C5: 画像スタイル</label>
+            <label>C6: Image Style</label>
+            <label locale="ja">C6: 画像スタイル</label>
             <item value="vivid">
                 <label>vivid</label>
             </item>
@@ -71,22 +93,31 @@
             </item>
         </config>
         <config name="conf_Quality" form-type="SELECT_ITEM">
-            <label>C6: Image Quality</label>
-            <label locale="ja">C6: 画像品質</label>
+            <label>C7: Image Quality</label>
+            <label locale="ja">C7: 画像品質</label>
             <item value="standard">
-                <label>standard</label>
+                <label>standard (dall-e-3)</label>
             </item>
             <item value="hd">
-                <label>hd</label>
+                <label>hd (dall-e-3)</label>
+            </item>
+            <item value="high">
+                <label>high (gpt-image-1)</label>
+            </item>
+            <item value="medium">
+                <label>medium (gpt-image-1)</label>
+            </item>
+            <item value="low">
+                <label>low (gpt-image-1)</label>
             </item>
         </config>
         <config name="conf_File" required="true" form-type="SELECT" select-data-type="FILE">
-            <label>C7: Data item to add the generated file</label>
-            <label locale="ja">C7: 生成されたファイルを追加保存するデータ項目</label>
+            <label>C8: Data item to add the generated file</label>
+            <label locale="ja">C8: 生成されたファイルを追加保存するデータ項目</label>
         </config>
         <config name="conf_FileName" form-type="TEXTFIELD" required="true" el-enabled="true">
-            <label>C8: File name to save as</label>
-            <label locale="ja">C8: 保存する際のファイル名</label>
+            <label>C9: File name to save as</label>
+            <label locale="ja">C9: 保存する際のファイル名</label>
         </config>
     </configs>
 
@@ -103,6 +134,7 @@ function main() {
 
     const size = retriveSelectItem('conf_Size');
     const style = retriveSelectItem('conf_Style');
+    const format = retriveSelectFormatItem('conf_Format');
     const quality = retriveSelectItem('conf_Quality');
     const fileName = configs.get('conf_FileName');
     if (fileName === '') {
@@ -110,7 +142,7 @@ function main() {
     }
 
     ////// == 演算 / Calculating ==
-    const newFile = generateImage(auth, organizationId, model, prompt, size, style, quality, fileName);
+    const newFile = generateImage(auth, organizationId, model, prompt, size, style, format, quality, fileName);
 
     saveFileData('conf_File', newFile);
 }
@@ -130,17 +162,32 @@ const retriveSelectItem = (configName) => {
 };
 
 /**
+ * form-type="SELECT_ITEM" format の設定値を取得する
+ * 空の場合、png を返す
+ * @param configName
+ * @returns {undefined|String}
+ */
+const retriveSelectFormatItem = () => {
+    const value = configs.get("conf_Format");
+    if (value === '') {
+        return "png";
+    }
+    return value;
+};
+
+/**
  * 画像生成
  * @param auth
  * @param organizationId
  * @param model
  * @param prompt
  * @param size
+ * @param output_format
  * @param style
  * @param quality
  * @returns {String} answer1
  */
-const generateImage = (auth, organizationId, model, prompt, size, style, quality, fileName) => {
+const generateImage = (auth, organizationId, model, prompt, size, style, format, quality, fileName) => {
     // https://platform.openai.com/docs/guides/safety-best-practices
     // Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse.
     const user = `m${processInstance.getProcessModelInfoId().toString()}`;
@@ -150,12 +197,21 @@ const generateImage = (auth, organizationId, model, prompt, size, style, quality
         model,
         prompt,
         size,
-        style,
         quality,
         user,
         n: 1,
-        response_format: 'b64_json'
     };
+
+    if (model === "gpt-image-1") {
+        Object.assign(requestJson, {
+            output_format: format
+        });
+    } else {
+        Object.assign(requestJson, {
+            style,
+            response_format: 'b64_json'
+        });
+    }
 
     let request = httpClient.begin().authSetting(auth)
         .body(JSON.stringify(requestJson), 'application/json');
@@ -172,11 +228,20 @@ const generateImage = (auth, organizationId, model, prompt, size, style, quality
     }
     const responseJson = JSON.parse(responseBody);
     const image = base64.decodeFromStringToByteArray(responseJson.data[0].b64_json);
-    return new com.questetra.bpms.core.event.scripttask.NewQfile(
-        fileName,
-        "image/png",
-        image
-    );
+
+    if (model === "gpt-image-1"){
+        return new com.questetra.bpms.core.event.scripttask.NewQfile(
+            fileName,
+            `image/${format}`,
+            image
+        );
+    } else {
+        return new com.questetra.bpms.core.event.scripttask.NewQfile(
+            fileName,
+            "image/png",
+            image
+        );
+    }
 };
 
 /**
@@ -238,13 +303,14 @@ const saveFileData = (configName, newFile) => {
  * @param {String} model
  * @param {String} prompt
  * @param {String} size
+ * @param {String} format
  * @param {String} style
  * @param {String} quality
  * @param {String} fileName
  * @param {null|Array<Object>} files
  * @returns {DataDefinitionView} fileDef
  */
-const prepareConfigs = (authKey, organizationId, model, prompt, size, style, quality, fileName, files) => {
+const prepareConfigs = (authKey, organizationId, model, prompt, size, format, style, quality, fileName, files) => {
     const authSetting = httpClient.createAuthSettingToken('ChatGPT', authKey);
     configs.putObject('conf_Auth', authSetting);
 
@@ -252,6 +318,7 @@ const prepareConfigs = (authKey, organizationId, model, prompt, size, style, qua
     configs.put('conf_Model', model);
     configs.put('conf_Prompt', prompt);
     configs.put('conf_Size', size);
+    configs.put('conf_Format', format);
     configs.put('conf_Style', style);
     configs.put('conf_Quality', quality);
     configs.put('conf_FileName', fileName);
@@ -284,7 +351,7 @@ const assertError = (errorMsg) => {
  * マルチバイト文字を含む
  */
 test('OrganizationId is invalid', () => {
-    prepareConfigs('key', 'そしき', 'dall-e-2', 'Prompt', '512x512', '', '', 'test.png', null);
+    prepareConfigs('key', 'そしき', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
     assertError("node.event.intermediate.message.throwing.http.header.invalid");
 });
 
@@ -292,7 +359,7 @@ test('OrganizationId is invalid', () => {
  * プロンプトが空
  */
 test('Prompt is empty', () => {
-    prepareConfigs('key', '', 'dall-e-2', '', '512x512', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'dall-e-2', '', '512x512', '', '', '', 'test.png', null);
     assertError('Prompt is empty.');
 });
 
@@ -300,7 +367,7 @@ test('Prompt is empty', () => {
  * ファイル名が空
  */
 test('FileName is empty', () => {
-    prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', null);
+    prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', '', null);
     assertError('File name is empty.');
 });
 
@@ -317,6 +384,7 @@ test('FileName is empty', () => {
  * @param {String} model
  * @param {String} prompt
  * @param {String} size
+ * @param {String} format
  * @param {String} style
  * @param {String} quality
  */
@@ -326,7 +394,7 @@ const assertRequest = ({
                            contentType,
                            headers,
                            body
-                       }, authKey, organizationId, model, prompt, size, style, quality) => {
+                       }, authKey, organizationId, model, prompt, size, format, style, quality) => {
     expect(url).toEqual('https://api.openai.com/v1/images/generations');
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
@@ -338,20 +406,26 @@ const assertRequest = ({
     expect(bodyObj.model).toEqual(model);
     expect(bodyObj.prompt).toEqual(prompt);
     expect(bodyObj.size).toEqual(size);
+    if (model === "gpt-image-1") {
+        expect(bodyObj.output_format).toEqual(format);
+    }
     expect(bodyObj.style).toEqual(style);
     expect(bodyObj.quality).toEqual(quality);
     expect(bodyObj.n).toEqual(1);
-    expect(bodyObj.response_format).toEqual('b64_json');
+    //expect(bodyObj.response_format).toEqual('b64_json');
+    if (model !== "gpt-image-1") {
+        expect(bodyObj.response_format).toEqual('b64_json');
+    }
 };
 
 /**
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('invalidKey', '', 'dall-e-2', 'Prompt', '512x512', '', '', 'test.png', null);
+    prepareConfigs('invalidKey', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'invalidKey', '', 'dall-e-2', 'Prompt', '512x512', undefined, undefined);
+        assertRequest(request, 'invalidKey', '', 'dall-e-2', 'Prompt', '512x512', '', undefined, undefined);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -390,10 +464,10 @@ const assertFile = (file, name, contentType, body) => {
  * 成功
  */
 test('Success to request', () => {
-    const fileDef = prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', 'test.png', null);
+    const fileDef = prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'dall-e-2', 'Prompt', '512x512', undefined, undefined);
+        assertRequest(request, 'key', '', 'dall-e-2', 'Prompt', '512x512', '', undefined, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
     });
     main();
@@ -410,12 +484,12 @@ test('Success to request', () => {
  * 生成された画像を保存するデータ項目に、他のファイルがすでに添付されている場合
  */
 test('Success to request - with organization ID, Style, Quality', () => {
-    const fileDef = prepareConfigs('key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', 'vivid', 'hd', 'image.png', null);
+    const fileDef = prepareConfigs('key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', '', 'vivid', 'hd', 'image.png', null);
     // 生成された画像を保存するデータ項目に、他のファイルをあらかじめ添付しておく
     engine.setData(fileDef, [engine.createQfile('既存のファイル.json', 'application/json', '{}')]);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', 'vivid', 'hd');
+        assertRequest(request, 'key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', '', 'vivid', 'hd');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("png"));
     });
     main();
@@ -425,6 +499,25 @@ test('Success to request - with organization ID, Style, Quality', () => {
     expect(files.size()).toEqual(2);
     assertFile(files.get(0), '既存のファイル.json', 'application/json', '{}');
     assertFile(files.get(1), 'image.png', 'image/png', 'png');
+});
+
+/**
+ * 成功 - サイズ / 画像形式 / 品質を指定
+ * gpt-image-1
+ */
+test('Success to request - Size, Format, Quality', () => {
+    const fileDef = prepareConfigs('key', '', 'gpt-image-1', 'Prompt', '1024x1792', 'webp', '', 'high', 'test.webp', null);
+
+    httpClient.setRequestHandler(request => {
+        assertRequest(request, 'key', '', 'gpt-image-1', 'Prompt', '1024x1792', 'webp', undefined, 'high');
+        return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
+    });
+    main();
+
+    // データ項目の値をチェック
+    const files = engine.findData(fileDef);
+    expect(files.size()).toEqual(1);
+    assertFile(files.get(0), 'test.webp', 'image/webp', 'image');
 });
 
     ]]></test>


### PR DESCRIPTION
@tatsumiQ さん

アイテム名を「OpenAI: 画像生成」に変更しました。
モデルの候補に gpt-image-1 を追加しました。
gpt-image-1 で指定できる画像形式パラメータ　output_format を追加しました。
「Amazon Bedrock: Stability AI: 画像生成」を参考にし、サイズの次の順にしました。 

ご確認をお願いします。