### PR TITLE
t10944 開始: Gmail: メール受信時　検索条件の修正／古すぎる timestamp で取り込まれなかったメールのログ出力

### DIFF
--- a/start_event/gmail-message-received.xml
+++ b/start_event/gmail-message-received.xml
@@ -3,7 +3,7 @@
     <addon-type>START_EVENT</addon-type>
     <label>Start: Gmail: Email Message Received</label>
     <label locale="ja">開始: Gmail: メール受信時</label>
-    <last-modified>2025-10-02</last-modified>
+    <last-modified>2025-10-06</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
@@ -181,7 +181,7 @@ function getMessages(auth, labelIds, limit, timestampLowerLimit) {
             if (isOld) {
                 engine.log(`excluded by timestampLowerLimit: id=${msg.id}, timestamp=${datetimeFormatter.format(msg.timestamp)}`);
             }
-        return !isOld; // timestampLowerLimit 以前のものを除外
+            return !isOld; // timestampLowerLimit 以前のものを除外
         });
 }
 


### PR DESCRIPTION
@tatsumiQ  さん

修正しました。ご確認をお願いします。