### PR TITLE
T11091: OpenAI ChatGPT: チャット　モデルの選択肢に gpt-5.1 / gpt-5.2 を追加　推論量の選択肢を追加

### DIFF
--- a/chatgpt-chat-completion.xml
+++ b/chatgpt-chat-completion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2025-10-02</last-modified>
+    <last-modified>2025-12-19</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -66,6 +66,12 @@
             <item value="gpt-5-nano">
                 <label>gpt-5-nano</label>
             </item>
+            <item value="gpt-5.1">
+                <label>gpt-5.1</label>
+            </item>
+            <item value="gpt-5.2">
+                <label>gpt-5.2</label>
+            </item>
             <item value="o1">
                 <label>o1</label>
             </item>
@@ -84,8 +90,12 @@
             <label locale="ja">C3: 使用するトークン数の上限（空白の場合、2048）</label>
         </config>
         <config name="conf_ReasoningEffort" form-type="SELECT_ITEM">
-            <label>C4: Reasoning Effort (Only supported for o- and gpt-5 series)</label>
-            <label locale="ja">C4: 推論量 (o-シリーズ、gpt-5 シリーズのみ指定可能)</label>
+            <label>C4: Reasoning Effort (Only for o-, gpt-5 and later series)</label>
+            <label locale="ja">C4: 推論量 (o-シリーズ、gpt-5 シリーズ以降のみ指定可能)</label>
+            <item value="none">
+                <label>none (Only for gpt-5.1 and gpt-5.2)</label>
+                <label locale="ja">none (gpt-5.1 と gpt-5.2 のみ)</label>
+            </item>
             <item value="minimal">
                 <label>minimal (Only for gpt-5 series)</label>
                 <label locale="ja">minimal (gpt-5 シリーズのみ)</label>
@@ -94,16 +104,20 @@
                 <label>low</label>
             </item>
             <item value="medium">
-                <label>medium (default)</label>
-                <label locale="ja">medium (デフォルト)</label>
+                <label>medium</label>
+                <label locale="ja">medium</label>
             </item>
             <item value="high">
                 <label>high</label>
             </item>
+            <item value="xhigh">
+                <label>xhigh (Only for gpt-5.2)</label>
+                <label locale="ja">xhigh (gpt-5.2 のみ)</label>
+            </item>
         </config>
         <config name="conf_Verbosity" form-type="SELECT_ITEM">
-            <label>C5: Verbosity (Only supported for gpt-5 series)</label>
-            <label locale="ja">C5: 回答量 (gpt-5 シリーズのみ指定可能)</label>
+            <label>C5: Verbosity (Only for gpt-5 and later series)</label>
+            <label locale="ja">C5: 回答量 (gpt-5 シリーズ以降のみ指定可能)</label>
             <item value="low">
                 <label>low</label>
             </item>


### PR DESCRIPTION
選択肢を追加しただけなので、単体テストはとくに変更していません。