### PR TITLE
T11778: Google ドライブ: フォルダ検索　検索結果が空でも正常終了するオプションを追加

### DIFF
--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -1,39 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <service-task-definition>
-<last-modified>2025-01-21</last-modified>
-<license>(C) Questetra, Inc. (MIT License)</license>
-<engine-type>3</engine-type>
-<addon-version>2</addon-version>
-<label>Google Drive: Search Folder</label>
-<label locale="ja">Google ドライブ: フォルダ検索</label>
-<summary>This item searches for the folder with the specific name, directly under the specified folder on Google Drive.</summary>
-<summary locale="ja">この工程は、Google ドライブ の指定フォルダ直下に、特定の名前のフォルダがあるかどうか調べます。</summary>
-<help-page-url>https://support.questetra.com/bpmn-icons/googledrive-foldersearch/</help-page-url>
-<help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/googledrive-foldersearch/</help-page-url>
-<configs>
-  <config name="OAuth_V2" required="true" form-type="OAUTH2" auth-type="OAUTH2_JWT_BEARER">
-    <label>C1: Service Account Setting</label>
-    <label locale="ja">C1: サービスアカウント設定</label>
-  </config>
-  <config name="ParentFolderId" required="true" el-enabled="true">
-    <label>C2: Parent Folder ID</label>
-    <label locale="ja">C2: 検索するフォルダの親フォルダの ID</label>
-  </config>
-  <config name="FolderName" required="true" el-enabled="true">
-    <label>C3: Folder Name to search for</label>
-    <label locale="ja">C3: 検索するフォルダの名称</label>
-  </config>
-  <config name="FolderIdItem" form-type="SELECT" select-data-type="STRING">
-    <label>C4: Data item that will save Folder ID</label>
-    <label locale="ja">C4: 検索したフォルダの ID を保存するデータ項目</label>
-  </config>
-  <config name="WebViewUrlItem" form-type="SELECT" select-data-type="STRING">
-    <label>C5: Data item that will save web view URL of Folder</label>
-    <label locale="ja">C5: 検索したフォルダの表示 URL を保存するデータ項目</label>
-  </config>
-</configs>
+    <last-modified>2026-07-24</last-modified>
+    <license>(C) Questetra, Inc. (MIT License)</license>
+    <engine-type>3</engine-type>
+    <addon-version>2</addon-version>
+    <label>Google Drive: Search Folder</label>
+    <label locale="ja">Google ドライブ: フォルダ検索</label>
+    <summary>This item searches for the folder with the specific name, directly under the specified folder on Google
+        Drive.
+    </summary>
+    <summary locale="ja">この工程は、Google ドライブ の指定フォルダ直下に、特定の名前のフォルダがあるかどうか調べます。
+    </summary>
+    <help-page-url>https://support.questetra.com/en/bpmn-icons/googledrive-foldersearch/</help-page-url>
+    <help-page-url locale="ja">https://support.questetra.com/ja/bpmn-icons/googledrive-foldersearch/</help-page-url>
+    <configs>
+        <config name="OAuth_V2" required="true" form-type="OAUTH2" auth-type="OAUTH2_JWT_BEARER">
+            <label>C1: Service Account Setting</label>
+            <label locale="ja">C1: サービスアカウント設定</label>
+        </config>
+        <config name="ParentFolderId" required="true" el-enabled="true">
+            <label>C2: Parent Folder ID</label>
+            <label locale="ja">C2: 検索するフォルダの親フォルダの ID</label>
+        </config>
+        <config name="FolderName" required="true" el-enabled="true">
+            <label>C3: Folder Name to search for</label>
+            <label locale="ja">C3: 検索するフォルダの名称</label>
+        </config>
+        <config name="FolderIdItem" form-type="SELECT" select-data-type="STRING">
+            <label>C4: Data item that will save Folder ID</label>
+            <label locale="ja">C4: 検索したフォルダの ID を保存するデータ項目</label>
+        </config>
+        <config name="WebViewUrlItem" form-type="SELECT" select-data-type="STRING">
+            <label>C5: Data item that will save web view URL of Folder</label>
+            <label locale="ja">C5: 検索したフォルダの表示 URL を保存するデータ項目</label>
+        </config>
+        <config name="conf_SucceedIfNotFound" form-type="TOGGLE">
+            <label>C6: If not found, finish successfully with C4/C5 data blank</label>
+            <label locale="ja">C6: 見つからなければ、C4・C5 のデータ項目を空にして正常終了する</label>
+        </config>
+    </configs>
 
-<script><![CDATA[
+    <script><![CDATA[
 function main() {
     //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const oauthV2 = configs.getObject("OAuth_V2");
@@ -51,12 +58,19 @@ function main() {
     if (idDataDef === null && urlDataDef === null) {
         throw new Error("Neither of Data Items to save result are set.");
     }
+    const succeedIfNotFound = configs.getObject("conf_SucceedIfNotFound");
 
     //// == 演算 / Calculating ==
     const driveId = getDriveId(oauthV2, parentFolderId);
     const folders = searchFolder(oauthV2, driveId, parentFolderId, folderName);
     const folderNum = folders.length;
     if (folderNum === 0) {
+        if (succeedIfNotFound) {
+            // C6 が ON の場合、エラーにせず、データ項目を空にして正常終了する
+            setFolderData(idDataDef, []);
+            setFolderData(urlDataDef, []);
+            return;
+        }
         throw new Error(`Could not find Folder:${folderName} with Parent Folder ID:${parentFolderId}`);
     }
     const folderIdList = [];
@@ -220,31 +234,31 @@ function setFolderData(dataDef, folderInfoList) {
     }
 }
 
-]]></script>
+    ]]></script>
 
-<icon>
-iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAA71JREFUWEfF
-V11oFFcU/s7M7K6TRs1vK1VUSGmbCK2SB6VFgpLWlYC2omIDLaUlCBGfimwWgw9Fu9mW0ocSoUhE
-aKmlgUgUyShiEUWSh4AW7L9CS5PGZhuTJmTi7swcmUn3d+ZOdtGy87Ts3HvOd77zfefeIZT5oVLy
-h2MP3wTMViJqZqABQM1/+6cIuMvMo4B8RYuGzhUbd0kArT1TK2VWj5CEg2DUFRWYkGALX5ikf3Kl
-q2bGb48vgJ0x/T2WEC86cWEmQoIsRIai6mkRCCGAcHy+F0ydRVW81CLik1qk4pDXMk8A4bj+NRhv
-LRW3pPeEs1pEbXeTVPDPE63clc3NRB4DTs8JfX6V7d2soKVRgizlk5cyGBdvmbj8velLDDHez9VE
-JoqtdoXU3/wE19Io452tCtQgUP2Uu3u/TliInE1CT/pgICQM1p9LuyMTZUdMP06Eo37wYweC2LhO
-wsQ0o245QZHzVxsm8O2IgS+vG74sMOPEpajabS/KAAjH9Um/6vdvUdD+qoKQAiykgFmdUb/CzcLE
-DCN+PoWfxi0xCEJCi6j1GQDOhCNrQLRjdQ2h+40g1tdnE/4zy6gIkdOO3Mdi4OodE59eTPmbhKU9
-9sR0IoZj870gsec7tivY1axAkbIxDQuY/JexaiWBCoiYnmd8fsnAzV98BMl8UotWHHK27uzRhxnY
-7AX55XUSjrQFULvcTbdNs92G2kr3u1u/W4h+I1YjASNDXeqWRQZ69EnAe85Hdwew9QXZVeXsAqP3
-soENayS0bZJR4EpHJ2eupTA4KmQhoXWpi00N9+j2qhyCF7l4/SUZHdsUVC7Lr9Du87UfTXx8IYW1
-dYRje4JYXe1m4d7fjI8GkxibYi9yLa1LlYUAbHEd3xdE0xoXLhQqPdchuZlsnZwfNXDqqqct8wC4
-WlBK0FLA5gDMtsBLhJ+9HcSLz7qrH3/AmFtgBJR8ym0uQwG4tGJawNBtE/3D+Szki9DDhrubZbzb
-EsCyQBaz3wASmX7sAePDgST+SBToINeGokF0Yn8Qm9ZLTlXMwF/TjKdXuEewKHnSAPpHDHx1w0MD
-uYPIcYLHKH7leRmHdyioqiCHdltU9u9inx/+tNDd73E4FY5iO6DoMPqgLYBtTTLuzzBWVZHL7yIw
-cw8Zfd8Z0G6754DnYSQ6jm2fd74WQMMzhMpQcdXb7br+s4nYoMd5IDqOnZFcxIWkWPpF64QXkvSG
-sl7JsiDKeCn9X5go9VqeBlHWD5M0iLJ+mhUquSwfp49ru6X2PwLQFL0wM02BagAAAABJRU5ErkJg
-gg==
-</icon>
-    
-<test><![CDATA[
+    <icon>
+    iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAA71JREFUWEfF
+    V11oFFcU/s7M7K6TRs1vK1VUSGmbCK2SB6VFgpLWlYC2omIDLaUlCBGfimwWgw9Fu9mW0ocSoUhE
+    aKmlgUgUyShiEUWSh4AW7L9CS5PGZhuTJmTi7swcmUn3d+ZOdtGy87Ts3HvOd77zfefeIZT5oVLy
+    h2MP3wTMViJqZqABQM1/+6cIuMvMo4B8RYuGzhUbd0kArT1TK2VWj5CEg2DUFRWYkGALX5ikf3Kl
+    q2bGb48vgJ0x/T2WEC86cWEmQoIsRIai6mkRCCGAcHy+F0ydRVW81CLik1qk4pDXMk8A4bj+NRhv
+    LRW3pPeEs1pEbXeTVPDPE63clc3NRB4DTs8JfX6V7d2soKVRgizlk5cyGBdvmbj8velLDDHez9VE
+    JoqtdoXU3/wE19Io452tCtQgUP2Uu3u/TliInE1CT/pgICQM1p9LuyMTZUdMP06Eo37wYweC2LhO
+    wsQ0o245QZHzVxsm8O2IgS+vG74sMOPEpajabS/KAAjH9Um/6vdvUdD+qoKQAiykgFmdUb/CzcLE
+    DCN+PoWfxi0xCEJCi6j1GQDOhCNrQLRjdQ2h+40g1tdnE/4zy6gIkdOO3Mdi4OodE59eTPmbhKU9
+    9sR0IoZj870gsec7tivY1axAkbIxDQuY/JexaiWBCoiYnmd8fsnAzV98BMl8UotWHHK27uzRhxnY
+    7AX55XUSjrQFULvcTbdNs92G2kr3u1u/W4h+I1YjASNDXeqWRQZ69EnAe85Hdwew9QXZVeXsAqP3
+    soENayS0bZJR4EpHJ2eupTA4KmQhoXWpi00N9+j2qhyCF7l4/SUZHdsUVC7Lr9Du87UfTXx8IYW1
+    dYRje4JYXe1m4d7fjI8GkxibYi9yLa1LlYUAbHEd3xdE0xoXLhQqPdchuZlsnZwfNXDqqqct8wC4
+    WlBK0FLA5gDMtsBLhJ+9HcSLz7qrH3/AmFtgBJR8ym0uQwG4tGJawNBtE/3D+Szki9DDhrubZbzb
+    EsCyQBaz3wASmX7sAePDgST+SBToINeGokF0Yn8Qm9ZLTlXMwF/TjKdXuEewKHnSAPpHDHx1w0MD
+    uYPIcYLHKH7leRmHdyioqiCHdltU9u9inx/+tNDd73E4FY5iO6DoMPqgLYBtTTLuzzBWVZHL7yIw
+    cw8Zfd8Z0G6754DnYSQ6jm2fd74WQMMzhMpQcdXb7br+s4nYoMd5IDqOnZFcxIWkWPpF64QXkvSG
+    sl7JsiDKeCn9X5go9VqeBlHWD5M0iLJ+mhUquSwfp49ru6X2PwLQFL0wM02BagAAAABJRU5ErkJg
+    gg==
+    </icon>
+
+    <test><![CDATA[
 const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD3Zg0KVn2jff8t
 NHk7p8uWEvsaxA59CkGi1v81kyVsnd+yxm23nWIKhGplhy0hK7dnBP3OMB0YCfvo
@@ -774,6 +788,55 @@ test('Could not find Folder', () => {
 });
 
 /**
+ * GET API 成功 - 検索したフォルダが見つからない場合でも、C6（conf_SucceedIfNotFound）が ON なら
+ * エラーにせず、データ項目を空にして正常終了する
+ *（親フォルダのドライブ ID を取得する）
+ *（フォルダを検索する）
+ */
+test('Success - C6 is ON: succeed with blank data items if not found', () => {
+    const privateKeyId = 'key-67890';
+    const serviceAccount = 'service2@questetra.com';
+    const folderId = 'uvwx56789099';
+    const folderName = 'folder9';
+    const {
+        idDef,
+        urlDef
+    } = prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, folderId, folderName);
+
+    // C6 をトグル ON にする
+    configs.putObject('conf_SucceedIfNotFound', true);
+
+    let reqCount = 0;
+    const token = 'token8';
+    httpClient.setRequestHandler((request) => {
+        if (reqCount % 2 === 0) {
+            assertTokenRequest(request, SCOPE, serviceAccount);
+            reqCount++;
+            return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({
+                'access_token': token
+            }));
+        }
+        if (reqCount++ === 1) {
+            assertGetDriveIdRequest(request, token, folderId);
+            // マイドライブの場合、ドライブIDが無い
+            return httpClient.createHttpResponse(200, 'application/json', '{}');
+        }
+        assertSearchFolderRequest(request, token, null, folderId, folderName);
+        // 親フォルダ内にリストが無い
+        const responsePostObj = {
+            "files": []
+        };
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responsePostObj));
+    });
+    // <script> のスクリプトを実行（エラーにならないことを確認）
+    main();
+
+    // 文字型データ項目が空になっていることを確認
+    expect(engine.findData(idDef)).toEqual('');
+    expect(engine.findData(urlDef)).toEqual('');
+});
+
+/**
  * GET API 成功 - フォルダが複数見つかるが、 ID、URL を保存する文字型データ項目が単一行でエラー
  *（親フォルダのドライブ ID を取得する）
  *（フォルダを検索する）
@@ -856,5 +919,5 @@ test('Success - Set a Folder to single-line string Data Item', () => {
     expect(engine.findData(urlDef)).toEqual('https://drive.google.com/drive/folders/Folder1_mmmnnnooo333444555');
 });
 
-]]></test>
+    ]]></test>
 </service-task-definition>

--- a/google-drive-folder-search.xml
+++ b/google-drive-folder-search.xml
@@ -41,7 +41,7 @@
     </configs>
 
     <script><![CDATA[
-function main() {
+const main = () => {
     //// == 工程コンフィグ・ワークフローデータの参照 / Config & Data Retrieving ==
     const oauthV2 = configs.getObject("OAuth_V2");
     let parentFolderId = configs.get("ParentFolderId");
@@ -83,7 +83,7 @@ function main() {
     //// == ワークフローデータへの代入 / Data Updating ==
     setFolderData(idDataDef, folderIdList);
     setFolderData(urlDataDef, folderUrlList);
-}
+};
 
 const URL_TOKEN_REQUEST = 'https://oauth2.googleapis.com/token';
 const SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
@@ -154,7 +154,7 @@ const getAccessToken = (auth) => {
  * @param {String} parentFolderId 親フォルダの ID
  * @return {String} driveId ドライブ ID (共有ドライブになければ null)
  */
-function getDriveId(oauthV2, parentFolderId) {
+const getDriveId = (oauthV2, parentFolderId) => {
     if (parentFolderId === "root") {
         return null;
     }
@@ -167,7 +167,7 @@ function getDriveId(oauthV2, parentFolderId) {
         .get(url);
     const status = response.getStatusCode();
     const responseTxt = response.getResponseAsString();
-    if (status >= 300) {
+    if (status !== 200) {
         const errorMsg = `Failed to get parent folder with parent folder ID:${parentFolderId}. status:${status}`;
         engine.log(responseTxt);
         throw new Error(errorMsg);
@@ -177,7 +177,7 @@ function getDriveId(oauthV2, parentFolderId) {
         return null;
     }
     return driveId;
-}
+};
 
 /**
  * Google ドライブのフォルダを検索
@@ -189,7 +189,7 @@ function getDriveId(oauthV2, parentFolderId) {
  * @return {String} folders[].id フォルダの ID
  * @return {String} folders[].webViewLink フォルダの表示 URL
  */
-function searchFolder(oauthV2, driveId, parentFolderId, folderName) {
+const searchFolder = (oauthV2, driveId, parentFolderId, folderName) => {
     const folderNameRep = folderName.replace(/['\\]/g, "\\$&"); // ' と \ をエスケープ
     const q = `mimeType = 'application/vnd.google-apps.folder' and trashed = false and name = '${folderNameRep}' and '${parentFolderId}' in parents`;
     const url = "https://www.googleapis.com/drive/v3/files";
@@ -198,7 +198,7 @@ function searchFolder(oauthV2, driveId, parentFolderId, folderName) {
     request = request.oauth2JwtBearer(oauthV2, () => getAccessToken(oauthV2));
     request = request.queryParam("q", q)
         .queryParam("pageSize", "1000")
-        .queryParam("fields", "files(id,webViewLink)");
+        .queryParam("fields", "nextPageToken,files(id,webViewLink)");
     if (driveId !== null) { // 親フォルダが共有ドライブにある場合
         request = request
             .queryParam("includeItemsFromAllDrives", "true")
@@ -209,21 +209,26 @@ function searchFolder(oauthV2, driveId, parentFolderId, folderName) {
     const response = request.get(url);
     const status = response.getStatusCode();
     const responseTxt = response.getResponseAsString();
-    if (status >= 300) {
+    if (status !== 200) {
         const errorMsg = `Failed to search. status:${status}`;
         engine.log(responseTxt);
         throw new Error(errorMsg);
     }
-    const folders = JSON.parse(responseTxt).files;
+    const json = JSON.parse(responseTxt);
+    // 通常ありえないが、同名のフォルダが 1000 件以上見つかり、1 ページで取得しきれなかった場合はエラーにする
+    if (json.nextPageToken !== undefined && json.nextPageToken !== null) {
+        throw new Error("Too many folders with the specified name found.");
+    }
+    const folders = json.files;
     return folders;
-}
+};
 
 /**
  * フォルダの情報をデータ項目にセットする
  * @param {ProcessDataDefinitionView} dataDef 保存先データ項目の ProcessDataDefinitionView
  * @param {Array<String>} folderInfoList 保存するフォルダ情報の配列
  */
-function setFolderData(dataDef, folderInfoList) {
+const setFolderData = (dataDef, folderInfoList) => {
     if (dataDef !== null) {
         //Multiple Judge
         if (dataDef.matchDataType("STRING_TEXTFIELD") && folderInfoList.length > 1) {
@@ -232,7 +237,7 @@ function setFolderData(dataDef, folderInfoList) {
         const folderInfoStr = folderInfoList.join("\n");
         engine.setData(dataDef, folderInfoStr);
     }
-}
+};
 
     ]]></script>
 
@@ -520,9 +525,9 @@ const assertSearchFolderRequest = ({ url, method, headers }, token, driveId, par
         .replace(/\)/g, '%29');
     const q = `mimeType+%3D+%27application%2Fvnd.google-apps.folder%27+and+trashed+%3D+false+and+name+%3D+%27${encodedFolderName}%27+and+%27${parentFolderId}%27+in+parents`;
     if (driveId !== null) { // 親フォルダが共有ドライブにある場合
-        expect(url).toEqual(`https://www.googleapis.com/drive/v3/files?q=${q}&pageSize=1000&fields=files%28id%2CwebViewLink%29&includeItemsFromAllDrives=true&supportsAllDrives=true&corpora=drive&driveId=${driveId}`);
+        expect(url).toEqual(`https://www.googleapis.com/drive/v3/files?q=${q}&pageSize=1000&fields=nextPageToken%2Cfiles%28id%2CwebViewLink%29&includeItemsFromAllDrives=true&supportsAllDrives=true&corpora=drive&driveId=${driveId}`);
     } else {
-        expect(url).toEqual(`https://www.googleapis.com/drive/v3/files?q=${q}&pageSize=1000&fields=files%28id%2CwebViewLink%29`);
+        expect(url).toEqual(`https://www.googleapis.com/drive/v3/files?q=${q}&pageSize=1000&fields=nextPageToken%2Cfiles%28id%2CwebViewLink%29`);
     }
     expect(method).toEqual('GET');
     expect(headers.Authorization).toEqual(`Bearer ${token}`);
@@ -777,14 +782,58 @@ test('Could not find Folder', () => {
             return httpClient.createHttpResponse(200, 'application/json', '{}');
         }
         assertSearchFolderRequest(request, token, null, folderId, folderName);
-        // 親フォルダ内にリストが無い		
+        // 親フォルダ内にリストが無い
         const responsePostObj = {
             "files": []
         };
-        return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行し、エラーがスローされることを確認
     assertError('Could not find Folder:folder6 with Parent Folder ID:uvwx56789012');
+});
+
+/**
+ * GET API 成功 - レスポンスに nextPageToken が含まれる場合（同名フォルダが1ページで取得しきれない場合）はエラー
+ *（親フォルダのドライブ ID を取得する）
+ *（フォルダを検索する）
+ */
+test('Too many folders with the specified name found (nextPageToken present)', () => {
+    const privateKeyId = 'key-67890';
+    const serviceAccount = 'service2@questetra.com';
+    const folderId = 'uvwx56789013';
+    const folderName = 'folder6b';
+    prepareConfigs(SCOPE, privateKeyId, PRIVATE_KEY, serviceAccount, folderId, folderName);
+
+    let reqCount = 0;
+    const token = 'token5b';
+    httpClient.setRequestHandler((request) => {
+        if (reqCount % 2 === 0) {
+            assertTokenRequest(request, SCOPE, serviceAccount);
+            reqCount++;
+            return httpClient.createHttpResponse(200, 'application/json', JSON.stringify({
+                'access_token': token
+            }));
+        }
+        if (reqCount++ === 1) {
+            assertGetDriveIdRequest(request, token, folderId);
+            // マイドライブの場合、ドライブIDが無い
+            return httpClient.createHttpResponse(200, 'application/json', '{}');
+        }
+        assertSearchFolderRequest(request, token, null, folderId, folderName);
+        // 1 ページ目に 1000 件見つかり、nextPageToken が返る（同名フォルダが1ページで取得しきれない）
+        const responsePostObj = {
+            "files": [
+                {
+                    "id": "Folder1_nextpage",
+                    "webViewLink": "https://drive.google.com/drive/folders/Folder1_nextpage"
+                }
+            ],
+            "nextPageToken": "token-for-next-page"
+        };
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responsePostObj));
+    });
+    // <script> のスクリプトを実行し、エラーがスローされることを確認
+    assertError('Too many folders with the specified name found.');
 });
 
 /**
@@ -910,7 +959,7 @@ test('Success - Set a Folder to single-line string Data Item', () => {
                 }
             ]
         };
-        return httpClient.createHttpResponse(201, 'application/json', JSON.stringify(responsePostObj));
+        return httpClient.createHttpResponse(200, 'application/json', JSON.stringify(responsePostObj));
     });
     // <script> のスクリプトを実行
     main();


### PR DESCRIPTION
- 検索結果が空でも正常終了するオプションを追加しました
- 滅多にないケースですが、検索結果が多すぎで 1 ページ（1000件）で取得できない場合はエラーになるようにしました
- 英語ヘルプページのパスに `/en/` を追加しました
- その他、リファクタリングを行いました
  - インデントも調整したため、変更箇所が多くなっています