### PR TITLE
t11520 タイマー開始: kintone: レコード数　「プロセス」を「ケース」に変更

### DIFF
--- a/start_event/kintone-num-of-records.xml
+++ b/start_event/kintone-num-of-records.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <addon-type>START_EVENT_TIMER</addon-type>
-    <last-modified>2023-08-08</last-modified>
+    <last-modified>2026-04-20</last-modified>
     <engine-type>3</engine-type>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <label>Timer Start: kintone: Number of Records</label>
     <label locale="ja">タイマー開始: kintone: レコード数</label>
-    <summary>This item periodically starts processes with the number of records matching the search query from a Kintone
-        App. In each string type data item of each process, each record ID will be set.
+    <summary>This item periodically starts cases with the number of records matching the search query from a Kintone
+        App. In each string type data item of each case, each record ID will be set.
     </summary>
-    <summary locale="ja">このアイテムは、kintone アプリから検索クエリに合致するレコード数の数だけ、定期的にプロセスを開始します。
-        各プロセスの文字型データ項目には、それぞれのレコード ID が設定されます。
+    <summary locale="ja">このアイテムは、kintone アプリから検索クエリに合致するレコード数の数だけ、定期的にケースを開始します。
+        各ケースの文字型データ項目には、それぞれのレコード ID が設定されます。
     </summary>
     <configs>
         <config name="conf_auth" required="true" form-type="OAUTH2" auth-type="TOKEN">


### PR DESCRIPTION
@hatanaka-akihiro さん

ケースログで
`typeError: invokeMember (getOAuth2Token) on com.questetra.bpms.core.event.scripttask.HttpClientWrapper failed due to: Cannot convert 'kintone API Token'(language: Java, type: com.oracle.truffle.api.strings.TruffleString) to Java type 'com.questetra.bpms.core.event.scripttask.AuthSettingWrapper': Unsupported target type. at line number 36`
のエラーが出ます。

詳細はチケットで質問します