### PR TITLE
T11527: Microsoft Teams: チャンネルに投稿　の作成

### DIFF
--- a/microsoft-teams-channel-post.xml
+++ b/microsoft-teams-channel-post.xml
@@ -4,7 +4,7 @@
     <addon-version>2</addon-version>
     <label>Microsoft Teams: Post to Channel</label>
     <label locale="ja">Microsoft Teams: チャンネルに投稿</label>
-    <last-modified>2026-04-21</last-modified>
+    <last-modified>2026-04-22</last-modified>
     <license>(C) Questetra, Inc. (MIT License)</license>
     <summary>This item posts a message, or a reply to a message, in a channel on Microsoft Teams.</summary>
     <summary locale="ja">この工程は、Microsoft Teams のチャンネルに、メッセージまたはメッセージへの返信を投稿します。</summary>
@@ -40,8 +40,8 @@
 
     <script><![CDATA[
 // OAuth2 config sample at [OAuth 2.0 Setting]
-// - Authorization Endpoint URL: https://login.microsoftonline.com/{your-tenant-id}/oauth2/v2.0/authorize
-// - Token Endpoint URL: https://login.microsoftonline.com/{your-tenant-id}/oauth2/v2.0/token
+// - Authorization Endpoint URL: https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize
+// - Token Endpoint URL: https://login.microsoftonline.com/organizations/oauth2/v2.0/token
 // - Scope: ChannnelMessage.Send offline_access
 // - Consumer Key: (Get by Microsoft Azure Active Directory)
 // - Consumer Secret: (Get by Microsoft Azure Active Directory)
@@ -175,7 +175,6 @@ const post = (oauth2, teamId, channelId, messageId, subject, markdownText) => {
         engine.log(responseStr);
         throw new Error(`Failed to post message. status: ${status}`);
     }
-    engine.log(responseStr); // テスト用
     return JSON.parse(responseStr).webUrl;
 };
 


### PR DESCRIPTION
テスト用のログ出力が残っていたので、削除。
ついでに、コメントの OAuth2 エンドポイントを tenant-id を使わないものに変更。