### PR TITLE
T11245 Google Vertex AI: Gemini: チャット　モデルの選択肢から gemini-2.0-flash gemini-2.0-flash-lite を削除／添付ファイルの解像度、思考の要約を保存するデータ項目を指定できるように

### DIFF
--- a/google-vertexai-gemini-chat.xml
+++ b/google-vertexai-gemini-chat.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Google Vertex AI: Gemini: Chat</label>
     <label locale="ja">Google Vertex AI: Gemini: チャット</label>
-    <last-modified>2026-01-19</last-modified>
+    <last-modified>2026-01-27</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item sends a message to a Gemini model on Google Vertex AI
         and stores the response in the specified data item.</summary>
@@ -128,7 +128,7 @@ const main = () => {
         throw new Error('User Message is empty.');
     }
     const inlineImages = retrieveImages();
-    const mediaResolution = configs.get('conf_Image1Resolution');
+    const mediaResolution = configs.get('conf_Images1Resolution');
 
     ////// == 演算 / Calculating ==
     const {answer, thought} = invokeModel(
@@ -639,7 +639,7 @@ const prepareConfigs = (
     configs.put('conf_StopSequences', stopSequences);
     configs.put('conf_Message1', message);
     configs.put('conf_ThinkingLevel', thinkingLevel);
-    configs.put('conf_Image1Resolution', mediaResolution);
+    configs.put('conf_Images1Resolution', mediaResolution);
     if (thoughtDef !== null) {
         configs.putObject('conf_Thought1', thoughtDef);
     }


### PR DESCRIPTION
添付ファイルの解像度の設定読み出し時の config 名が誤っていたので、修正しました。