### PR TITLE
T11600: OpenAI: 画像生成　モデル選択肢に gpt-image-2, gpt-image-1-mini を追加／gpt-image-1, dall-e-2, dall-e-3 を削除／モデル、サイズを固定値で指定できるように

### DIFF
--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -144,7 +144,7 @@ const retrieveSize = () => {
     }
 
     // 1. 基本的な形式チェック: 数字x数字（1〜4桁）
-    const formatRegex = /^(\d{1,4})x(\d{1,4})$/i;
+    const formatRegex = /^([1-9]\d{0,3})x([1-9]\d{0,3})$/;
     const match = size.match(formatRegex);
     if (!match) {
         throw new Error('Size is invalid. It must be WIDTHxHEIGHT.');

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -27,7 +27,7 @@
             </label>
             <label locale="ja">C-deprecated: 組織 ID（空白の場合、デフォルトの組織）</label>
         </config>
-        <config name="conf_Model" required="true" form-type="SELECT_ITEM">
+        <config name="conf_Model" required="true" form-type="SELECT_ITEM" editable="true">
             <label>C2: Model</label>
             <label locale="ja">C2: モデル</label>
             <item value="gpt-image-2">
@@ -41,34 +41,22 @@
             <label>C3: Prompt</label>
             <label locale="ja">C3: プロンプト</label>
         </config>
-        <config name="conf_Size" form-type="SELECT_ITEM">
+        <config name="conf_Size" form-type="SELECT_ITEM" editable="true">
             <label>C4: Image Size (auto if not selected)</label>
             <label locale="ja">C4: 画像サイズ (未設定の場合、自動)</label>
             <item value="1024x1024">
                 <label>1024x1024</label>
             </item>
-            <item value="512x512">
-                <label>512x512 (dall-e-2)</label>
-            </item>
-            <item value="256x256">
-                <label>256x256 (dall-e-2)</label>
-            </item>
-            <item value="1792x1024">
-                <label>1792x1024 (dall-e-3)</label>
-            </item>
-            <item value="1024x1792">
-                <label>1024x1792 (dall-e-3)</label>
-            </item>
             <item value="1536x1024">
-                <label>1536x1024 (gpt-image-1)</label>
+                <label>1536x1024</label>
             </item>
             <item value="1024x1536">
-                <label>1024x1536 (gpt-image-1)</label>
+                <label>1024x1536</label>
             </item>
         </config>
         <config name="conf_Format" form-type="SELECT_ITEM">
-            <label>C5: Image Format (Only supported for gpt-image-1)</label>
-            <label locale="ja">C5: 画像形式 (gpt-image-1 のみ指定可能)</label>
+            <label>C5: Image Format</label>
+            <label locale="ja">C5: 画像形式</label>
             <item value="png">
                 <label>PNG (default)</label>
                 <label locale="ja">PNG (デフォルト)</label>
@@ -80,34 +68,17 @@
                 <label>WEBP</label>
             </item>
         </config>
-        <config name="conf_Style" form-type="SELECT_ITEM">
-            <label>C6: Image Style (Only supported for dall-e-3)</label>
-            <label locale="ja">C6: 画像スタイル (dall-e-3 のみ指定可能)</label>
-            <item value="vivid">
-                <label>vivid (default)</label>
-                <label locale="ja">vivid (デフォルト)</label>
-            </item>
-            <item value="natural">
-                <label>natural</label>
-            </item>
-        </config>
         <config name="conf_Quality" form-type="SELECT_ITEM">
             <label>C7: Image Quality (auto if not selected)</label>
             <label locale="ja">C7: 画像品質 (未設定の場合、自動)</label>
-            <item value="standard">
-                <label>standard (dall-e-3)</label>
-            </item>
-            <item value="hd">
-                <label>hd (dall-e-3)</label>
-            </item>
             <item value="low">
-                <label>low (gpt-image-1)</label>
+                <label>low</label>
             </item>
             <item value="medium">
-                <label>medium (gpt-image-1)</label>
+                <label>medium</label>
             </item>
             <item value="high">
-                <label>high (gpt-image-1)</label>
+                <label>high</label>
             </item>
         </config>
         <config name="conf_File" required="true" form-type="SELECT" select-data-type="FILE">
@@ -131,17 +102,16 @@ function main() {
         throw new Error('Prompt is empty.');
     }
 
-    const size = retriveSelectItem('conf_Size');
-    const style = retriveSelectItem('conf_Style');
-    const format = retriveSelectItem('conf_Format');
-    const quality = retriveSelectItem('conf_Quality');
+    const size = retrieveSelectItem('conf_Size');
+    const format = retrieveSelectItem('conf_Format');
+    const quality = retrieveSelectItem('conf_Quality');
     const fileName = configs.get('conf_FileName');
     if (fileName === '') {
         throw new Error('File name is empty.');
     }
 
     ////// == 演算 / Calculating ==
-    const newFile = generateImage(auth, organizationId, model, prompt, size, style, format, quality, fileName);
+    const newFile = generateImage(auth, organizationId, model, prompt, size, format, quality, fileName);
 
     saveFileData('conf_File', newFile);
 }
@@ -152,7 +122,7 @@ function main() {
  * @param configName
  * @returns {undefined|String}
  */
-const retriveSelectItem = (configName) => {
+const retrieveSelectItem = (configName) => {
     const value = configs.get(configName);
     if (value === '') {
         return undefined;
@@ -168,11 +138,10 @@ const retriveSelectItem = (configName) => {
  * @param prompt
  * @param size
  * @param output_format
- * @param style
  * @param quality
  * @returns {String} answer1
  */
-const generateImage = (auth, organizationId, model, prompt, size, style, format, quality, fileName) => {
+const generateImage = (auth, organizationId, model, prompt, size, format, quality, fileName) => {
     // https://platform.openai.com/docs/guides/safety-best-practices
     // Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse.
     const user = `m${processInstance.getProcessModelInfoId().toString()}`;
@@ -182,18 +151,11 @@ const generateImage = (auth, organizationId, model, prompt, size, style, format,
         model,
         prompt,
         size,
-        style,
         output_format: format,
         quality,
         user,
         n: 1,
     };
-
-    if (model !== "gpt-image-1") {
-        Object.assign(requestJson, {
-            response_format: 'b64_json'
-        });
-    }
 
     let request = httpClient.begin().authSetting(auth)
         .body(JSON.stringify(requestJson), 'application/json');
@@ -212,7 +174,7 @@ const generateImage = (auth, organizationId, model, prompt, size, style, format,
     const image = base64.decodeFromStringToByteArray(responseJson.data[0].b64_json);
 
     let contentType = "image/png";
-    if (model === "gpt-image-1" && format !== undefined) {
+    if (format !== undefined) {
         contentType = `image/${format}`;
     }
 
@@ -386,14 +348,10 @@ const assertRequest = ({
     expect(bodyObj.prompt).toEqual(prompt);
     expect(bodyObj.size).toEqual(size);
     expect(bodyObj.output_format).toEqual(format);
-    expect(bodyObj.style).toEqual(style);
+    expect(bodyObj.style).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
     expect(bodyObj.quality).toEqual(quality);
     expect(bodyObj.n).toEqual(1);
-    if (model !== "gpt-image-1") {
-        expect(bodyObj.response_format).toEqual('b64_json');
-    } else {
-        expect(bodyObj.response_format).toEqual(undefined);
-    }
+    expect(bodyObj.response_format).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
 };
 
 /**

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2026-05-22</last-modified>
+    <last-modified>2026-05-26</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -96,13 +96,13 @@ function main() {
     ////// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const auth = configs.getObject('conf_Auth');   /// REQUIRED
     const organizationId = configs.get('conf_OrganizationId');
-    const model = configs.get('conf_Model');
+    const model = retrieveModel();
     const prompt = configs.get('conf_Prompt');
     if (prompt === '') {
         throw new Error('Prompt is empty.');
     }
 
-    const size = retrieveSelectItem('conf_Size');
+    const size = retrieveSize();
     const format = retrieveSelectItem('conf_Format');
     const quality = retrieveSelectItem('conf_Quality');
     const fileName = configs.get('conf_FileName');
@@ -115,6 +115,67 @@ function main() {
 
     saveFileData('conf_File', newFile);
 }
+
+/**
+ * config からモデル ID を読み出す
+ * モデル ID として不正な場合はエラー
+ * @return {String}
+ */
+const retrieveModel = () => {
+    const model = configs.get('conf_Model');
+    const reg = new RegExp('^[a-z0-9.-]+$');
+    if (!reg.test(model)) {
+        throw new Error('Model is invalid. It contains an invalid character.');
+    }
+    return model;
+};
+
+/**
+ * config からサイズを読み出す
+ * 形式: WIDTHxHEIGHT (例: 1920x1080)
+ * 指定なしの場合は 'auto'
+ * サイズとして不正な場合はエラー
+ * @return {String}
+ */
+const retrieveSize = () => {
+    const size = retrieveSelectItem('conf_Size');
+    if (size === undefined) {
+        return 'auto';
+    }
+
+    // 1. 基本的な形式チェック: 数字x数字（1〜4桁）
+    const formatRegex = /^(\d{1,4})x(\d{1,4})$/i;
+    const match = size.match(formatRegex);
+    if (!match) {
+        throw new Error('Size is invalid. It must be WIDTHxHEIGHT.');
+    }
+    const width = parseInt(match[1], 10);
+    const height = parseInt(match[2], 10);
+
+    // 2. 各値が16の倍数か確認
+    if (width % 16 !== 0 || height % 16 !== 0) {
+        throw new Error('Size is invalid. Both width and height must be divisible by 16.');
+    }
+
+    // 3. 最大値チェック
+    const MAX_DIMENSION = 3840;
+    const MAX_OTHER_DIMENSION = 2160;
+    const isValidSize =
+        (width <= MAX_DIMENSION && height <= MAX_OTHER_DIMENSION) ||
+        (width <= MAX_OTHER_DIMENSION && height <= MAX_DIMENSION);
+    if (!isValidSize) {
+        throw new Error(`Size is invalid. It exceeds maximum. MAX: ${MAX_DIMENSION}x${MAX_OTHER_DIMENION} or ${MAX_OTHER_DIMENION}x${MAX_DIMENSION}`);
+    }
+
+    // 4. 比率チェック（1:3 ～ 3:1）
+    const MAX_RATIO = 3;
+    const ratio = Math.max(width, height) / Math.min(width, height);
+    if (ratio > MAX_RATIO) {
+        throw new Error(`Size is invalid. Its aspect ratio out of range. Allowed: 1:${MAX_RATIO} to ${MAX_RATIO}:1`);
+    }
+
+    return size;
+};
 
 /**
  * form-type="SELECT_ITEM" の設定値を取得する

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -180,7 +180,7 @@ const retrieveSize = () => {
         (width <= MAX_DIMENSION && height <= MAX_OTHER_DIMENSION) ||
         (width <= MAX_OTHER_DIMENSION && height <= MAX_DIMENSION);
     if (!isValidSize) {
-        throw new Error(`Size is invalid. It exceeds maximum. MAX: ${MAX_DIMENSION}x${MAX_OTHER_DIMENION} or ${MAX_OTHER_DIMENION}x${MAX_DIMENSION}`);
+        throw new Error(`Size is invalid. It exceeds maximum. MAX: ${MAX_DIMENSION}x${MAX_OTHER_DIMENSION} or ${MAX_OTHER_DIMENSION}x${MAX_DIMENSION}`);
     }
 
     // 4. 比率チェック（1:3 ～ 3:1）
@@ -329,13 +329,13 @@ const saveFileData = (configName, newFile) => {
  * @param {String} prompt
  * @param {String} size
  * @param {String} format
- * @param {String} style
+ * @param {String} background
  * @param {String} quality
  * @param {String} fileName
  * @param {null|Array<Object>} files
  * @returns {DataDefinitionView} fileDef
  */
-const prepareConfigs = (authKey, organizationId, model, prompt, size, format, style, quality, fileName, files) => {
+const prepareConfigs = (authKey, organizationId, model, prompt, size, format, background, quality, fileName, files) => {
     const authSetting = httpClient.createAuthSettingToken('ChatGPT', authKey);
     configs.putObject('conf_Auth', authSetting);
 
@@ -344,7 +344,7 @@ const prepareConfigs = (authKey, organizationId, model, prompt, size, format, st
     configs.put('conf_Prompt', prompt);
     configs.put('conf_Size', size);
     configs.put('conf_Format', format);
-    configs.put('conf_Style', style);
+    configs.put('conf_Background', background);
     configs.put('conf_Quality', quality);
     configs.put('conf_FileName', fileName);
 
@@ -372,11 +372,20 @@ const assertError = (errorMsg) => {
 };
 
 /**
+ * モデル ID が不正
+ * 不正な文字を含む
+ */
+test('Model is invalid', () => {
+    prepareConfigs('key', '', 'gpt-image-2!', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
+    assertError('Model is invalid. It contains an invalid character.');
+});
+
+/**
  * OraganizationId が不正
  * マルチバイト文字を含む
  */
 test('OrganizationId is invalid', () => {
-    prepareConfigs('key', 'そしき', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
+    prepareConfigs('key', 'そしき', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
     assertError("node.event.intermediate.message.throwing.http.header.invalid");
 });
 
@@ -384,15 +393,55 @@ test('OrganizationId is invalid', () => {
  * プロンプトが空
  */
 test('Prompt is empty', () => {
-    prepareConfigs('key', '', 'dall-e-2', '', '512x512', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2', '', '1024x1024', '', '', '', 'test.png', null);
     assertError('Prompt is empty.');
+});
+
+/**
+ * サイズが不正 - WIDTHxHEIGHT 形式でない
+ */
+test('Size is invalid - bad format', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024-1024', '', '', '', 'test.png', null);
+    assertError('Size is invalid. It must be WIDTHxHEIGHT.');
+});
+
+/**
+ * サイズが不正 - 16の倍数でない
+ */
+test('Size is invalid - not divisible by 16', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1000x1024', '', '', '', 'test.png', null);
+    assertError('Size is invalid. Both width and height must be divisible by 16.');
+});
+
+/**
+ * サイズが不正 - 最大値超過
+ */
+test('Size is invalid - exceeds maximum', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '3856x3856', '', '', '', 'test.png', null);
+    assertError('Size is invalid. It exceeds maximum. MAX: 3840x2160 or 2160x3840');
+});
+
+/**
+ * サイズが不正 - アスペクト比が範囲外
+ */
+test('Size is invalid - aspect ratio out of range', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '2048x512', '', '', '', 'test.png', null);
+    assertError('Size is invalid. Its aspect ratio out of range. Allowed: 1:3 to 3:1');
+});
+
+/**
+ * 背景透過 + JPEG の組み合わせエラー
+ */
+test('Background transparent with JPEG format', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', 'jpeg', 'transparent', '', 'test.jpg', null);
+    assertError('When background is transparent, image format must be either PNG (default) or WEBP.');
 });
 
 /**
  * ファイル名が空
  */
 test('FileName is empty', () => {
-    prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', '', null);
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', '', null);
     assertError('File name is empty.');
 });
 
@@ -410,7 +459,7 @@ test('FileName is empty', () => {
  * @param {String} prompt
  * @param {String} size
  * @param {String} format
- * @param {String} style
+ * @param {String} background
  * @param {String} quality
  */
 const assertRequest = ({
@@ -419,7 +468,7 @@ const assertRequest = ({
                            contentType,
                            headers,
                            body
-                       }, authKey, organizationId, model, prompt, size, format, style, quality) => {
+                       }, authKey, organizationId, model, prompt, size, format, background, quality) => {
     expect(url).toEqual('https://api.openai.com/v1/images/generations');
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
@@ -432,9 +481,10 @@ const assertRequest = ({
     expect(bodyObj.prompt).toEqual(prompt);
     expect(bodyObj.size).toEqual(size);
     expect(bodyObj.output_format).toEqual(format);
-    expect(bodyObj.style).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
+    expect(bodyObj.background).toEqual(background);
     expect(bodyObj.quality).toEqual(quality);
     expect(bodyObj.n).toEqual(1);
+    expect(bodyObj.style).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
     expect(bodyObj.response_format).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
 };
 
@@ -442,10 +492,10 @@ const assertRequest = ({
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('invalidKey', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
+    prepareConfigs('invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'invalidKey', '', 'dall-e-2', 'Prompt', '512x512', undefined, undefined, undefined);
+        assertRequest(request, 'invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', undefined, undefined, undefined);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -461,7 +511,12 @@ const createResponse = (image) => {
         "created": Math.floor(Date.now() / 1000),
         "data": [{
             b64_json: base64.encodeToString(image)
-        }]
+        }],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "total_tokens": 300
+        }
     };
     return JSON.stringify(responseObj);
 };
@@ -481,13 +536,14 @@ const assertFile = (file, name, contentType, body) => {
 };
 
 /**
- * 成功
+ * 成功 - 最小限の設定
+ * gpt-image-2 / サイズ・形式・背景・品質はすべて未指定
  */
-test('Success to request', () => {
-    const fileDef = prepareConfigs('key', '', 'dall-e-2', 'Prompt', '512x512', '', '', '', 'test.png', null);
+test('Success - gpt-image-2, minimum config', () => {
+    const fileDef = prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'dall-e-2', 'Prompt', '512x512', undefined, undefined, undefined);
+        assertRequest(request, 'key', '', 'gpt-image-2', 'Prompt', undefined, undefined, undefined, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
     });
     main();
@@ -498,19 +554,19 @@ test('Success to request', () => {
     assertFile(files.get(0), 'test.png', 'image/png', 'image');
 });
 
-
 /**
- * 成功 - 組織 ID / スタイル / 品質を指定
+ * 成功 - 組織 ID / サイズ / 形式 / 背景 / 品質を指定
+ * gpt-image-1-mini / WEBP + 透過背景
  * 生成された画像を保存するデータ項目に、他のファイルがすでに添付されている場合
  */
-test('Success to request - with organization ID, Style, Quality', () => {
-    const fileDef = prepareConfigs('key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', '', 'vivid', 'hd', 'image.png', null);
+test('Success - gpt-image-1-mini, with organization ID, all params', () => {
+    const fileDef = prepareConfigs('key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'transparent', 'high', 'image.webp', null);
     // 生成された画像を保存するデータ項目に、他のファイルをあらかじめ添付しておく
     engine.setData(fileDef, [engine.createQfile('既存のファイル.json', 'image/png', '{}')]);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key2', 'org', 'dall-e-3', '綺麗な画像', '1024x1024', undefined, 'vivid', 'hd');
-        return httpClient.createHttpResponse(200, 'application/json', createResponse("png"));
+        assertRequest(request, 'key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'transparent', 'high');
+        return httpClient.createHttpResponse(200, 'application/json', createResponse("webp-data"));
     });
     main();
 
@@ -518,26 +574,26 @@ test('Success to request - with organization ID, Style, Quality', () => {
     const files = engine.findData(fileDef);
     expect(files.size()).toEqual(2);
     assertFile(files.get(0), '既存のファイル.json', 'image/png', '{}');
-    assertFile(files.get(1), 'image.png', 'image/png', 'png');
+    assertFile(files.get(1), 'image.webp', 'image/webp', 'webp-data');
 });
 
 /**
- * 成功 - サイズ / 画像形式 / 品質を指定
- * gpt-image-1
+ * 成功 - 編集可能な SELECT_ITEM で任意のモデル ID を指定
+ * gpt-image-1.5 / JPEG + 不透過背景
  */
-test('Success to request - Size, Format, Quality', () => {
-    const fileDef = prepareConfigs('key', '', 'gpt-image-1', 'Prompt', '1024x1792', 'webp', '', 'high', 'test.webp', null);
+test('Success - gpt-image-1.5, custom model ID', () => {
+    const fileDef = prepareConfigs('key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'opaque', 'medium', 'test.jpg', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'gpt-image-1', 'Prompt', '1024x1792', 'webp', undefined, 'high');
-        return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
+        assertRequest(request, 'key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'opaque', 'medium');
+        return httpClient.createHttpResponse(200, 'application/json', createResponse("jpeg-data"));
     });
     main();
 
     // データ項目の値をチェック
     const files = engine.findData(fileDef);
     expect(files.size()).toEqual(1);
-    assertFile(files.get(0), 'test.webp', 'image/webp', 'image');
+    assertFile(files.get(0), 'test.jpg', 'image/jpeg', 'jpeg-data');
 });
 
     ]]></test>

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2026-05-29</last-modified>
+    <last-modified>2026-06-02</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -21,11 +21,6 @@
                 auth-type="TOKEN">
             <label>C1: Authorization Setting in which Project API Key is set</label>
             <label locale="ja">C1: プロジェクトに紐づく API キーを設定した認証設定</label>
-        </config>
-        <config deprecated="true" name="conf_OrganizationId" required="false" form-type="TEXTFIELD">
-            <label>C-deprecated: Organization ID (Default organization if blank)
-            </label>
-            <label locale="ja">C-deprecated: 組織 ID（空白の場合、デフォルトの組織）</label>
         </config>
         <config name="conf_Model" required="true" form-type="SELECT_ITEM" editable="true">
             <label>C2: Model</label>
@@ -95,7 +90,6 @@
 function main() {
     ////// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const auth = configs.getObject('conf_Auth');   /// REQUIRED
-    const organizationId = configs.get('conf_OrganizationId');
     const model = retrieveModel();
     const prompt = configs.get('conf_Prompt');
     if (prompt === '') {
@@ -111,7 +105,7 @@ function main() {
     }
 
     ////// == 演算 / Calculating ==
-    const newFile = generateImage(auth, organizationId, model, prompt, size, format, quality, fileName);
+    const newFile = generateImage(auth, model, prompt, size, format, quality, fileName);
 
     saveFileData('conf_File', newFile);
 }
@@ -170,7 +164,6 @@ const retrieveSelectItem = (configName) => {
 /**
  * 画像生成
  * @param auth
- * @param organizationId
  * @param model
  * @param prompt
  * @param size
@@ -178,7 +171,7 @@ const retrieveSelectItem = (configName) => {
  * @param quality
  * @returns {String} answer1
  */
-const generateImage = (auth, organizationId, model, prompt, size, format, quality, fileName) => {
+const generateImage = (auth, model, prompt, size, format, quality, fileName) => {
     // https://platform.openai.com/docs/guides/safety-best-practices
     // Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse.
     const user = `m${processInstance.getProcessModelInfoId().toString()}`;
@@ -194,12 +187,9 @@ const generateImage = (auth, organizationId, model, prompt, size, format, qualit
         n: 1,
     };
 
-    let request = httpClient.begin().authSetting(auth)
-        .body(JSON.stringify(requestJson), 'application/json');
-    if (organizationId !== null && organizationId !== '') {
-        request = request.header('OpenAI-Organization', organizationId);
-    }
-    const response = request.post('https://api.openai.com/v1/images/generations');
+    const response = httpClient.begin().authSetting(auth)
+        .body(JSON.stringify(requestJson), 'application/json')
+        .post('https://api.openai.com/v1/images/generations');
 
     const responseCode = response.getStatusCode();
     const responseBody = response.getResponseAsString();
@@ -282,7 +272,6 @@ const saveFileData = (configName, newFile) => {
 /**
  * 設定の準備
  * @param {String} authKey
- * @param {String} organizationId
  * @param {String} model
  * @param {String} prompt
  * @param {String} size
@@ -292,11 +281,9 @@ const saveFileData = (configName, newFile) => {
  * @param {null|Array<Object>} files
  * @returns {DataDefinitionView} fileDef
  */
-const prepareConfigs = (authKey, organizationId, model, prompt, size, format, quality, fileName, files) => {
+const prepareConfigs = (authKey, model, prompt, size, format, quality, fileName, files) => {
     const authSetting = httpClient.createAuthSettingToken('ChatGPT', authKey);
     configs.putObject('conf_Auth', authSetting);
-
-    configs.put('conf_OrganizationId', organizationId);
     configs.put('conf_Model', model);
     configs.put('conf_Prompt', prompt);
     configs.put('conf_Size', size);
@@ -332,24 +319,15 @@ const assertError = (errorMsg) => {
  * 不正な文字を含む
  */
 test('Model is invalid', () => {
-    prepareConfigs('key', '', 'gpt-image-2!', 'Prompt', '1024x1024', '', '', 'test.png', null);
+    prepareConfigs('key', 'gpt-image-2!', 'Prompt', '1024x1024', '', '', 'test.png', null);
     assertError('Model is invalid. It contains an invalid character.');
-});
-
-/**
- * OraganizationId が不正
- * マルチバイト文字を含む
- */
-test('OrganizationId is invalid', () => {
-    prepareConfigs('key', 'そしき', 'gpt-image-2', 'Prompt', '1024x1024', '', '', 'test.png', null);
-    assertError("node.event.intermediate.message.throwing.http.header.invalid");
 });
 
 /**
  * プロンプトが空
  */
 test('Prompt is empty', () => {
-    prepareConfigs('key', '', 'gpt-image-2', '', '1024x1024', '', '', 'test.png', null);
+    prepareConfigs('key', 'gpt-image-2', '', '1024x1024', '', '', 'test.png', null);
     assertError('Prompt is empty.');
 });
 
@@ -357,7 +335,7 @@ test('Prompt is empty', () => {
  * サイズが不正 - WIDTHxHEIGHT 形式でない
  */
 test('Size is invalid - bad format', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024-1024', '', '', 'test.png', null);
+    prepareConfigs('key', 'gpt-image-2', 'Prompt', '1024-1024', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
@@ -365,7 +343,7 @@ test('Size is invalid - bad format', () => {
  * サイズが不正 - width が 0 始まり
  */
 test('Size is invalid - width starts with 0', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '0512x1024', '', '', 'test.png', null);
+    prepareConfigs('key', 'gpt-image-2', 'Prompt', '0512x1024', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
@@ -373,7 +351,7 @@ test('Size is invalid - width starts with 0', () => {
  * サイズが不正 - height が 0 始まり
  */
 test('Size is invalid - height starts with 0', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x0512', '', '', 'test.png', null);
+    prepareConfigs('key', 'gpt-image-2', 'Prompt', '1024x0512', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
@@ -381,7 +359,7 @@ test('Size is invalid - height starts with 0', () => {
  * ファイル名が空
  */
 test('FileName is empty', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', null);
+    prepareConfigs('key', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', null);
     assertError('File name is empty.');
 });
 
@@ -394,7 +372,6 @@ test('FileName is empty', () => {
  * @param request.headers
  * @param request.body
  * @param {String} authKey
- * @param {String} organizationId
  * @param {String} model
  * @param {String} prompt
  * @param {String} size
@@ -407,14 +384,11 @@ const assertRequest = ({
                            contentType,
                            headers,
                            body
-                       }, authKey, organizationId, model, prompt, size, format, quality) => {
+                       }, authKey, model, prompt, size, format, quality) => {
     expect(url).toEqual('https://api.openai.com/v1/images/generations');
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     expect(headers['Authorization']).toEqual(`Bearer ${authKey}`);
-    if (organizationId !== '') {
-        expect(headers['OpenAI-Organization']).toEqual(organizationId);
-    }
     const bodyObj = JSON.parse(body);
     expect(bodyObj.model).toEqual(model);
     expect(bodyObj.prompt).toEqual(prompt);
@@ -430,10 +404,10 @@ const assertRequest = ({
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', 'test.png', null);
+    prepareConfigs('invalidKey', 'gpt-image-2', 'Prompt', '1024x1024', '', '', 'test.png', null);
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', undefined, undefined);
+        assertRequest(request, 'invalidKey', 'gpt-image-2', 'Prompt', '1024x1024', undefined, undefined);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -478,10 +452,10 @@ const assertFile = (file, name, contentType, body) => {
  * gpt-image-2 / サイズ・形式・品質はすべて未指定
  */
 test('Success - gpt-image-2, minimum config', () => {
-    const fileDef = prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '', '', '', 'test.png', null);
+    const fileDef = prepareConfigs('key', 'gpt-image-2', 'Prompt', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'gpt-image-2', 'Prompt', undefined, undefined, undefined);
+        assertRequest(request, 'key', 'gpt-image-2', 'Prompt', undefined, undefined, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
     });
     main();
@@ -493,17 +467,17 @@ test('Success - gpt-image-2, minimum config', () => {
 });
 
 /**
- * 成功 - 組織 ID / サイズ / 形式 / 品質を指定
+ * 成功 - サイズ / 形式 / 品質を指定
  * gpt-image-1-mini / WEBP
  * 生成された画像を保存するデータ項目に、他のファイルがすでに添付されている場合
  */
-test('Success - gpt-image-1-mini, with organization ID, all params', () => {
-    const fileDef = prepareConfigs('key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high', 'image.webp', null);
+test('Success - gpt-image-1-mini, all params', () => {
+    const fileDef = prepareConfigs('key2', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high', 'image.webp', null);
     // 生成された画像を保存するデータ項目に、他のファイルをあらかじめ添付しておく
     engine.setData(fileDef, [engine.createQfile('既存のファイル.json', 'image/png', '{}')]);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high');
+        assertRequest(request, 'key2', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("webp-data"));
     });
     main();
@@ -520,10 +494,10 @@ test('Success - gpt-image-1-mini, with organization ID, all params', () => {
  * gpt-image-1.5 / JPEG
  */
 test('Success - gpt-image-1.5, custom model ID', () => {
-    const fileDef = prepareConfigs('key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium', 'test.jpg', null);
+    const fileDef = prepareConfigs('key', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium', 'test.jpg', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium');
+        assertRequest(request, 'key', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("jpeg-data"));
     });
     main();

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -148,9 +148,10 @@ const retrieveModel = () => {
 
 /**
  * config からサイズを読み出す
- * 形式: WIDTHxHEIGHT (例: 1920x1080)
+ * 形式: WIDTHxHEIGHT (例: 1024x1024)
  * 指定なしの場合は undefined
- * サイズとして不正な場合はエラー
+ * 形式が不正な場合はエラー
+ * 細かなバリデーションは API に任せ、ここではチェックしない
  * @return {String}
  */
 const retrieveSize = () => {
@@ -159,35 +160,10 @@ const retrieveSize = () => {
         return undefined;
     }
 
-    // 1. 基本的な形式チェック: 数字x数字（1〜4桁）
+    // 基本的な形式チェック: 数字x数字（1〜4桁）
     const formatRegex = /^([1-9]\d{0,3})x([1-9]\d{0,3})$/;
-    const match = size.match(formatRegex);
-    if (!match) {
+    if (!formatRegex.test(size)) {
         throw new Error('Size is invalid. It must be WIDTHxHEIGHT.');
-    }
-    const width = parseInt(match[1], 10);
-    const height = parseInt(match[2], 10);
-
-    // 2. 各値が16の倍数か確認
-    if (width % 16 !== 0 || height % 16 !== 0) {
-        throw new Error('Size is invalid. Both width and height must be divisible by 16.');
-    }
-
-    // 3. 最大値チェック
-    const MAX_DIMENSION = 3840;
-    const MAX_OTHER_DIMENSION = 2160;
-    const isValidSize =
-        (width <= MAX_DIMENSION && height <= MAX_OTHER_DIMENSION) ||
-        (width <= MAX_OTHER_DIMENSION && height <= MAX_DIMENSION);
-    if (!isValidSize) {
-        throw new Error(`Size is invalid. It exceeds maximum. MAX: ${MAX_DIMENSION}x${MAX_OTHER_DIMENSION} or ${MAX_OTHER_DIMENSION}x${MAX_DIMENSION}`);
-    }
-
-    // 4. 比率チェック（1:3 ～ 3:1）
-    const MAX_RATIO = 3;
-    const ratio = Math.max(width, height) / Math.min(width, height);
-    if (ratio > MAX_RATIO) {
-        throw new Error(`Size is invalid. Its aspect ratio out of range. Allowed: 1:${MAX_RATIO} to ${MAX_RATIO}:1`);
     }
 
     return size;
@@ -406,27 +382,19 @@ test('Size is invalid - bad format', () => {
 });
 
 /**
- * サイズが不正 - 16の倍数でない
+ * サイズが不正 - width が 0 始まり
  */
-test('Size is invalid - not divisible by 16', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1000x1024', '', '', '', 'test.png', null);
-    assertError('Size is invalid. Both width and height must be divisible by 16.');
+test('Size is invalid - width starts with 0', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '0512x1024', '', '', '', 'test.png', null);
+    assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
 /**
- * サイズが不正 - 最大値超過
+ * サイズが不正 - height が 0 始まり
  */
-test('Size is invalid - exceeds maximum', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '3856x3856', '', '', '', 'test.png', null);
-    assertError('Size is invalid. It exceeds maximum. MAX: 3840x2160 or 2160x3840');
-});
-
-/**
- * サイズが不正 - アスペクト比が範囲外
- */
-test('Size is invalid - aspect ratio out of range', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '2048x512', '', '', '', 'test.png', null);
-    assertError('Size is invalid. Its aspect ratio out of range. Allowed: 1:3 to 3:1');
+test('Size is invalid - height starts with 0', () => {
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x0512', '', '', '', 'test.png', null);
+    assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
 /**

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2026-05-26</last-modified>
+    <last-modified>2026-05-29</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -68,21 +68,9 @@
                 <label>WEBP</label>
             </item>
         </config>
-        <config name="conf_Background" form-type="SELECT_ITEM">
-            <label>C6: Image Background (auto if not selected)</label>
-            <label locale="ja">C6: 画像背景 (未設定の場合、自動）</label>
-            <item value="transparent">
-                <label>transparent (Image Format must be either PNG or WEBP)</label>
-                <label locale="ja">透過する（画像形式が PNG または WEBP の場合のみ）</label>
-            </item>
-            <item value="opaque">
-                <label>opaque</label>
-                <label locale="ja">透過しない</label>
-            </item>
-        </config>
         <config name="conf_Quality" form-type="SELECT_ITEM">
-            <label>C7: Image Quality (auto if not selected)</label>
-            <label locale="ja">C7: 画像品質 (未設定の場合、自動)</label>
+            <label>C6: Image Quality (auto if not selected)</label>
+            <label locale="ja">C6: 画像品質 (未設定の場合、自動)</label>
             <item value="low">
                 <label>low</label>
             </item>
@@ -94,12 +82,12 @@
             </item>
         </config>
         <config name="conf_File" required="true" form-type="SELECT" select-data-type="FILE">
-            <label>C8: Data item to add the generated file</label>
-            <label locale="ja">C8: 生成されたファイルを追加保存するデータ項目</label>
+            <label>C7: Data item to add the generated file</label>
+            <label locale="ja">C7: 生成されたファイルを追加保存するデータ項目</label>
         </config>
         <config name="conf_FileName" form-type="TEXTFIELD" required="true" el-enabled="true">
-            <label>C9: File name to save as</label>
-            <label locale="ja">C9: 保存する際のファイル名</label>
+            <label>C8: File name to save as</label>
+            <label locale="ja">C8: 保存する際のファイル名</label>
         </config>
     </configs>
 
@@ -116,10 +104,6 @@ function main() {
 
     const size = retrieveSize();
     const format = retrieveSelectItem('conf_Format');
-    const background = retrieveSelectItem('conf_Background');
-    if (background === 'transparent' && format === 'jpeg') {
-        throw new Error('When background is transparent, image format must be either PNG (default) or WEBP.');
-    }
     const quality = retrieveSelectItem('conf_Quality');
     const fileName = configs.get('conf_FileName');
     if (fileName === '') {
@@ -127,7 +111,7 @@ function main() {
     }
 
     ////// == 演算 / Calculating ==
-    const newFile = generateImage(auth, organizationId, model, prompt, size, format, background, quality, fileName);
+    const newFile = generateImage(auth, organizationId, model, prompt, size, format, quality, fileName);
 
     saveFileData('conf_File', newFile);
 }
@@ -191,11 +175,10 @@ const retrieveSelectItem = (configName) => {
  * @param prompt
  * @param size
  * @param format
- * @param background
  * @param quality
  * @returns {String} answer1
  */
-const generateImage = (auth, organizationId, model, prompt, size, format, background, quality, fileName) => {
+const generateImage = (auth, organizationId, model, prompt, size, format, quality, fileName) => {
     // https://platform.openai.com/docs/guides/safety-best-practices
     // Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse.
     const user = `m${processInstance.getProcessModelInfoId().toString()}`;
@@ -206,7 +189,6 @@ const generateImage = (auth, organizationId, model, prompt, size, format, backgr
         prompt,
         size,
         output_format: format,
-        background,
         quality,
         user,
         n: 1,
@@ -305,13 +287,12 @@ const saveFileData = (configName, newFile) => {
  * @param {String} prompt
  * @param {String} size
  * @param {String} format
- * @param {String} background
  * @param {String} quality
  * @param {String} fileName
  * @param {null|Array<Object>} files
  * @returns {DataDefinitionView} fileDef
  */
-const prepareConfigs = (authKey, organizationId, model, prompt, size, format, background, quality, fileName, files) => {
+const prepareConfigs = (authKey, organizationId, model, prompt, size, format, quality, fileName, files) => {
     const authSetting = httpClient.createAuthSettingToken('ChatGPT', authKey);
     configs.putObject('conf_Auth', authSetting);
 
@@ -320,7 +301,6 @@ const prepareConfigs = (authKey, organizationId, model, prompt, size, format, ba
     configs.put('conf_Prompt', prompt);
     configs.put('conf_Size', size);
     configs.put('conf_Format', format);
-    configs.put('conf_Background', background);
     configs.put('conf_Quality', quality);
     configs.put('conf_FileName', fileName);
 
@@ -352,7 +332,7 @@ const assertError = (errorMsg) => {
  * 不正な文字を含む
  */
 test('Model is invalid', () => {
-    prepareConfigs('key', '', 'gpt-image-2!', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2!', 'Prompt', '1024x1024', '', '', 'test.png', null);
     assertError('Model is invalid. It contains an invalid character.');
 });
 
@@ -361,7 +341,7 @@ test('Model is invalid', () => {
  * マルチバイト文字を含む
  */
 test('OrganizationId is invalid', () => {
-    prepareConfigs('key', 'そしき', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
+    prepareConfigs('key', 'そしき', 'gpt-image-2', 'Prompt', '1024x1024', '', '', 'test.png', null);
     assertError("node.event.intermediate.message.throwing.http.header.invalid");
 });
 
@@ -369,7 +349,7 @@ test('OrganizationId is invalid', () => {
  * プロンプトが空
  */
 test('Prompt is empty', () => {
-    prepareConfigs('key', '', 'gpt-image-2', '', '1024x1024', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2', '', '1024x1024', '', '', 'test.png', null);
     assertError('Prompt is empty.');
 });
 
@@ -377,7 +357,7 @@ test('Prompt is empty', () => {
  * サイズが不正 - WIDTHxHEIGHT 形式でない
  */
 test('Size is invalid - bad format', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024-1024', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024-1024', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
@@ -385,7 +365,7 @@ test('Size is invalid - bad format', () => {
  * サイズが不正 - width が 0 始まり
  */
 test('Size is invalid - width starts with 0', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '0512x1024', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '0512x1024', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
 });
 
@@ -393,23 +373,15 @@ test('Size is invalid - width starts with 0', () => {
  * サイズが不正 - height が 0 始まり
  */
 test('Size is invalid - height starts with 0', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x0512', '', '', '', 'test.png', null);
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x0512', '', '', 'test.png', null);
     assertError('Size is invalid. It must be WIDTHxHEIGHT.');
-});
-
-/**
- * 背景透過 + JPEG の組み合わせエラー
- */
-test('Background transparent with JPEG format', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', 'jpeg', 'transparent', '', 'test.jpg', null);
-    assertError('When background is transparent, image format must be either PNG (default) or WEBP.');
 });
 
 /**
  * ファイル名が空
  */
 test('FileName is empty', () => {
-    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', '', null);
+    prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', null);
     assertError('File name is empty.');
 });
 
@@ -427,7 +399,6 @@ test('FileName is empty', () => {
  * @param {String} prompt
  * @param {String} size
  * @param {String} format
- * @param {String} background
  * @param {String} quality
  */
 const assertRequest = ({
@@ -436,7 +407,7 @@ const assertRequest = ({
                            contentType,
                            headers,
                            body
-                       }, authKey, organizationId, model, prompt, size, format, background, quality) => {
+                       }, authKey, organizationId, model, prompt, size, format, quality) => {
     expect(url).toEqual('https://api.openai.com/v1/images/generations');
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
@@ -449,7 +420,6 @@ const assertRequest = ({
     expect(bodyObj.prompt).toEqual(prompt);
     expect(bodyObj.size).toEqual(size);
     expect(bodyObj.output_format).toEqual(format);
-    expect(bodyObj.background).toEqual(background);
     expect(bodyObj.quality).toEqual(quality);
     expect(bodyObj.n).toEqual(1);
     expect(bodyObj.style).toEqual(undefined); // 旧モデル用のパラメータが設定されていないことを確認
@@ -460,10 +430,10 @@ const assertRequest = ({
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', '', 'test.png', null);
+    prepareConfigs('invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', '', '', 'test.png', null);
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', undefined, undefined, undefined);
+        assertRequest(request, 'invalidKey', '', 'gpt-image-2', 'Prompt', '1024x1024', undefined, undefined);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -505,13 +475,13 @@ const assertFile = (file, name, contentType, body) => {
 
 /**
  * 成功 - 最小限の設定
- * gpt-image-2 / サイズ・形式・背景・品質はすべて未指定
+ * gpt-image-2 / サイズ・形式・品質はすべて未指定
  */
 test('Success - gpt-image-2, minimum config', () => {
-    const fileDef = prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '', '', '', '', 'test.png', null);
+    const fileDef = prepareConfigs('key', '', 'gpt-image-2', 'Prompt', '', '', '', 'test.png', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'gpt-image-2', 'Prompt', undefined, undefined, undefined, undefined);
+        assertRequest(request, 'key', '', 'gpt-image-2', 'Prompt', undefined, undefined, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("image"));
     });
     main();
@@ -523,17 +493,17 @@ test('Success - gpt-image-2, minimum config', () => {
 });
 
 /**
- * 成功 - 組織 ID / サイズ / 形式 / 背景 / 品質を指定
- * gpt-image-1-mini / WEBP + 透過背景
+ * 成功 - 組織 ID / サイズ / 形式 / 品質を指定
+ * gpt-image-1-mini / WEBP
  * 生成された画像を保存するデータ項目に、他のファイルがすでに添付されている場合
  */
 test('Success - gpt-image-1-mini, with organization ID, all params', () => {
-    const fileDef = prepareConfigs('key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'transparent', 'high', 'image.webp', null);
+    const fileDef = prepareConfigs('key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high', 'image.webp', null);
     // 生成された画像を保存するデータ項目に、他のファイルをあらかじめ添付しておく
     engine.setData(fileDef, [engine.createQfile('既存のファイル.json', 'image/png', '{}')]);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'transparent', 'high');
+        assertRequest(request, 'key2', 'org', 'gpt-image-1-mini', '綺麗な画像', '1536x1024', 'webp', 'high');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("webp-data"));
     });
     main();
@@ -547,13 +517,13 @@ test('Success - gpt-image-1-mini, with organization ID, all params', () => {
 
 /**
  * 成功 - 編集可能な SELECT_ITEM で任意のモデル ID を指定
- * gpt-image-1.5 / JPEG + 不透過背景
+ * gpt-image-1.5 / JPEG
  */
 test('Success - gpt-image-1.5, custom model ID', () => {
-    const fileDef = prepareConfigs('key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'opaque', 'medium', 'test.jpg', null);
+    const fileDef = prepareConfigs('key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium', 'test.jpg', null);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'opaque', 'medium');
+        assertRequest(request, 'key', '', 'gpt-image-1.5', 'Prompt', '1024x1536', 'jpeg', 'medium');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("jpeg-data"));
     });
     main();

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2025-09-01</last-modified>
+    <last-modified>2026-05-22</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -30,14 +30,11 @@
         <config name="conf_Model" required="true" form-type="SELECT_ITEM">
             <label>C2: Model</label>
             <label locale="ja">C2: モデル</label>
-            <item value="dall-e-2">
-                <label>dall-e-2</label>
+            <item value="gpt-image-2">
+                <label>gpt-image-2</label>
             </item>
-            <item value="dall-e-3">
-                <label>dall-e-3</label>
-            </item>
-            <item value="gpt-image-1">
-                <label>gpt-image-1</label>
+            <item value="gpt-image-1-mini">
+                <label>gpt-image-1-mini</label>
             </item>
         </config>
         <config name="conf_Prompt" required="true" el-enabled="true" form-type="TEXTFIELD">

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -55,8 +55,8 @@
             </item>
         </config>
         <config name="conf_Format" form-type="SELECT_ITEM">
-            <label>C5: Image Format</label>
-            <label locale="ja">C5: 画像形式</label>
+            <label>C5: Image Format (PNG if not selected)</label>
+            <label locale="ja">C5: 画像形式 (未設定の場合、PNG）</label>
             <item value="png">
                 <label>PNG (default)</label>
                 <label locale="ja">PNG (デフォルト)</label>
@@ -66,6 +66,18 @@
             </item>
             <item value="webp">
                 <label>WEBP</label>
+            </item>
+        </config>
+        <config name="conf_Background" form-type="SELECT_ITEM">
+            <label>C6: Image Background (auto if not selected)</label>
+            <label locale="ja">C6: 画像背景 (未設定の場合、自動）</label>
+            <item value="transparent">
+                <label>transparent (Image Format must be either PNG or WEBP)</label>
+                <label locale="ja">透過する（画像形式が PNG または WEBP の場合のみ）</label>
+            </item>
+            <item value="opaque">
+                <label>opaque</label>
+                <label locale="ja">透過しない</label>
             </item>
         </config>
         <config name="conf_Quality" form-type="SELECT_ITEM">
@@ -104,6 +116,10 @@ function main() {
 
     const size = retrieveSize();
     const format = retrieveSelectItem('conf_Format');
+    const background = retrieveSelectItem('conf_Background');
+    if (background === 'transparent' && format === 'jpeg') {
+        throw new Error('When background is transparent, image format must be either PNG (default) or WEBP.');
+    }
     const quality = retrieveSelectItem('conf_Quality');
     const fileName = configs.get('conf_FileName');
     if (fileName === '') {
@@ -111,7 +127,7 @@ function main() {
     }
 
     ////// == 演算 / Calculating ==
-    const newFile = generateImage(auth, organizationId, model, prompt, size, format, quality, fileName);
+    const newFile = generateImage(auth, organizationId, model, prompt, size, format, background, quality, fileName);
 
     saveFileData('conf_File', newFile);
 }
@@ -133,14 +149,14 @@ const retrieveModel = () => {
 /**
  * config からサイズを読み出す
  * 形式: WIDTHxHEIGHT (例: 1920x1080)
- * 指定なしの場合は 'auto'
+ * 指定なしの場合は undefined
  * サイズとして不正な場合はエラー
  * @return {String}
  */
 const retrieveSize = () => {
     const size = retrieveSelectItem('conf_Size');
     if (size === undefined) {
-        return 'auto';
+        return undefined;
     }
 
     // 1. 基本的な形式チェック: 数字x数字（1〜4桁）
@@ -198,11 +214,12 @@ const retrieveSelectItem = (configName) => {
  * @param model
  * @param prompt
  * @param size
- * @param output_format
+ * @param format
+ * @param background
  * @param quality
  * @returns {String} answer1
  */
-const generateImage = (auth, organizationId, model, prompt, size, format, quality, fileName) => {
+const generateImage = (auth, organizationId, model, prompt, size, format, background, quality, fileName) => {
     // https://platform.openai.com/docs/guides/safety-best-practices
     // Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse.
     const user = `m${processInstance.getProcessModelInfoId().toString()}`;
@@ -213,6 +230,7 @@ const generateImage = (auth, organizationId, model, prompt, size, format, qualit
         prompt,
         size,
         output_format: format,
+        background,
         quality,
         user,
         n: 1,

--- a/openai-dalle-image-generate.xml
+++ b/openai-dalle-image-generate.xml
@@ -171,6 +171,11 @@ const generateImage = (auth, organizationId, model, prompt, size, format, qualit
         throw new Error(`Failed to request. status: ${responseCode}`);
     }
     const responseJson = JSON.parse(responseBody);
+    const usage = responseJson.usage;
+    engine.log(`Input Tokens: ${usage.input_tokens}`);
+    engine.log(`Output Tokens: ${usage.output_tokens}`);
+    engine.log(`Total Tokens: ${usage.total_tokens}`);
+
     const image = base64.decodeFromStringToByteArray(responseJson.data[0].b64_json);
 
     let contentType = "image/png";


### PR DESCRIPTION
変更点まとめ

- モデルの入れ替え
  - 追加
    - gpt-image-2
    - gpt-image-1-mini
    - (gpt-image-1.5 も追加されているが、gpt-image-2 のほうが新しく、コストも安いため、選択肢に追加していない。固定値で指定可能)
  - 削除
    - gpt-image-1 : deprecated になったが、まだ使用可能。固定値で指定可能
    - dall-e-2 : 2026年5月12日でシャットダウン済み
    - dall-e-3 : 2026年5月12日でシャットダウン済み

- モデルを固定値で指定できるように
  - deprecated になったモデルが設定されたままになるように（gpt-image-1 は deprecated だが、まだシャットダウンはされていないので）
  - 選択肢に加えなかった gpt-image-1.5 も指定できるように

- サイズの選択肢を整理し、固定値でも指定できるように
  - dall-e 用の選択肢を削除
  - gpt モデル用の代表的な値を選択肢に残している
  - gpt-image-2 では、一定の条件を満たせば `WIDTHxHEIGHT` 形式で任意のサイズを指定できるので、固定値でも指定できるように

- ~画像背景を指定できるように~
  - ~`透過する` (transparent) または `透過しない` (opaque) を選択できる。指定なしの場合は自動（プロンプト次第）~
  - gpt-image-2 では背景の透過に対応していない。透過に対応しているモデルではプロンプトで指示すれば透過されるので、パラメータとしては追加しないことにした

- 画像スタイルを削除
  - dall-e-3 でしか指定できない設定項目のため

- 画像品質の dall-e 用の選択肢を削除