### PR TITLE
T11577: OpenAI ChatGPT: チャット　モデル選択肢の選択肢に gpt-5.5 を追加／deprecated になったモデルを削除

### DIFF
--- a/chatgpt-chat-completion.xml
+++ b/chatgpt-chat-completion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2026-06-01</last-modified>
+    <last-modified>2026-06-02</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -23,11 +23,6 @@
                 auth-type="TOKEN">
             <label>C1: Authorization Setting in which Project API Key is set</label>
             <label locale="ja">C1: プロジェクトに紐づく API キーを設定した認証設定</label>
-        </config>
-        <config deprecated="true" name="conf_OrganizationId" required="false" form-type="TEXTFIELD">
-            <label>C-deprecated: Organization ID (Default organization if blank)
-            </label>
-            <label locale="ja">C-deprecated: 組織 ID（空白の場合、デフォルトの組織）</label>
         </config>
         <config name="conf_Model" required="true"
                 form-type="SELECT_ITEM" editable="true">
@@ -167,7 +162,6 @@ const AVAILABLE_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/we
 function main() {
     ////// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const auth = configs.getObject('conf_Auth');   /// REQUIRED
-    const organizationId = configs.get('conf_OrganizationId');
     const model = configs.get('conf_Model');
     const maxTokens = retrieveMaxTokens();
     const reasoningEffort = retrieveSelectItem('conf_ReasoningEffort');
@@ -188,7 +182,7 @@ function main() {
     const imageDetail1 = retrieveSelectItem('conf_Images1Detail');
 
     ////// == 演算 / Calculating ==
-    const answer1 = createChat(auth, organizationId, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, requestUser, gptRole, message1, imageUrls1, imageDetail1);
+    const answer1 = createChat(auth, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, requestUser, gptRole, message1, imageUrls1, imageDetail1);
 
     ////// == ワークフローデータへの代入 / Data Updating ==
     saveData('conf_Answer1', answer1 ?? '');
@@ -293,7 +287,6 @@ const retrieveImageUrls = (configName) => {
 /**
  * チャットの実行
  * @param auth
- * @param organizationId
  * @param model
  * @param maxTokens
  * @param reasoningEffort
@@ -307,7 +300,7 @@ const retrieveImageUrls = (configName) => {
  * @param imageDetail1
  * @returns {String} answer1
  */
-const createChat = (auth, organizationId, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, requestUser, gptRole, message1, imageUrls1, imageDetail1) => {
+const createChat = (auth, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, requestUser, gptRole, message1, imageUrls1, imageDetail1) => {
     //// OpenAI API > Documentation > API REFERENCE > CHAT
     //// https://platform.openai.com/docs/api-reference/chat
 
@@ -351,12 +344,9 @@ const createChat = (auth, organizationId, model, maxTokens, reasoningEffort, ver
         content: message1Content
     });
 
-    let request = httpClient.begin().authSetting(auth)
-        .body(JSON.stringify(requestJson), 'application/json');
-    if (organizationId !== null && organizationId !== '') {
-        request = request.header('OpenAI-Organization', organizationId);
-    }
-    const response = request.post('https://api.openai.com/v1/chat/completions');
+    const response = httpClient.begin().authSetting(auth)
+        .body(JSON.stringify(requestJson), 'application/json')
+        .post('https://api.openai.com/v1/chat/completions');
 
     const responseCode = response.getStatusCode();
     const responseBody = response.getResponseAsString();
@@ -427,7 +417,6 @@ const saveData = (configName, data) => {
 /**
  * 設定の準備
  * @param {String} authKey
- * @param {String} organizationId
  * @param {String} model
  * @param {String} maxTokens
  * @param {String} reasoningEffort
@@ -438,11 +427,10 @@ const saveData = (configName, data) => {
  * @param {String} message
  * @returns {DataDefinitionView} answerDef
  */
-const prepareConfigs = (authKey, organizationId, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, gptRole, message) => {
+const prepareConfigs = (authKey, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, gptRole, message) => {
     const authSetting = httpClient.createAuthSettingToken('ChatGPT', authKey);
     configs.putObject('conf_Auth', authSetting);
 
-    configs.put('conf_OrganizationId', organizationId);
     configs.put('conf_Model', model);
     configs.put('conf_MaxTokens', maxTokens);
     configs.put('conf_ReasoningEffort', reasoningEffort);
@@ -479,7 +467,7 @@ const assertError = (errorMsg) => {
  * メッセージが空
  */
 test('Message is empty', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '', '', '', '');
+    prepareConfigs('key', 'gpt-5.5', '', '', '', '', '', '', '');
     assertError('User Message is empty.');
 });
 
@@ -487,7 +475,7 @@ test('Message is empty', () => {
  * トークン数の最大値が正の整数でない - 数字でない文字を含む場合
  */
 test('Maximum number of tokens must be a positive integer - includes a non-numeric character', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '1.1', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '1.1', '', '', '', '', '', 'こんにちは');
     assertError('Maximum number of tokens must be a positive integer.');
 });
 
@@ -495,7 +483,7 @@ test('Maximum number of tokens must be a positive integer - includes a non-numer
  * トークン数の最大値が正の整数でない - ゼロ
  */
 test('Maximum number of tokens must be a positive integer - 0', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '0', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '0', '', '', '', '', '', 'こんにちは');
     assertError('Maximum number of tokens must be a positive integer.');
 });
 
@@ -503,7 +491,7 @@ test('Maximum number of tokens must be a positive integer - 0', () => {
  * 温度が不正 - 数字、小数点でない文字を含む
  */
 test('Invalid temperature - includes a non-numeric character', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '-1', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '', '', '', '-1', '', '', 'こんにちは');
     assertError('Temperature must be a number from 0 to 2.');
 });
 
@@ -511,7 +499,7 @@ test('Invalid temperature - includes a non-numeric character', () => {
  * 温度が不正 - 2 を超える
  */
 test('Invalid temperature - bigger than 2', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '2.1', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '', '', '', '2.1', '', '', 'こんにちは');
     assertError('Temperature must be a number from 0 to 2.');
 });
 
@@ -523,7 +511,7 @@ test('Too many stop sequences', () => {
     for (let i = 0; i < MAX_STOP_SEQUENCE_NUM + 1; i++) {
         stopSequences += `stop${i}\n`;
     }
-    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '', stopSequences, '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '', '', '', '', stopSequences, '', 'こんにちは');
     assertError(`Too many stop sequences. The maximum number is ${MAX_STOP_SEQUENCE_NUM}.`);
 });
 
@@ -555,7 +543,7 @@ const createQfile = (name, contentType, size) => {
  * 添付画像のサイズが大きすぎる
  */
 test('Image file is too large', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
 
     // 添付画像を指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
@@ -571,7 +559,7 @@ test('Image file is too large', () => {
  * 添付画像の Content-Type がサポート外
  */
 test('Content-Type of image file is not supported', () => {
-    prepareConfigs('key', '', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
 
     // 添付画像を指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
@@ -593,7 +581,6 @@ test('Content-Type of image file is not supported', () => {
  * @param request.headers
  * @param request.body
  * @param {String} authKey
- * @param {String} organizationId
  * @param {String} model
  * @param {Number} maxTokens
  * @param {String} reasoningEffort
@@ -611,14 +598,11 @@ const assertRequest = ({
                            contentType,
                            headers,
                            body
-                       }, authKey, organizationId, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, gptRole, message, imageContentTypes, imageDetail = undefined) => {
+                       }, authKey, model, maxTokens, reasoningEffort, verbosity, temperature, stopSequences, gptRole, message, imageContentTypes, imageDetail = undefined) => {
     expect(url).toEqual('https://api.openai.com/v1/chat/completions');
     expect(method).toEqual('POST');
     expect(contentType).toEqual('application/json');
     expect(headers['Authorization']).toEqual(`Bearer ${authKey}`);
-    if (organizationId !== '') {
-        expect(headers['OpenAI-Organization']).toEqual(organizationId);
-    }
     const bodyObj = JSON.parse(body);
     expect(bodyObj.safety_identifier).toEqual(`m${processInstance.getProcessModelInfoId().toString()}`);
     expect(bodyObj.model).toEqual(model);
@@ -669,10 +653,10 @@ const assertAttachment = (userMessage, index, contentType, imageDetail) => {
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('key2', '', 'gpt-5.5', '', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key2', 'gpt-5.5', '', '', '', '', '', '', 'こんにちは');
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'key2', '', 'gpt-5.5', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, '', 'こんにちは', []);
+        assertRequest(request, 'key2', 'gpt-5.5', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, '', 'こんにちは', []);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -682,7 +666,7 @@ test('Fail to request', () => {
  * API リクエストが 200 レスポンスを返すが、トークン切れで回答が空の場合
  */
 test('No response content generated', () => {
-    prepareConfigs('key2', '', 'gpt-5.5', '100', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key2', 'gpt-5.5', '100', '', '', '', '', '', 'こんにちは');
     const responseObj = {
         "id": "chatcmpl-123",
         "object": "chat.completion",
@@ -706,7 +690,7 @@ test('No response content generated', () => {
     };
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'key2', '', 'gpt-5.5', 100, undefined, undefined, 1, undefined, '', 'こんにちは', []);
+        assertRequest(request, 'key2', 'gpt-5.5', 100, undefined, undefined, 1, undefined, '', 'こんにちは', []);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
     assertError('No response content generated. Finish Reason: length');
@@ -747,11 +731,11 @@ const createResponse = (answerText) => {
  * 成功
  */
 test('Success to request', () => {
-    const answerDef = prepareConfigs('key3', '', 'gpt-4.1', '', '', '', '', '', 'Robot', 'Hello World');
+    const answerDef = prepareConfigs('key3', 'gpt-4.1', '', '', '', '', '', 'Robot', 'Hello World');
     // 添付画像指定なし
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key3', '', 'gpt-4.1', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, 'Robot', 'Hello World', []);
+        assertRequest(request, 'key3', 'gpt-4.1', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, 'Robot', 'Hello World', []);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("\n\nHello there, how may I assist you today?"));
     });
     main();
@@ -761,44 +745,15 @@ test('Success to request', () => {
 });
 
 /**
- * 成功 - 組織 ID を指定
- * reasoningEffort を指定
- * verbosity は指定なし
- * 回答を保存するデータ項目に、文字型 Markdown を指定
- */
-test('Success to request - with organization ID', () => {
-    prepareConfigs('key4', 'org-1', 'gpt-5', '', 'minimal', '', '', '', '', 'Hi!');
-
-    // 回答を保存するデータ項目に、文字型 Markdown を指定
-    const answerDef = engine.createDataDefinition('回答', 1, 'q_answer', 'STRING_MARKDOWN');
-    engine.setData(answerDef, '事前文字列');
-    configs.putObject('conf_Answer1', answerDef);
-
-
-    // 添付画像はデータ項目の指定はあるが、ファイル添付なし
-    const imagesDef = engine.createDataDefinition('添付画像', 2, 'q_images', 'FILE');
-    configs.putObject('conf_Images1', imagesDef);
-
-    httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key4', 'org-1', 'gpt-5', MAX_TOKENS_DEFAULT, 'minimal', undefined, 1, undefined, '', 'Hi!', []);
-        return httpClient.createHttpResponse(200, 'application/json', createResponse("Hi! How can I help you?"));
-    });
-    main();
-
-    // データ項目の値をチェック
-    expect(engine.findData(answerDef)).toEqual("Hi! How can I help you?");
-});
-
-/**
  * 成功 - 最大トークン数を指定
  * reasoning_effort は指定なし
  * verbosity を指定
  */
 test('Success to request - with max_tokens', () => {
-    const answerDef = prepareConfigs('key5', '', 'gpt-5-mini', '100', '', 'high', '', '', 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
+    const answerDef = prepareConfigs('key5', 'gpt-5-mini', '100', '', 'high', '', '', 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-5-mini', 100, undefined, 'high', 1, undefined, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
+        assertRequest(request, 'key5', 'gpt-5-mini', 100, undefined, 'high', 1, undefined, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("Hi! It's sunny today."));
     });
     main();
@@ -812,7 +767,7 @@ test('Success to request - with max_tokens', () => {
  * 回答を保存するデータ項目に、文字型 Markdown を指定
  */
 test('Success to request - with temperature', () => {
-    prepareConfigs('key5', '', 'gpt-4.1-mini', '', '', '', '1', '', 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
+    prepareConfigs('key5', 'gpt-4.1-mini', '', '', '', '1', '', 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
 
     // 回答を保存するデータ項目に、文字型 Markdown を指定
     const answerDef = engine.createDataDefinition('回答', 1, 'q_answer', 'STRING_MARKDOWN');
@@ -820,7 +775,7 @@ test('Success to request - with temperature', () => {
     configs.putObject('conf_Answer1', answerDef);
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-4.1-mini', MAX_TOKENS_DEFAULT, undefined, undefined,1, undefined, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
+        assertRequest(request, 'key5', 'gpt-4.1-mini', MAX_TOKENS_DEFAULT, undefined, undefined,1, undefined, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("Hi! It's sunny today."));
     });
     main();
@@ -838,10 +793,10 @@ test('Success to request - with stop', () => {
         stopSequences.push(`stop${i}`);
     }
     const stopSequencesStr = stopSequences.join('\n') + '\n';
-    const answerDef = prepareConfigs('key5', '', 'gpt-5.4-nano', '', '', '', '', stopSequencesStr, 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
+    const answerDef = prepareConfigs('key5', 'gpt-5.4-nano', '', '', '', '', stopSequencesStr, 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-5.4-nano', MAX_TOKENS_DEFAULT, undefined, undefined, 1, stopSequences, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
+        assertRequest(request, 'key5', 'gpt-5.4-nano', MAX_TOKENS_DEFAULT, undefined, undefined, 1, stopSequences, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("Hi! It's sunny today."));
     });
     main();
@@ -854,7 +809,7 @@ test('Success to request - with stop', () => {
  * 成功 - 画像を添付。detail 指定なし  reasoningEffort  verbosity を指定
  */
 test('Success to request - with attached images, no detail param', () => {
-    const answerDef = prepareConfigs('key5', '', 'o3', '', 'high', 'low', '', '', '', 'Describe the images attached.');
+    const answerDef = prepareConfigs('key5', 'o3', '', 'high', 'low', '', '', '', 'Describe the images attached.');
     configs.put('conf_Images1Detail', undefined);
 
     // 添付画像を指定
@@ -868,7 +823,7 @@ test('Success to request - with attached images, no detail param', () => {
 
     const imageContentTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'o3', MAX_TOKENS_DEFAULT, 'high', 'low', 1, undefined, '', 'Describe the images attached.', imageContentTypes, undefined);
+        assertRequest(request, 'key5', 'o3', MAX_TOKENS_DEFAULT, 'high', 'low', 1, undefined, '', 'Describe the images attached.', imageContentTypes, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("The first one is a blue circle and the second one is a red square."));
     });
     main();
@@ -881,7 +836,7 @@ test('Success to request - with attached images, no detail param', () => {
  * 成功 - 画像を添付。detail を指定    reasoningEffort  verbosity を指定
  */
 test('Success to request - with attached images, detail param set', () => {
-    const answerDef = prepareConfigs('key5', '', 'gpt-5-nano', '', 'medium', 'medium', '', '', '', 'Describe the images attached.');
+    const answerDef = prepareConfigs('key5', 'gpt-5-nano', '', 'medium', 'medium', '', '', '', 'Describe the images attached.');
     configs.put('conf_Images1Detail', 'low');
 
     // 添付画像を指定
@@ -893,7 +848,7 @@ test('Success to request - with attached images, detail param set', () => {
 
     const imageContentTypes = ['image/png', 'image/jpeg'];
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-5-nano', MAX_TOKENS_DEFAULT, 'medium', 'medium', 1, undefined, '', 'Describe the images attached.', imageContentTypes, 'low');
+        assertRequest(request, 'key5', 'gpt-5-nano', MAX_TOKENS_DEFAULT, 'medium', 'medium', 1, undefined, '', 'Describe the images attached.', imageContentTypes, 'low');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("The first one is a blue circle and the second one is a red square."));
     });
     main();
@@ -906,7 +861,7 @@ test('Success to request - with attached images, detail param set', () => {
  * 成功 - 画像を添付。detail を original に指定。gpt-5.4 モデル
  */
 test('Success to request - gpt-5.4 with attached images, detail original', () => {
-    const answerDef = prepareConfigs('key5', '', 'gpt-5.4', '', 'high', 'medium', '', '', '', 'Describe the images attached.');
+    const answerDef = prepareConfigs('key5', 'gpt-5.4', '', 'high', 'medium', '', '', '', 'Describe the images attached.');
     configs.put('conf_Images1Detail', 'original');
 
     // 添付画像を指定
@@ -918,7 +873,7 @@ test('Success to request - gpt-5.4 with attached images, detail original', () =>
 
     const imageContentTypes = ['image/png', 'image/jpeg'];
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-5.4', MAX_TOKENS_DEFAULT, 'high', 'medium', 1, undefined, '', 'Describe the images attached.', imageContentTypes, 'original');
+        assertRequest(request, 'key5', 'gpt-5.4', MAX_TOKENS_DEFAULT, 'high', 'medium', 1, undefined, '', 'Describe the images attached.', imageContentTypes, 'original');
         return httpClient.createHttpResponse(200, 'application/json', createResponse("The first one is a blue circle and the second one is a red square."));
     });
     main();

--- a/chatgpt-chat-completion.xml
+++ b/chatgpt-chat-completion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
     <license>(C) Questetra, Inc. (MIT License)</license>
-    <last-modified>2026-04-16</last-modified>
+    <last-modified>2026-06-01</last-modified>
     <engine-type>3</engine-type>
     <addon-version>2</addon-version>
 
@@ -33,29 +33,11 @@
                 form-type="SELECT_ITEM" editable="true">
             <label>C2: Model</label>
             <label locale="ja">C2: モデル</label>
-            <item value="gpt-3.5-turbo">
-                <label>gpt-3.5-turbo</label>
-            </item>
-            <item value="gpt-4">
-                <label>gpt-4</label>
-            </item>
-            <item value="gpt-4-turbo">
-                <label>gpt-4-turbo</label>
-            </item>
-            <item value="gpt-4o">
-                <label>gpt-4o</label>
-            </item>
-            <item value="gpt-4o-mini">
-                <label>gpt-4o-mini</label>
-            </item>
             <item value="gpt-4.1">
                 <label>gpt-4.1</label>
             </item>
             <item value="gpt-4.1-mini">
                 <label>gpt-4.1-mini</label>
-            </item>
-            <item value="gpt-4.1-nano">
-                <label>gpt-4.1-nano</label>
             </item>
             <item value="gpt-5">
                 <label>gpt-5</label>
@@ -81,17 +63,11 @@
             <item value="gpt-5.4-nano">
                 <label>gpt-5.4-nano</label>
             </item>
-            <item value="o1">
-                <label>o1</label>
+            <item value="gpt-5.5">
+                <label>gpt-5.5</label>
             </item>
             <item value="o3">
                 <label>o3</label>
-            </item>
-            <item value="o3-mini">
-                <label>o3-mini</label>
-            </item>
-            <item value="o4-mini">
-                <label>o4-mini</label>
             </item>
         </config>
         <config name="conf_MaxTokens" required="false" form-type="TEXTFIELD">
@@ -142,14 +118,14 @@
             <label>C6: Temperature (0.0 - 2.0) (1.0 if blank)</label>
             <label locale="ja">C6: 温度（0.0 〜 2.0）（空白の場合、1.0）</label>
         </config>
-        <config name="conf_StopSequences" required="false" form-type="TEXTAREA">
-            <label>C7: Stop Sequences (write one per line, up to four)</label>
-            <label locale="ja">C7: 停止シーケンス（1 行に 1 つ、最大 4 つ）</label>
+        <config name="conf_StopSequences" required="false" form-type="TEXTAREA" deprecated="true">
+            <label>C-deprecated: Stop Sequences (write one per line, up to four)</label>
+            <label locale="ja">C-deprecated: 停止シーケンス（1 行に 1 つ、最大 4 つ）</label>
         </config>
         <config name="conf_GPT_Role" required="false" el-enabled="true"
                 form-type="TEXTAREA">
-            <label>C8: Role for ChatGPT</label>
-            <label locale="ja">C8: ChatGPT に与える役割</label>
+            <label>C7: Role for ChatGPT</label>
+            <label locale="ja">C7: ChatGPT に与える役割</label>
         </config>
         <config name="conf_Message1" required="true" el-enabled="true"
                 form-type="TEXTAREA">
@@ -171,8 +147,8 @@
                 <label>high</label>
             </item>
             <item value="original">
-                <label>original (Only for gpt-5.4)</label>
-                <label locale="ja">original (gpt-5.4 のみ指定可能)</label>
+                <label>original (Only for gpt-5.4 and later series)</label>
+                <label locale="ja">original (gpt-5.4 以降のシリーズのみ)</label>
             </item>
         </config>
         <config name="conf_Answer1" required="true" form-type="SELECT"
@@ -503,7 +479,7 @@ const assertError = (errorMsg) => {
  * メッセージが空
  */
 test('Message is empty', () => {
-    prepareConfigs('key', '', 'gpt-4', '', '', '', '', '', '', '');
+    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '', '', '', '');
     assertError('User Message is empty.');
 });
 
@@ -511,7 +487,7 @@ test('Message is empty', () => {
  * トークン数の最大値が正の整数でない - 数字でない文字を含む場合
  */
 test('Maximum number of tokens must be a positive integer - includes a non-numeric character', () => {
-    prepareConfigs('key', '', 'gpt-4', '1.1', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '1.1', '', '', '', '', '', 'こんにちは');
     assertError('Maximum number of tokens must be a positive integer.');
 });
 
@@ -519,7 +495,7 @@ test('Maximum number of tokens must be a positive integer - includes a non-numer
  * トークン数の最大値が正の整数でない - ゼロ
  */
 test('Maximum number of tokens must be a positive integer - 0', () => {
-    prepareConfigs('key', '', 'gpt-4', '0', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '0', '', '', '', '', '', 'こんにちは');
     assertError('Maximum number of tokens must be a positive integer.');
 });
 
@@ -527,7 +503,7 @@ test('Maximum number of tokens must be a positive integer - 0', () => {
  * 温度が不正 - 数字、小数点でない文字を含む
  */
 test('Invalid temperature - includes a non-numeric character', () => {
-    prepareConfigs('key', '', 'gpt-4', '', '', '', '-1', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '-1', '', '', 'こんにちは');
     assertError('Temperature must be a number from 0 to 2.');
 });
 
@@ -535,7 +511,7 @@ test('Invalid temperature - includes a non-numeric character', () => {
  * 温度が不正 - 2 を超える
  */
 test('Invalid temperature - bigger than 2', () => {
-    prepareConfigs('key', '', 'gpt-4', '', '', '', '2.1', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '2.1', '', '', 'こんにちは');
     assertError('Temperature must be a number from 0 to 2.');
 });
 
@@ -547,7 +523,7 @@ test('Too many stop sequences', () => {
     for (let i = 0; i < MAX_STOP_SEQUENCE_NUM + 1; i++) {
         stopSequences += `stop${i}\n`;
     }
-    prepareConfigs('key', '', 'gpt-4', '', '', '', '', stopSequences, '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '', '', '', '', stopSequences, '', 'こんにちは');
     assertError(`Too many stop sequences. The maximum number is ${MAX_STOP_SEQUENCE_NUM}.`);
 });
 
@@ -579,7 +555,7 @@ const createQfile = (name, contentType, size) => {
  * 添付画像のサイズが大きすぎる
  */
 test('Image file is too large', () => {
-    prepareConfigs('key', '', 'gpt-4-vision-preview', '150', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
 
     // 添付画像を指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
@@ -595,7 +571,7 @@ test('Image file is too large', () => {
  * 添付画像の Content-Type がサポート外
  */
 test('Content-Type of image file is not supported', () => {
-    prepareConfigs('key', '', 'gpt-4-vision-preview', '150', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key', '', 'gpt-5.5', '150', '', '', '', '', '', 'こんにちは');
 
     // 添付画像を指定
     const image1 = createQfile('画像1.png', 'image/png', 100);
@@ -693,10 +669,10 @@ const assertAttachment = (userMessage, index, contentType, imageDetail) => {
  * API リクエストでエラー
  */
 test('Fail to request', () => {
-    prepareConfigs('key2', '', 'gpt-3.5-turbo', '', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key2', '', 'gpt-5.5', '', '', '', '', '', '', 'こんにちは');
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'key2', '', 'gpt-3.5-turbo', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, '', 'こんにちは', []);
+        assertRequest(request, 'key2', '', 'gpt-5.5', MAX_TOKENS_DEFAULT, undefined, undefined, 1, undefined, '', 'こんにちは', []);
         return httpClient.createHttpResponse(400, 'application/json', '{}');
     });
     assertError('Failed to request. status: 400');
@@ -706,7 +682,7 @@ test('Fail to request', () => {
  * API リクエストが 200 レスポンスを返すが、トークン切れで回答が空の場合
  */
 test('No response content generated', () => {
-    prepareConfigs('key2', '', 'chatgpt-4o-latest', '100', '', '', '', '', '', 'こんにちは');
+    prepareConfigs('key2', '', 'gpt-5.5', '100', '', '', '', '', '', 'こんにちは');
     const responseObj = {
         "id": "chatcmpl-123",
         "object": "chat.completion",
@@ -730,7 +706,7 @@ test('No response content generated', () => {
     };
 
     httpClient.setRequestHandler((request) => {
-        assertRequest(request, 'key2', '', 'chatgpt-4o-latest', 100, undefined, undefined, 1, undefined, '', 'こんにちは', []);
+        assertRequest(request, 'key2', '', 'gpt-5.5', 100, undefined, undefined, 1, undefined, '', 'こんにちは', []);
         return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responseObj));
     });
     assertError('No response content generated. Finish Reason: length');
@@ -862,10 +838,10 @@ test('Success to request - with stop', () => {
         stopSequences.push(`stop${i}`);
     }
     const stopSequencesStr = stopSequences.join('\n') + '\n';
-    const answerDef = prepareConfigs('key5', '', 'gpt-4.1-nano', '', '', '', '', stopSequencesStr, 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
+    const answerDef = prepareConfigs('key5', '', 'gpt-5.4-nano', '', '', '', '', stopSequencesStr, 'Assistant', 'Hi! How\'s the weather in Kyoto today?');
 
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'gpt-4.1-nano', MAX_TOKENS_DEFAULT, undefined, undefined, 1, stopSequences, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
+        assertRequest(request, 'key5', '', 'gpt-5.4-nano', MAX_TOKENS_DEFAULT, undefined, undefined, 1, stopSequences, 'Assistant', 'Hi! How\'s the weather in Kyoto today?', []);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("Hi! It's sunny today."));
     });
     main();
@@ -878,7 +854,7 @@ test('Success to request - with stop', () => {
  * 成功 - 画像を添付。detail 指定なし  reasoningEffort  verbosity を指定
  */
 test('Success to request - with attached images, no detail param', () => {
-    const answerDef = prepareConfigs('key5', '', 'o3-mini', '', 'high', 'low', '', '', '', 'Describe the images attached.');
+    const answerDef = prepareConfigs('key5', '', 'o3', '', 'high', 'low', '', '', '', 'Describe the images attached.');
     configs.put('conf_Images1Detail', undefined);
 
     // 添付画像を指定
@@ -892,7 +868,7 @@ test('Success to request - with attached images, no detail param', () => {
 
     const imageContentTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
     httpClient.setRequestHandler(request => {
-        assertRequest(request, 'key5', '', 'o3-mini', MAX_TOKENS_DEFAULT, 'high', 'low', 1, undefined, '', 'Describe the images attached.', imageContentTypes, undefined);
+        assertRequest(request, 'key5', '', 'o3', MAX_TOKENS_DEFAULT, 'high', 'low', 1, undefined, '', 'Describe the images attached.', imageContentTypes, undefined);
         return httpClient.createHttpResponse(200, 'application/json', createResponse("The first one is a blue circle and the second one is a red square."));
     });
     main();


### PR DESCRIPTION
T11625: OpenAI ChatGPT: チャット　設定項目「停止シーケンス」を deprecated にする
T11646 OpenAI ChatGPT: チャット　deprecated な設定項目「組織 ID」を削除する
の変更も含みます。